### PR TITLE
Adjust useMultipleItems in collectionStore and listQuery store

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "evtmitter": "^0.3.3",
     "immer": "^10.0.3",
     "klona": "^2.0.6",
-    "t-state": "^8.10.0"
+    "t-state": "^8.10.1"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^2.0.6
     version: 2.0.6
   t-state:
-    specifier: ^8.10.0
-    version: 8.10.0(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^8.10.1
+    version: 8.10.1(react-dom@18.2.0)(react@18.2.0)
 
 devDependencies:
   '@lucasols/eslint-plugin-extended-lint':
@@ -2769,8 +2769,8 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
 
-  /t-state@8.10.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-oabhyEJtuQUtcYBwnmM5CDBbJ8pkI+hPD4OZjDoccDR6JA8OeKadPw23m2Q73A0OL/mR0NhgkBPNGneBYiU/UA==}
+  /t-state@8.10.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-8zD1EoFsuU4C7pTl7GfNF5PjG8dogOMvNZwTNUgFIrZlPXb7giwagzSH4BWXBmWoWL+VDP0YGH5HI2jR4yMfcw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       react: ^18.0.0

--- a/src/collectionStore.ts
+++ b/src/collectionStore.ts
@@ -523,10 +523,10 @@ export function newTSDFCollectionStore<
       }
     });
 
-    const ignoreQueriesInRefetchOnMount = useConst(() => new Set<string>());
+    const ignoreItemsInRefetchOnMount = useConst(() => new Set<string>());
 
     useEffect(() => {
-      const removedQueries = new Set(ignoreQueriesInRefetchOnMount);
+      const removedQueries = new Set(ignoreItemsInRefetchOnMount);
 
       for (const {
         itemKey: itemId,
@@ -536,9 +536,7 @@ export function newTSDFCollectionStore<
       } of queriesWithId) {
         removedQueries.delete(itemId);
 
-        if (isOffScreen) {
-          continue;
-        }
+        if (isOffScreen) continue;
 
         if (itemId) {
           const itemState = getItemState(payload);
@@ -546,11 +544,11 @@ export function newTSDFCollectionStore<
 
           const shouldFetch = !itemState?.wasLoaded || itemState.refetchOnMount;
 
-          if (!shouldFetch && ignoreQueriesInRefetchOnMount.has(itemId)) {
+          if (!shouldFetch && ignoreItemsInRefetchOnMount.has(itemId)) {
             continue;
           }
 
-          ignoreQueriesInRefetchOnMount.add(itemId);
+          ignoreItemsInRefetchOnMount.add(itemId);
 
           if (disableRefetchOnMount) {
             if (shouldFetch) {
@@ -564,9 +562,9 @@ export function newTSDFCollectionStore<
       }
 
       for (const itemId of removedQueries) {
-        ignoreQueriesInRefetchOnMount.delete(itemId);
+        ignoreItemsInRefetchOnMount.delete(itemId);
       }
-    }, [ignoreQueriesInRefetchOnMount, queriesWithId]);
+    }, [ignoreItemsInRefetchOnMount, queriesWithId]);
 
     return storeState;
   }

--- a/src/collectionStore.ts
+++ b/src/collectionStore.ts
@@ -390,10 +390,10 @@ export function newTSDFCollectionStore<
     items: CollectionUseMultipleItemsQuery<ItemPayload, QueryMetadata>[],
     {
       selector,
-      selectorUseExternalDeps,
+      selectorUsesExternalDeps,
     }: {
       selector?: (data: ItemState | null) => Selected;
-      selectorUseExternalDeps?: boolean;
+      selectorUsesExternalDeps?: boolean;
     } = {},
   ) {
     type QueryWithId = {
@@ -431,7 +431,7 @@ export function newTSDFCollectionStore<
         // eslint-disable-next-line react-hooks/exhaustive-deps
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      selectorUseExternalDeps ? [selector] : [],
+      [selectorUsesExternalDeps ? selector : 0],
     );
 
     const resultSelector = useCallback(
@@ -574,7 +574,7 @@ export function newTSDFCollectionStore<
     {
       omitPayload,
       selector,
-      selectorUseExternalDeps,
+      selectorUsesExternalDeps,
       ensureIsLoaded,
       returnRefetchingStatus,
       disableRefetchOnMount,
@@ -582,7 +582,7 @@ export function newTSDFCollectionStore<
       isOffScreen,
     }: {
       selector?: (data: ItemState | null) => Selected;
-      selectorUseExternalDeps?: boolean;
+      selectorUsesExternalDeps?: boolean;
       omitPayload?: boolean;
       returnRefetchingStatus?: boolean;
       disableRefetchOnMount?: boolean;
@@ -617,7 +617,7 @@ export function newTSDFCollectionStore<
 
     const item = useMultipleItems(query, {
       selector,
-      selectorUseExternalDeps,
+      selectorUsesExternalDeps,
     });
 
     const result = useMemo(

--- a/src/listQueryStore.ts
+++ b/src/listQueryStore.ts
@@ -741,14 +741,14 @@ export function newTSDFListQueryStore<
     >[],
     {
       itemSelector = defaultItemSelector,
-      selectorUseExternalDeps,
+      selectorUsesExternalDeps,
     }: {
       itemSelector?: (
         data: ItemState,
         id: ItemPayload,
         itemKey: string,
       ) => SelectedItem;
-      selectorUseExternalDeps?: boolean;
+      selectorUsesExternalDeps?: boolean;
     } = {},
   ) {
     type QueryWithId = {
@@ -775,10 +775,9 @@ export function newTSDFListQueryStore<
     }, [queries]);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const dataSelector = useCallback(
-      itemSelector,
-      selectorUseExternalDeps ? [itemSelector] : [],
-    );
+    const dataSelector = useCallback(itemSelector, [
+      selectorUsesExternalDeps ? itemSelector : 0,
+    ]);
 
     const resultSelector = useCallback(
       (state: State) => {
@@ -920,7 +919,7 @@ export function newTSDFListQueryStore<
       loadSize,
       omitPayload,
       ensureIsLoaded,
-      selectorUseExternalDeps,
+      selectorUsesExternalDeps,
     }: {
       itemSelector?: (
         data: ItemState,
@@ -934,7 +933,7 @@ export function newTSDFListQueryStore<
       ensureIsLoaded?: boolean;
       loadSize?: number;
       isOffScreen?: boolean;
-      selectorUseExternalDeps?: boolean;
+      selectorUsesExternalDeps?: boolean;
     } = {},
   ) {
     const query = useMemo(
@@ -965,7 +964,7 @@ export function newTSDFListQueryStore<
 
     const queryResult = useMultipleListQueries(query, {
       itemSelector,
-      selectorUseExternalDeps,
+      selectorUsesExternalDeps,
     });
 
     const result = useMemo(
@@ -1289,10 +1288,9 @@ export function newTSDFListQueryStore<
     } = {},
   ) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const dataSelector = useCallback(
-      selector,
-      selectorUsesExternalDeps ? [selector] : [],
-    );
+    const dataSelector = useCallback(selector, [
+      selectorUsesExternalDeps ? selector : 0,
+    ]);
 
     type PayloadWithKey = {
       payload: ItemPayload;
@@ -1459,7 +1457,16 @@ export function newTSDFListQueryStore<
 
   function useItem<SelectedItem = ItemState | null>(
     itemPayload: ItemPayload | false | null | undefined,
-    options: {
+    {
+      selector,
+      selectorUsesExternalDeps,
+      disableRefetchOnMount,
+      returnIdleStatus,
+      returnRefetchingStatus,
+      ensureIsLoaded,
+      loadFromStateOnly,
+      isOffScreen,
+    }: {
       selector?: (
         data: ItemState | null,
         id: ItemPayload | null,
@@ -1473,8 +1480,6 @@ export function newTSDFListQueryStore<
       isOffScreen?: boolean;
     } = {},
   ) {
-    const { ensureIsLoaded } = options;
-
     const query = useMemo(
       (): ListQueryUseMultipleItemsQuery<ItemPayload, undefined>[] =>
         itemPayload === false ||
@@ -1484,30 +1489,30 @@ export function newTSDFListQueryStore<
           : [
               {
                 payload: itemPayload,
-                disableRefetchOnMount: options.disableRefetchOnMount,
-                isOffScreen: options.isOffScreen,
-                returnIdleStatus: options.returnIdleStatus,
-                returnRefetchingStatus: options.returnRefetchingStatus,
+                disableRefetchOnMount,
+                isOffScreen,
+                returnIdleStatus,
+                returnRefetchingStatus,
               },
             ],
       [
         itemPayload,
-        options.disableRefetchOnMount,
-        options.isOffScreen,
-        options.returnIdleStatus,
-        options.returnRefetchingStatus,
+        disableRefetchOnMount,
+        isOffScreen,
+        returnIdleStatus,
+        returnRefetchingStatus,
       ],
     );
 
     const queryResult = useMultipleItems<SelectedItem>(query, {
-      selector: options.selector,
-      selectorUsesExternalDeps: options.selectorUsesExternalDeps,
-      loadFromStateOnly: options.loadFromStateOnly,
+      selector,
+      selectorUsesExternalDeps,
+      loadFromStateOnly,
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const memoizedSelector = useCallback(
-      options.selector ?? defaultItemDataSelector,
+      selector ?? defaultItemDataSelector,
       [],
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ export {
   TSFDCollectionItem,
   TSFDUseCollectionItemReturn,
   OnCollectionItemInvalidate,
+  CollectionUseMultipleItemsQuery,
 } from './collectionStore';
 export {
   newTSDFListQueryStore,
@@ -27,6 +28,8 @@ export {
   OnListQueryInvalidate,
   OnListQueryItemInvalidate,
   FetchListFnReturnItem,
+  ListQueryUseMultipleItemsQuery,
+  ListQueryUseMultipleListQueriesQuery,
 } from './listQueryStore';
 export { TSDFStatus, ValidPayload, ValidStoreState } from './storeShared';
 export { useListItemIsLoading } from './useListItemIsLoading';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,1 @@
+export type NonPartial<T> = { [K in keyof Required<T>]: T[K] };

--- a/test/collectionStoreHooks2.test.tsx
+++ b/test/collectionStoreHooks2.test.tsx
@@ -16,8 +16,8 @@ test.concurrent(
     const env = createTestEnv({
       initialServerData: { '1': defaultTodo, '2': defaultTodo },
       useLoadedSnapshot: true,
-      emulateRTU: true,
       disableInitialDataInvalidation: true,
+      emulateRTU: true,
     });
 
     const renders = createRenderStore({
@@ -83,3 +83,197 @@ test.concurrent(
     `);
   },
 );
+
+test('disable then enable isOffScreen', async () => {
+  const env = createTestEnv({
+    initialServerData: { '1': defaultTodo, '2': defaultTodo },
+    useLoadedSnapshot: true,
+    emulateRTU: true,
+    disableInitialDataInvalidation: true,
+    lowPriorityThrottleMs: 10,
+  });
+
+  const renders = createRenderStore({
+    filterKeys: ['status', 'data', 'payload'],
+  });
+
+  const { rerender } = renderHook(
+    ({ isOffScreen }: { isOffScreen: boolean }) => {
+      const result = env.store.useItem('1', {
+        isOffScreen,
+        returnRefetchingStatus: true,
+      });
+
+      renders.add(result);
+    },
+    { initialProps: { isOffScreen: false } },
+  );
+
+  await sleep(120);
+
+  renders.addMark('set disabled');
+
+  rerender({ isOffScreen: true });
+
+  await sleep(120);
+
+  renders.addMark('enabled again');
+
+  rerender({ isOffScreen: false });
+
+  await sleep(200);
+
+  expect(renders.snapshot).toMatchInlineSnapshot(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: refetching -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+
+    >>> set disabled
+
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+
+    >>> enabled again
+
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+    "
+  `);
+
+  expect(env.serverMock.fetchsCount).toBe(1);
+});
+
+test('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
+  const env = createTestEnv({
+    initialServerData: { '1': defaultTodo, '2': defaultTodo },
+    useLoadedSnapshot: true,
+    lowPriorityThrottleMs: 10,
+  });
+
+  const filterKeys = ['status', 'data', 'payload', 'rrfs'];
+  const renders1 = createRenderStore({ filterKeys });
+  const renders2 = createRenderStore({ filterKeys });
+
+  const { rerender } = renderHook(
+    ({ returnRefetchingStatus }: { returnRefetchingStatus: boolean }) => {
+      const result = env.store.useMultipleItems(
+        ['1', '2'].map((payload) => ({
+          payload,
+          returnRefetchingStatus,
+        })),
+      );
+
+      renders1.add({ ...result[0]!, rrfs: returnRefetchingStatus });
+      renders2.add({ ...result[1]!, rrfs: returnRefetchingStatus });
+    },
+    { initialProps: { returnRefetchingStatus: false } },
+  );
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(2);
+
+  rerender({ returnRefetchingStatus: true });
+
+  await sleep(200);
+
+  expect(env.serverMock.fetchsCount).toBe(2);
+
+  expect(renders1.snapshot).toMatchInlineSnapshot(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: false
+    status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: true
+    "
+  `);
+  expect(renders2.snapshot).toMatchInlineSnapshot(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: false
+    status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: true
+    "
+  `);
+});
+
+test('useMultipleItems should not trigger a mount refetch for unchanged items', async () => {
+  const env = createTestEnv({
+    initialServerData: {
+      '1': defaultTodo,
+      '2': defaultTodo,
+      '3': defaultTodo,
+      '4': defaultTodo,
+      '5': defaultTodo,
+    },
+    useLoadedSnapshot: true,
+    lowPriorityThrottleMs: 10,
+  });
+
+  const renders = createRenderStore({
+    filterKeys: ['i', 'status', 'data', 'payload'],
+  });
+
+  const { rerender } = renderHook(
+    ({ items }: { items: string[] }) => {
+      const result = env.store.useMultipleItems(
+        items.map((payload) => ({ payload })),
+      );
+
+      renders.add(result);
+    },
+    { initialProps: { items: ['1', '2'] } },
+  );
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(2);
+
+  renders.addMark('add item');
+  rerender({ items: ['1', '2', '3'] });
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(3);
+
+  renders.addMark('remove item');
+  rerender({ items: ['2', '3'] });
+
+  await sleep(200);
+
+  expect(env.serverMock.fetchsCount).toBe(3);
+
+  renders.addMark('add removed item back');
+
+  env.serverMock.produceData((draft) => {
+    draft['1']!.title = 'changed';
+  });
+
+  rerender({ items: ['2', '3', '1'] });
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(4);
+
+  expect(renders.snapshot).toMatchInlineSnapshot(`
+    "
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+
+    >>> add item
+
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 3 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+
+    >>> remove item
+
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+
+    >>> add removed item back
+
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+    i: 3 -- status: success -- data: {title:todo, completed:false} -- payload: 1
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+    i: 3 -- status: success -- data: {title:changed, completed:false} -- payload: 1
+    "
+  `);
+});

--- a/test/collectionStoreHooks2.test.tsx
+++ b/test/collectionStoreHooks2.test.tsx
@@ -20,7 +20,9 @@ test.concurrent(
       disableInitialDataInvalidation: true,
     });
 
-    const renders = createRenderStore();
+    const renders = createRenderStore({
+      rejectKeys: ['queryMetadata'],
+    });
 
     const { rerender } = renderHook(
       ({ isOffScreen }: { isOffScreen: boolean }) => {

--- a/test/collectionStoreHooks2.test.tsx
+++ b/test/collectionStoreHooks2.test.tsx
@@ -142,7 +142,7 @@ test('disable then enable isOffScreen', async () => {
   expect(env.serverMock.fetchsCount).toBe(1);
 });
 
-test('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
+test.concurrent('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
   const env = createTestEnv({
     initialServerData: { '1': defaultTodo, '2': defaultTodo },
     useLoadedSnapshot: true,
@@ -178,13 +178,13 @@ test('useMultipleItems should not trigger a mount refetch when some option chang
 
   expect(env.serverMock.fetchsCount).toBe(2);
 
-  expect(renders1.snapshot).toMatchInlineSnapshot(`
+  expect(renders1.snapshot).toMatchInlineSnapshotString(`
     "
     status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: false
     status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: true
     "
   `);
-  expect(renders2.snapshot).toMatchInlineSnapshot(`
+  expect(renders2.snapshot).toMatchInlineSnapshotString(`
     "
     status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: false
     status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: true
@@ -192,7 +192,7 @@ test('useMultipleItems should not trigger a mount refetch when some option chang
   `);
 });
 
-test('useMultipleItems should not trigger a mount refetch for unchanged items', async () => {
+test.concurrent('useMultipleItems should not trigger a mount refetch for unchanged items', async () => {
   const env = createTestEnv({
     initialServerData: {
       '1': defaultTodo,
@@ -250,7 +250,7 @@ test('useMultipleItems should not trigger a mount refetch for unchanged items', 
 
   expect(env.serverMock.fetchsCount).toBe(4);
 
-  expect(renders.snapshot).toMatchInlineSnapshot(`
+  expect(renders.snapshot).toMatchInlineSnapshotString(`
     "
     i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
     i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2

--- a/test/getCacheId.test.ts
+++ b/test/getCacheId.test.ts
@@ -146,3 +146,15 @@ test('getCacheId handles nested arrays', () => {
     `"{"a":[1,2,3,[2,1,3]]}"`,
   );
 });
+
+test('a subset of a value can be checked via includes', () => {
+  const subSetObj = { z: 0, a: 1, b: 2 };
+
+  expect(
+    getCacheId({
+      a: 1,
+      b: 2,
+      c: subSetObj,
+    }).includes(getCacheId(subSetObj)),
+  ).toBeTruthy();
+});

--- a/test/listQueryStoreHooks3.test.tsx
+++ b/test/listQueryStoreHooks3.test.tsx
@@ -216,17 +216,17 @@ test.concurrent('useItem: disable then enable isOffScreen', async () => {
 
   expect(renders.snapshot).toMatchInlineSnapshotString(`
     "
-    status: success -- data: {title:todo, completed:false} -- payload: 1
-    status: refetching -- data: {title:todo, completed:false} -- payload: 1
-    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- data: {id:1, name:User 1} -- payload: users||1
+    status: refetching -- data: {id:1, name:User 1} -- payload: users||1
+    status: success -- data: {id:1, name:User 1} -- payload: users||1
 
     >>> set disabled
 
-    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- data: {id:1, name:User 1} -- payload: users||1
 
     >>> enabled again
 
-    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- data: {id:1, name:User 1} -- payload: users||1
     "
   `);
 
@@ -279,157 +279,290 @@ test.concurrent('useListQuery: disable then enable isOffScreen', async () => {
 
   expect(renders.snapshot).toMatchInlineSnapshotString(`
     "
-    status: success -- data: {title:todo, completed:false} -- payload: 1
-    status: refetching -- data: {title:todo, completed:false} -- payload: 1
-    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    status: refetching -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
 
     >>> set disabled
 
-    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
 
     >>> enabled again
 
-    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
     "
   `);
 
   expect(env.serverMock.fetchsCount).toBe(1);
 });
 
-test('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
-  const env = createTestEnv({
-    initialServerData,
-    useLoadedSnapshot: { tables: ['products', 'users'] },
-    lowPriorityThrottleMs: 10,
-  });
+test.concurrent(
+  'useMultipleItems should not trigger a mount refetch when some option changes',
+  async () => {
+    const env = createTestEnv({
+      initialServerData,
+      useLoadedSnapshot: { tables: ['products', 'users'] },
+      lowPriorityThrottleMs: 10,
+    });
 
-  const filterKeys = ['status', 'data', 'payload', 'rrfs'];
-  const renders1 = createRenderStore({ filterKeys });
-  const renders2 = createRenderStore({ filterKeys });
+    const filterKeys = ['status', 'data', 'payload', 'rrfs'];
+    const renders1 = createRenderStore({ filterKeys });
+    const renders2 = createRenderStore({ filterKeys });
 
-  const { rerender } = renderHook(
-    ({ returnRefetchingStatus }: { returnRefetchingStatus: boolean }) => {
-      const result = env.store.useMultipleItems(
-        ['users||1', 'users||2'].map((payload) => ({
-          payload,
-          returnRefetchingStatus,
-        })),
-      );
+    const { rerender } = renderHook(
+      ({ returnRefetchingStatus }: { returnRefetchingStatus: boolean }) => {
+        const result = env.store.useMultipleItems(
+          ['users||1', 'users||2'].map((payload) => ({
+            payload,
+            returnRefetchingStatus,
+          })),
+        );
 
-      renders1.add({ ...result[0]!, rrfs: returnRefetchingStatus });
-      renders2.add({ ...result[1]!, rrfs: returnRefetchingStatus });
-    },
-    { initialProps: { returnRefetchingStatus: false } },
-  );
+        renders1.add({ ...result[0]!, rrfs: returnRefetchingStatus });
+        renders2.add({ ...result[1]!, rrfs: returnRefetchingStatus });
+      },
+      { initialProps: { returnRefetchingStatus: false } },
+    );
 
-  await env.serverMock.waitFetchIdle();
+    await env.serverMock.waitFetchIdle();
 
-  expect(env.serverMock.fetchsCount).toBe(2);
+    expect(env.serverMock.fetchsCount).toBe(2);
 
-  rerender({ returnRefetchingStatus: true });
+    rerender({ returnRefetchingStatus: true });
 
-  await sleep(200);
+    await sleep(200);
 
-  expect(env.serverMock.fetchsCount).toBe(2);
+    expect(env.serverMock.fetchsCount).toBe(2);
 
-  expect(renders1.snapshot).toMatchInlineSnapshot(`
+    expect(renders1.snapshot).toMatchInlineSnapshotString(`
     "
-    status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: false
-    status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: true
-    "
-  `);
-  expect(renders2.snapshot).toMatchInlineSnapshot(`
-    "
-    status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: false
-    status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: true
+    status: success -- data: {id:1, name:User 1} -- payload: users||1 -- rrfs: false
+    status: success -- data: {id:1, name:User 1} -- payload: users||1 -- rrfs: true
     "
   `);
-});
-
-test('useMultipleItems should not trigger a mount refetch for unchanged items', async () => {
-  const env = createTestEnv({
-    initialServerData,
-    useLoadedSnapshot: { tables: ['products', 'users'] },
-    lowPriorityThrottleMs: 10,
-  });
-
-  const renders = createRenderStore({
-    filterKeys: ['i', 'status', 'data', 'payload'],
-  });
-
-  const { rerender } = renderHook(
-    ({ items }: { items: string[] }) => {
-      const result = env.store.useMultipleItems(
-        items.map((payload) => ({ payload })),
-      );
-
-      renders.add(result);
-    },
-    { initialProps: { items: ['users||1', 'users||2'] } },
-  );
-
-  await env.serverMock.waitFetchIdle();
-
-  expect(env.serverMock.fetchsCount).toBe(2);
-
-  renders.addMark('add item');
-  rerender({ items: ['users||1', 'users||2', 'users||3'] });
-
-  await env.serverMock.waitFetchIdle();
-
-  expect(env.serverMock.fetchsCount).toBe(3);
-
-  renders.addMark('remove item');
-  rerender({ items: ['users||2', 'users||3'] });
-
-  await sleep(200);
-
-  expect(env.serverMock.fetchsCount).toBe(3);
-
-  renders.addMark('add removed item back');
-
-  env.serverMock.produceData((draft) => {
-    draft.users![0]!.name = 'changed';
-  });
-
-  rerender({ items: ['users||2', 'users||3', 'users||1'] });
-
-  await env.serverMock.waitFetchIdle();
-
-  expect(env.serverMock.fetchsCount).toBe(4);
-
-  expect(renders.snapshot).toMatchInlineSnapshot(`
+    expect(renders2.snapshot).toMatchInlineSnapshotString(`
     "
-    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
-    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    status: success -- data: {id:2, name:User 2} -- payload: users||2 -- rrfs: false
+    status: success -- data: {id:2, name:User 2} -- payload: users||2 -- rrfs: true
+    "
+  `);
+  },
+);
+
+test.concurrent(
+  'useMultipleItems should not trigger a mount refetch for unchanged items',
+  async () => {
+    const env = createTestEnv({
+      initialServerData,
+      useLoadedSnapshot: { tables: ['products', 'users'] },
+      lowPriorityThrottleMs: 10,
+    });
+
+    const renders = createRenderStore({
+      filterKeys: ['i', 'status', 'data', 'payload'],
+    });
+
+    const { rerender } = renderHook(
+      ({ items }: { items: string[] }) => {
+        const result = env.store.useMultipleItems(
+          items.map((payload) => ({ payload })),
+        );
+
+        renders.add(result);
+      },
+      { initialProps: { items: ['users||1', 'users||2'] } },
+    );
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(2);
+
+    renders.addMark('add item');
+    rerender({ items: ['users||1', 'users||2', 'users||3'] });
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(3);
+
+    renders.addMark('remove item');
+    rerender({ items: ['users||2', 'users||3'] });
+
+    await sleep(200);
+
+    expect(env.serverMock.fetchsCount).toBe(3);
+
+    renders.addMark('add removed item back');
+
+    env.serverMock.produceData((draft) => {
+      draft.users![0]!.name = 'changed';
+    });
+
+    rerender({ items: ['users||2', 'users||3', 'users||1'] });
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(4);
+
+    expect(renders.snapshot).toMatchInlineSnapshotString(`
+    "
+    i: 1 -- status: success -- data: {id:1, name:User 1} -- payload: users||1
+    i: 2 -- status: success -- data: {id:2, name:User 2} -- payload: users||2
 
     >>> add item
 
-    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
-    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2
-    i: 3 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+    i: 1 -- status: success -- data: {id:1, name:User 1} -- payload: users||1
+    i: 2 -- status: success -- data: {id:2, name:User 2} -- payload: users||2
+    i: 3 -- status: success -- data: {id:3, name:User 3} -- payload: users||3
 
     >>> remove item
 
-    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
-    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+    i: 1 -- status: success -- data: {id:2, name:User 2} -- payload: users||2
+    i: 2 -- status: success -- data: {id:3, name:User 3} -- payload: users||3
 
     >>> add removed item back
 
-    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
-    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
-    i: 3 -- status: success -- data: {title:todo, completed:false} -- payload: 1
-    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
-    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
-    i: 3 -- status: success -- data: {title:changed, completed:false} -- payload: 1
+    i: 1 -- status: success -- data: {id:2, name:User 2} -- payload: users||2
+    i: 2 -- status: success -- data: {id:3, name:User 3} -- payload: users||3
+    i: 3 -- status: success -- data: {id:1, name:User 1} -- payload: users||1
+    i: 1 -- status: success -- data: {id:2, name:User 2} -- payload: users||2
+    i: 2 -- status: success -- data: {id:3, name:User 3} -- payload: users||3
+    i: 3 -- status: success -- data: {id:1, name:changed} -- payload: users||1
     "
   `);
-});
+  },
+);
 
-test('useMultipleListQueries should not trigger a mount refetch when some option changes', async () => {
-  throw new Error('not implemented');
-});
+test.concurrent(
+  'useMultipleListQueries should not trigger a mount refetch when some option changes',
+  async () => {
+    const env = createTestEnv({
+      initialServerData,
+      useLoadedSnapshot: { tables: ['products', 'users'] },
+      lowPriorityThrottleMs: 10,
+    });
 
-test('useMultipleListQueries should not trigger a mount refetch for unchanged items', async () => {
-  throw new Error('not implemented');
-});
+    const filterKeys = ['i', 'status', 'items', 'payload', 'rrfs'];
+
+    const renders = createRenderStore({ filterKeys });
+
+    const { rerender } = renderHook(
+      ({ returnRefetchingStatus }: { returnRefetchingStatus: boolean }) => {
+        const result = env.store.useMultipleListQueries(
+          [{ tableId: 'users' }, { tableId: 'products' }].map((payload) => ({
+            payload,
+            returnRefetchingStatus,
+          })),
+        );
+
+        renders.add(
+          result.map((r) => ({ ...r, rrfs: returnRefetchingStatus })),
+        );
+      },
+      { initialProps: { returnRefetchingStatus: false } },
+    );
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(2);
+
+    rerender({ returnRefetchingStatus: true });
+
+    await sleep(200);
+
+    expect(env.serverMock.fetchsCount).toBe(2);
+
+    expect(renders.snapshot).toMatchInlineSnapshotString(`
+    "
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users} -- rrfs: false
+    i: 2 -- status: success -- items: [{id:1, name:Product 1}, ...(49 more)] -- payload: {tableId:products} -- rrfs: false
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users} -- rrfs: true
+    i: 2 -- status: success -- items: [{id:1, name:Product 1}, ...(49 more)] -- payload: {tableId:products} -- rrfs: true
+    "
+  `);
+  },
+);
+
+test.concurrent(
+  'useMultipleListQueries should not trigger a mount refetch for unchanged items',
+  async () => {
+    const env = createTestEnv({
+      initialServerData,
+      useLoadedSnapshot: { tables: ['products', 'users', 'orders'] },
+      lowPriorityThrottleMs: 10,
+    });
+
+    const renders = createRenderStore({
+      filterKeys: ['i', 'status', 'items', 'payload'],
+    });
+
+    const { rerender } = renderHook(
+      ({ items }: { items: string[] }) => {
+        const result = env.store.useMultipleListQueries(
+          items.map((payload) => ({
+            payload: { tableId: payload },
+          })),
+        );
+
+        renders.add(result);
+      },
+      { initialProps: { items: ['users', 'products'] } },
+    );
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(2);
+
+    renders.addMark('add item');
+    rerender({ items: ['users', 'products', 'orders'] });
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(3);
+
+    renders.addMark('remove item');
+    rerender({ items: ['users', 'orders'] });
+
+    await sleep(200);
+
+    expect(env.serverMock.fetchsCount).toBe(3);
+
+    renders.addMark('add removed item back');
+
+    env.serverMock.produceData((draft) => {
+      draft.products![0]!.name = 'changed';
+    });
+
+    rerender({ items: ['users', 'orders', 'products'] });
+
+    await env.serverMock.waitFetchIdle();
+
+    expect(env.serverMock.fetchsCount).toBe(4);
+
+    expect(renders.snapshot).toMatchInlineSnapshotString(`
+    "
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    i: 2 -- status: success -- items: [{id:1, name:Product 1}, ...(49 more)] -- payload: {tableId:products}
+
+    >>> add item
+
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    i: 2 -- status: success -- items: [{id:1, name:Product 1}, ...(49 more)] -- payload: {tableId:products}
+    i: 3 -- status: success -- items: [{id:1, name:Order 1}, ...(49 more)] -- payload: {tableId:orders}
+
+    >>> remove item
+
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    i: 2 -- status: success -- items: [{id:1, name:Order 1}, ...(49 more)] -- payload: {tableId:orders}
+
+    >>> add removed item back
+
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    i: 2 -- status: success -- items: [{id:1, name:Order 1}, ...(49 more)] -- payload: {tableId:orders}
+    i: 3 -- status: success -- items: [{id:1, name:Product 1}, ...(49 more)] -- payload: {tableId:products}
+    i: 1 -- status: success -- items: [{id:1, name:User 1}, ...(4 more)] -- payload: {tableId:users}
+    i: 2 -- status: success -- items: [{id:1, name:Order 1}, ...(49 more)] -- payload: {tableId:orders}
+    i: 3 -- status: success -- items: [{id:1, name:changed}, ...(49 more)] -- payload: {tableId:products}
+    "
+  `);
+  },
+);

--- a/test/listQueryStoreHooks3.test.tsx
+++ b/test/listQueryStoreHooks3.test.tsx
@@ -26,7 +26,9 @@ test.concurrent(
       disableInitialDataInvalidation: true,
     });
 
-    const renders = createRenderStore();
+    const renders = createRenderStore({
+      rejectKeys: ['queryMetadata'],
+    });
 
     const { rerender } = renderHook(
       ({ isOffScreen }: { isOffScreen: boolean }) => {
@@ -102,7 +104,9 @@ test.concurrent(
       disableInitialDataInvalidation: true,
     });
 
-    const renders = createRenderStore();
+    const renders = createRenderStore({
+      rejectKeys: ['queryMetadata'],
+    });
 
     const { rerender } = renderHook(
       ({ isOffScreen }: { isOffScreen: boolean }) => {

--- a/test/listQueryStoreHooks3.test.tsx
+++ b/test/listQueryStoreHooks3.test.tsx
@@ -174,3 +174,262 @@ test.concurrent(
     `);
   },
 );
+
+test.concurrent('useItem: disable then enable isOffScreen', async () => {
+  const env = createTestEnv({
+    initialServerData,
+    useLoadedSnapshot: { tables: ['products', 'users'] },
+    emulateRTU: true,
+    disableInitialDataInvalidation: true,
+    lowPriorityThrottleMs: 10,
+  });
+
+  const renders = createRenderStore({
+    filterKeys: ['status', 'data', 'payload'],
+  });
+
+  const { rerender } = renderHook(
+    ({ isOffScreen }: { isOffScreen: boolean }) => {
+      const result = env.store.useItem('users||1', {
+        isOffScreen,
+        returnRefetchingStatus: true,
+      });
+
+      renders.add(result);
+    },
+    { initialProps: { isOffScreen: false } },
+  );
+
+  await sleep(120);
+
+  renders.addMark('set disabled');
+
+  rerender({ isOffScreen: true });
+
+  await sleep(120);
+
+  renders.addMark('enabled again');
+
+  rerender({ isOffScreen: false });
+
+  await sleep(200);
+
+  expect(renders.snapshot).toMatchInlineSnapshotString(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: refetching -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+
+    >>> set disabled
+
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+
+    >>> enabled again
+
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+    "
+  `);
+
+  expect(env.serverMock.fetchsCount).toBe(1);
+});
+
+test.concurrent('useListQuery: disable then enable isOffScreen', async () => {
+  const env = createTestEnv({
+    initialServerData,
+    useLoadedSnapshot: { tables: ['products', 'users'] },
+    emulateRTU: true,
+    disableInitialDataInvalidation: true,
+    lowPriorityThrottleMs: 10,
+  });
+
+  const renders = createRenderStore({
+    filterKeys: ['status', 'items', 'payload'],
+  });
+
+  const { rerender } = renderHook(
+    ({ isOffScreen }: { isOffScreen: boolean }) => {
+      const result = env.store.useListQuery(
+        {
+          tableId: 'users',
+        },
+        {
+          isOffScreen,
+          returnRefetchingStatus: true,
+        },
+      );
+
+      renders.add(result);
+    },
+    { initialProps: { isOffScreen: false } },
+  );
+
+  await sleep(120);
+
+  renders.addMark('set disabled');
+
+  rerender({ isOffScreen: true });
+
+  await sleep(120);
+
+  renders.addMark('enabled again');
+
+  rerender({ isOffScreen: false });
+
+  await sleep(200);
+
+  expect(renders.snapshot).toMatchInlineSnapshotString(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+    status: refetching -- data: {title:todo, completed:false} -- payload: 1
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+
+    >>> set disabled
+
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+
+    >>> enabled again
+
+    status: success -- data: {title:todo, completed:false} -- payload: 1
+    "
+  `);
+
+  expect(env.serverMock.fetchsCount).toBe(1);
+});
+
+test('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
+  const env = createTestEnv({
+    initialServerData,
+    useLoadedSnapshot: { tables: ['products', 'users'] },
+    lowPriorityThrottleMs: 10,
+  });
+
+  const filterKeys = ['status', 'data', 'payload', 'rrfs'];
+  const renders1 = createRenderStore({ filterKeys });
+  const renders2 = createRenderStore({ filterKeys });
+
+  const { rerender } = renderHook(
+    ({ returnRefetchingStatus }: { returnRefetchingStatus: boolean }) => {
+      const result = env.store.useMultipleItems(
+        ['users||1', 'users||2'].map((payload) => ({
+          payload,
+          returnRefetchingStatus,
+        })),
+      );
+
+      renders1.add({ ...result[0]!, rrfs: returnRefetchingStatus });
+      renders2.add({ ...result[1]!, rrfs: returnRefetchingStatus });
+    },
+    { initialProps: { returnRefetchingStatus: false } },
+  );
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(2);
+
+  rerender({ returnRefetchingStatus: true });
+
+  await sleep(200);
+
+  expect(env.serverMock.fetchsCount).toBe(2);
+
+  expect(renders1.snapshot).toMatchInlineSnapshot(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: false
+    status: success -- data: {title:todo, completed:false} -- payload: 1 -- rrfs: true
+    "
+  `);
+  expect(renders2.snapshot).toMatchInlineSnapshot(`
+    "
+    status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: false
+    status: success -- data: {title:todo, completed:false} -- payload: 2 -- rrfs: true
+    "
+  `);
+});
+
+test('useMultipleItems should not trigger a mount refetch for unchanged items', async () => {
+  const env = createTestEnv({
+    initialServerData,
+    useLoadedSnapshot: { tables: ['products', 'users'] },
+    lowPriorityThrottleMs: 10,
+  });
+
+  const renders = createRenderStore({
+    filterKeys: ['i', 'status', 'data', 'payload'],
+  });
+
+  const { rerender } = renderHook(
+    ({ items }: { items: string[] }) => {
+      const result = env.store.useMultipleItems(
+        items.map((payload) => ({ payload })),
+      );
+
+      renders.add(result);
+    },
+    { initialProps: { items: ['users||1', 'users||2'] } },
+  );
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(2);
+
+  renders.addMark('add item');
+  rerender({ items: ['users||1', 'users||2', 'users||3'] });
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(3);
+
+  renders.addMark('remove item');
+  rerender({ items: ['users||2', 'users||3'] });
+
+  await sleep(200);
+
+  expect(env.serverMock.fetchsCount).toBe(3);
+
+  renders.addMark('add removed item back');
+
+  env.serverMock.produceData((draft) => {
+    draft.users![0]!.name = 'changed';
+  });
+
+  rerender({ items: ['users||2', 'users||3', 'users||1'] });
+
+  await env.serverMock.waitFetchIdle();
+
+  expect(env.serverMock.fetchsCount).toBe(4);
+
+  expect(renders.snapshot).toMatchInlineSnapshot(`
+    "
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+
+    >>> add item
+
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 1
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 3 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+
+    >>> remove item
+
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+
+    >>> add removed item back
+
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+    i: 3 -- status: success -- data: {title:todo, completed:false} -- payload: 1
+    i: 1 -- status: success -- data: {title:todo, completed:false} -- payload: 2
+    i: 2 -- status: success -- data: {title:todo, completed:false} -- payload: 3
+    i: 3 -- status: success -- data: {title:changed, completed:false} -- payload: 1
+    "
+  `);
+});
+
+test('useMultipleListQueries should not trigger a mount refetch when some option changes', async () => {
+  throw new Error('not implemented');
+});
+
+test('useMultipleListQueries should not trigger a mount refetch for unchanged items', async () => {
+  throw new Error('not implemented');
+});

--- a/test/mocks/fetchMock.ts
+++ b/test/mocks/fetchMock.ts
@@ -294,3 +294,19 @@ export function mockServerResource<Data, S = Data>({
 }
 
 export type ServerMock<Data> = ReturnType<typeof mockServerResource<Data>>;
+
+type Deferred<T> = {
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason: unknown) => void;
+  promise: Promise<T>;
+};
+
+export function defer<T = void>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return { resolve, reject, promise };
+}

--- a/test/utils/createDefaultListQueryStore.ts
+++ b/test/utils/createDefaultListQueryStore.ts
@@ -47,6 +47,7 @@ export function createDefaultListQueryStore({
   debugRequests: debuFetchs,
   emulateRTU,
   optimisticListUpdates,
+  lowPriorityThrottleMs,
   disableSyncInvalidation,
 }: {
   initialServerData?: Tables;
@@ -63,6 +64,7 @@ export function createDefaultListQueryStore({
   disableInitialDataInvalidation?: boolean;
   emulateRTU?: boolean;
   disableSyncInvalidation?: boolean;
+  lowPriorityThrottleMs?: number;
 
   optimisticListUpdates?: Parameters<
     typeof newTSDFListQueryStore<Row, any, ListQueryParams, string>
@@ -254,6 +256,7 @@ export function createDefaultListQueryStore({
     defaultQuerySize,
     getInitialData: () => initialData,
     disableInitialDataInvalidation,
+    lowPriorityThrottleMs,
     dynamicRealtimeThrottleMs: dynamicRTUThrottleMs,
     syncMutationsAndInvalidations: disableSyncInvalidation
       ? undefined

--- a/test/utils/objectUtils.ts
+++ b/test/utils/objectUtils.ts
@@ -16,3 +16,22 @@ export function pick<T, K extends keyof T>(
   }
   return result;
 }
+
+export function omit<T>(
+  obj: T | undefined,
+  keys: (keyof T)[],
+): Record<string, unknown> {
+  const result: any = {};
+
+  if (!obj) {
+    return result;
+  }
+
+  for (const key of Object.keys(obj)) {
+    if (!keys.includes(key as keyof T)) {
+      result[key] = obj[key as keyof T];
+    }
+  }
+
+  return result;
+}

--- a/test/utils/storeUtils.ts
+++ b/test/utils/storeUtils.ts
@@ -87,7 +87,7 @@ export function createDefaultDocumentStore({
   return { serverMock, store, getElapsedTime };
 }
 
-type Todo = {
+export type Todo = {
   title: string;
   completed: boolean;
   description?: string;


### PR DESCRIPTION
This pull request adjusts the useMultipleItems function in both the collectionStore and listQuery store. Specifically, it adds the ability to pass in an array of objects with a payload and optional queryMetadata property. 