### PR TITLE
Centralize document-store test state with testScenario option

### DIFF
--- a/src/documentStore.ts
+++ b/src/documentStore.ts
@@ -71,6 +71,7 @@ export type DocumentStoreOptions<State extends ValidStoreState> = {
     initialStatus?: DocumentStatus;
     initialData?: State;
     initialError?: StoreError;
+    initialLastFetchStartTime?: number;
   };
 };
 
@@ -205,6 +206,7 @@ export function createDocumentStore<State extends ValidStoreState>({
     dynamicRealtimeThrottleMs,
     mediumPriorityDelayMs,
     on: onSchedulerEvent,
+    initialLastFetchStartTime: testOptions?.initialLastFetchStartTime,
   });
 
   function scheduleFetch(

--- a/src/documentStore.ts
+++ b/src/documentStore.ts
@@ -54,9 +54,6 @@ export type OnDocumentInvalidate = (priority: FetchType) => void;
 export type DocumentStoreOptions<State extends ValidStoreState> = {
   debugName?: string;
   fetchFn: (signal: AbortSignal) => Promise<State>;
-  getInitialData?: () => State | undefined;
-  disableInitialInvalidation?: boolean;
-  disableRefetchOnMount?: boolean;
   errorNormalizer: (exception: Error) => StoreError;
   lowPriorityThrottleMs: number;
   baseCoalescingWindowMs: number;
@@ -67,6 +64,14 @@ export type DocumentStoreOptions<State extends ValidStoreState> = {
     error: unknown,
     options: { dontShowToast?: boolean },
   ) => void;
+  usesRealTimeUpdates?: boolean;
+  /** @internal */
+  '~test'?: {
+    initialRefetchOnMount?: FetchType;
+    initialStatus?: DocumentStatus;
+    initialData?: State;
+    initialError?: StoreError;
+  };
 };
 
 export type DocumentStore<State extends ValidStoreState> = ReturnType<
@@ -79,9 +84,6 @@ const DOC_REQUEST_ID = '_doc';
 export function createDocumentStore<State extends ValidStoreState>({
   debugName,
   fetchFn,
-  getInitialData,
-  disableInitialInvalidation,
-  disableRefetchOnMount: globalDisableRefetchOnMount,
   errorNormalizer,
   lowPriorityThrottleMs,
   baseCoalescingWindowMs,
@@ -89,21 +91,43 @@ export function createDocumentStore<State extends ValidStoreState>({
   mediumPriorityDelayMs,
   onSchedulerEvent,
   onMutationError,
+  usesRealTimeUpdates,
+  '~test': testOptions,
 }: DocumentStoreOptions<State>) {
   let invalidationWasTriggered = false;
 
-  const initialData = getInitialData?.();
+  let initialData: State | null = null;
+  let initialRefetchOnMount: FetchType | false = false;
+  let initialStatus: DocumentStatus = 'idle';
+  let initialError: StoreError | null = null;
+
+  const globalDisableRefetchOnMount = usesRealTimeUpdates;
+
+  if (import.meta.env.TEST && testOptions) {
+    if (testOptions.initialData) {
+      initialData = testOptions.initialData;
+    }
+
+    if (testOptions.initialRefetchOnMount) {
+      initialRefetchOnMount = testOptions.initialRefetchOnMount;
+    }
+
+    if (testOptions.initialStatus) {
+      initialStatus = testOptions.initialStatus;
+    }
+
+    if (testOptions.initialError) {
+      initialError = testOptions.initialError;
+    }
+  }
 
   const store = new Store<DocumentStoreState<State>>({
     debugName,
     state: () => ({
-      data: initialData ?? null,
-      error: null,
-      status: initialData !== undefined ? 'success' : 'idle',
-      refetchOnMount:
-        initialData !== undefined && !disableInitialInvalidation ?
-          'lowPriority'
-        : false,
+      data: initialData,
+      error: initialError,
+      status: initialStatus,
+      refetchOnMount: initialRefetchOnMount,
     }),
   });
 

--- a/tests/basic-functionality/document-store.test.ts
+++ b/tests/basic-functionality/document-store.test.ts
@@ -1,21 +1,5 @@
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
-import {
-  createDocumentStoreTestEnv as createDocumentStoreTestEnvBase,
-  type DocumentStoreTestEnvOptions,
-} from '../mocks/documentStoreTestEnv';
-
-function createDocumentStoreTestEnv<D>(
-  serverInitialData: D,
-  {
-    initialStateData = 'sameAsServer',
-    disableInitialInvalidation = true,
-  }: DocumentStoreTestEnvOptions<D> = {},
-) {
-  return createDocumentStoreTestEnvBase(serverInitialData, {
-    initialStateData,
-    disableInitialInvalidation,
-  });
-}
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -28,7 +12,8 @@ afterEach(() => {
 describe('basic fetch lifecycle', () => {
   test('idle -> loading -> success state transitions', async () => {
     const env = createDocumentStoreTestEnv(42, {
-      initialStateData: null,
+      testScenario: 'idle',
+      usesRealTimeUpdates: true,
     });
 
     // Initial state should be idle
@@ -66,9 +51,12 @@ describe('basic fetch lifecycle', () => {
   });
 
   test('refetch with existing data shows refetching status and returns new data', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
-    // Initial state - has data from getInitialData (serverInitialData = 42)
+    // Initial state - has data from testScenario (serverInitialData = 42)
     expect(env.store.state).toMatchInlineSnapshot(`
       data: { value: 42 }
       error: null
@@ -106,7 +94,10 @@ describe('basic fetch lifecycle', () => {
   });
 
   test('error during refetch preserves existing data', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // First do a successful refetch to get new data
     env.setServerData(100);
@@ -139,9 +130,12 @@ describe('basic fetch lifecycle', () => {
   });
 });
 
-describe('getInitialData option', () => {
+describe('testScenario: idle', () => {
   test('store starts with initialized data', () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // Should start with initial data and success status
     expect(env.store.state).toMatchInlineSnapshot(`
@@ -152,9 +146,10 @@ describe('getInitialData option', () => {
     `);
   });
 
-  test('initial data triggers refetch on mount when invalidation enabled', async () => {
+  test('idle store fetches data on first scheduleFetch', async () => {
     const env = createDocumentStoreTestEnv(42, {
-      initialStateData: null,
+      testScenario: 'idle',
+      usesRealTimeUpdates: true,
     });
 
     // Should start with no data and idle status
@@ -184,7 +179,10 @@ describe('getInitialData option', () => {
 
 describe('invalidateData priority', () => {
   test('lower priority invalidation should not override higher priority', () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     env.apiStore.invalidateData('highPriority');
     expect(env.store.state.refetchOnMount).toBe('highPriority');
@@ -195,7 +193,10 @@ describe('invalidateData priority', () => {
   });
 
   test('realtimeUpdate invalidation should not be overridden by lowPriority', () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     env.apiStore.invalidateData('realtimeUpdate');
     expect(env.store.state.refetchOnMount).toBe('realtimeUpdate');
@@ -206,7 +207,10 @@ describe('invalidateData priority', () => {
   });
 
   test('highPriority invalidation should not be overridden by realtimeUpdate', () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     env.apiStore.invalidateData('highPriority');
     expect(env.store.state.refetchOnMount).toBe('highPriority');
@@ -217,7 +221,10 @@ describe('invalidateData priority', () => {
   });
 
   test('higher priority can override lower priority invalidation', () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     env.apiStore.invalidateData('lowPriority');
     expect(env.store.state.refetchOnMount).toBe('lowPriority');

--- a/tests/hooks/document-hooks-2.test.tsx
+++ b/tests/hooks/document-hooks-2.test.tsx
@@ -2,13 +2,14 @@ import { createLoggerStore } from '@ls-stack/utils/testUtils';
 import { act, cleanup, renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
 });
 
 beforeEach(() => {
-  vi.setSystemTime(0);
+  vi.setSystemTime(TEST_INITIAL_TIME);
 });
 
 afterEach(() => {

--- a/tests/hooks/document-hooks-2.test.tsx
+++ b/tests/hooks/document-hooks-2.test.tsx
@@ -23,10 +23,7 @@ type StoreValue = {
 test('disable should keep the selected data and not be affected by invalidation', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    {
-      useLoadedSnapshot: true,
-      disableInitialInvalidation: true,
-    },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const renders = createLoggerStore();
@@ -120,10 +117,7 @@ test('disable should keep the selected data and not be affected by invalidation'
 test('isOffScreen should keep the selected data and not be affected by invalidation', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    {
-      useLoadedSnapshot: true,
-      disableInitialInvalidation: true,
-    },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const renders = createLoggerStore();
@@ -217,10 +211,7 @@ test('isOffScreen should keep the selected data and not be affected by invalidat
 test('useDocument selector result should remain stable across rerenders', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    {
-      useLoadedSnapshot: true,
-      disableInitialInvalidation: true,
-    },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const renders = createLoggerStore();

--- a/tests/hooks/document-hooks.test.tsx
+++ b/tests/hooks/document-hooks.test.tsx
@@ -13,13 +13,14 @@ import {
 import type { DocumentStatus } from '../../src/documentStore';
 import type { StoreError } from '../../src/utils/storeShared';
 import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
 });
 
 beforeEach(() => {
-  vi.setSystemTime(0);
+  vi.setSystemTime(TEST_INITIAL_TIME);
 });
 
 afterEach(() => {

--- a/tests/hooks/document-hooks.test.tsx
+++ b/tests/hooks/document-hooks.test.tsx
@@ -54,7 +54,7 @@ test('load data', async () => {
 test('invalidate data', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    { useLoadedSnapshot: true },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const { result } = renderHook(() => env.apiStore.useDocument());
@@ -78,10 +78,7 @@ test('invalidate data', async () => {
 test('revalidation with multiple components do not trigger multiple fetches', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    {
-      disableInitialInvalidation: true,
-      initialStateData: 'sameAsServer',
-    },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   for (let i = 0; i < 27; i += 1) {
@@ -108,7 +105,7 @@ test('revalidation with multiple components do not trigger multiple fetches', as
 test('data selector', () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    { useLoadedSnapshot: true },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const { result } = renderHook(() =>
@@ -263,7 +260,7 @@ test('disableRefetchOnMount', async () => {
 test('do not return refetching status by default', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    { useLoadedSnapshot: true },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const renders: Array<[string | null, DocumentStatus]> = [];
@@ -293,7 +290,7 @@ describe('action types', () => {
   test('action with optimistic update', async () => {
     const env = createDocumentStoreTestEnv<StoreValue>(
       { hello: 'world' },
-      { useLoadedSnapshot: true },
+      { testScenario: 'loaded', usesRealTimeUpdates: true },
     );
 
     const renders: Array<[string | null, DocumentStatus]> = [];
@@ -327,7 +324,7 @@ describe('action types', () => {
   test('action with optimistic update and revalidation', async () => {
     const env = createDocumentStoreTestEnv<StoreValue>(
       { hello: 'world' },
-      { useLoadedSnapshot: true },
+      { testScenario: 'loaded', usesRealTimeUpdates: true },
     );
 
     const renders: Array<[string | null, DocumentStatus]> = [];
@@ -365,7 +362,7 @@ describe('action types', () => {
   test('action without optimistic update', async () => {
     const env = createDocumentStoreTestEnv<StoreValue>(
       { hello: 'world' },
-      { useLoadedSnapshot: true },
+      { testScenario: 'loaded', usesRealTimeUpdates: true },
     );
 
     const renders: Array<[string | null, DocumentStatus]> = [];
@@ -400,7 +397,7 @@ describe('action types', () => {
   test('action with revalidation and without optimistic update', async () => {
     const env = createDocumentStoreTestEnv<StoreValue>(
       { hello: 'world' },
-      { useLoadedSnapshot: true },
+      { testScenario: 'loaded', usesRealTimeUpdates: true },
     );
 
     const renders: Array<[string | null, DocumentStatus]> = [];
@@ -438,10 +435,7 @@ describe('action types', () => {
 test('rollback on error', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    {
-      useLoadedSnapshot: true,
-      disableInitialInvalidation: true,
-    },
+    { testScenario: 'loaded', usesRealTimeUpdates: true },
   );
 
   const renders: Array<[string | null, DocumentStatus, StoreError | null]> = [];
@@ -597,7 +591,8 @@ test('RTU update works', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'lucas' },
     {
-      useLoadedSnapshot: true,
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
       dynamicRealtimeThrottleMs() {
         return 300;
       },
@@ -662,10 +657,7 @@ test('RTU update works', async () => {
 test('initial data is invalidated on first load', async () => {
   const env = createDocumentStoreTestEnv<StoreValue>(
     { hello: 'world' },
-    {
-      initialStateData: 'sameAsServer',
-      disableInitialInvalidation: false,
-    },
+    { testScenario: { idleWithLocalCache: 'sameAsServer' } },
   );
 
   env.setServerData({ hello: 'update' });

--- a/tests/mocks/documentStoreTestEnv.ts
+++ b/tests/mocks/documentStoreTestEnv.ts
@@ -10,32 +10,29 @@ import {
   normalizeError,
 } from './testEnvUtils';
 
+export type DocumentStoreTestScenario<D> =
+  | 'idle'
+  | 'loadedFromServer'
+  | { idleWithLocalCache: 'sameAsServer' | D };
+
 export type DocumentStoreTestEnvOptions<D> = {
   dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
   baseCoalescingWindowMs?: number;
   lowPriorityThrottleMs?: number;
   mediumPriorityDelayMs?: number;
-  initialStateData?:
-    | 'sameAsServer'
-    | {
-        value: D;
-      }
-    | null;
-  disableInitialInvalidation?: boolean;
-  /* simulate a loaded snapshot without initial invalidation and refetch on mount (as if component was already mounted) */
-  useLoadedSnapshot?: boolean;
+  testScenario?: DocumentStoreTestScenario<D>;
+  usesRealTimeUpdates?: boolean;
 };
 
 export function createDocumentStoreTestEnv<D>(
   serverInitialData: D,
   {
-    initialStateData = null,
-    disableInitialInvalidation = false,
     dynamicRealtimeThrottleMs,
     baseCoalescingWindowMs = 10,
     lowPriorityThrottleMs = 200,
     mediumPriorityDelayMs,
-    useLoadedSnapshot = false,
+    testScenario,
+    usesRealTimeUpdates,
   }: DocumentStoreTestEnvOptions<D> = {},
 ) {
   const {
@@ -54,10 +51,7 @@ export function createDocumentStoreTestEnv<D>(
 
   const serverMock = createServerMock<D>(serverInitialData, addAction);
 
-  const resolvedInitialState =
-    initialStateData === 'sameAsServer' || useLoadedSnapshot ?
-      { value: serverInitialData }
-    : initialStateData;
+  const testOptions = resolveTestOptions(testScenario, serverInitialData);
 
   const documentStore = createDocumentStore<{ value: D }>({
     errorNormalizer: normalizeError,
@@ -67,21 +61,21 @@ export function createDocumentStoreTestEnv<D>(
       const value = await serverMock.fetch(signal);
       return { value };
     },
-    disableInitialInvalidation: disableInitialInvalidation || useLoadedSnapshot,
-    getInitialData:
-      resolvedInitialState ? () => resolvedInitialState : undefined,
-    disableRefetchOnMount: disableInitialInvalidation || useLoadedSnapshot,
+    usesRealTimeUpdates,
     dynamicRealtimeThrottleMs,
     mediumPriorityDelayMs,
+    '~test': testOptions,
     onSchedulerEvent: (event) => {
       logSchedulerEvent(event, addAction);
     },
   });
 
-  serverMock.wsEvents.on('data_changed', () => {
-    addAction('received-ws-data-change-event');
-    documentStore.invalidateData('realtimeUpdate');
-  });
+  if (usesRealTimeUpdates) {
+    serverMock.wsEvents.on('data_changed', () => {
+      addAction('received-ws-data-change-event');
+      documentStore.invalidateData('realtimeUpdate');
+    });
+  }
 
   return {
     apiStore: documentStore,
@@ -187,5 +181,38 @@ export function createDocumentStoreTestEnv<D>(
     setServerData(value: D) {
       serverMock.setData(value);
     },
+  };
+}
+
+function resolveTestOptions<D>(
+  scenario: DocumentStoreTestScenario<D> | undefined,
+  serverInitialData: D,
+):
+  | {
+      initialRefetchOnMount?: FetchType;
+      initialStatus?: 'idle' | 'success';
+      initialData?: { value: D };
+    }
+  | undefined {
+  if (!scenario || scenario === 'idle') {
+    return undefined;
+  }
+
+  if (scenario === 'loadedFromServer') {
+    return {
+      initialData: { value: serverInitialData },
+      initialStatus: 'success',
+    };
+  }
+
+  const cacheData =
+    scenario.idleWithLocalCache === 'sameAsServer'
+      ? serverInitialData
+      : scenario.idleWithLocalCache;
+
+  return {
+    initialData: { value: cacheData },
+    initialStatus: 'success',
+    initialRefetchOnMount: 'lowPriority',
   };
 }

--- a/tests/mocks/documentStoreTestEnv.ts
+++ b/tests/mocks/documentStoreTestEnv.ts
@@ -197,6 +197,7 @@ function resolveTestOptions<D>(
       initialRefetchOnMount?: FetchType;
       initialStatus?: 'idle' | 'success';
       initialData?: { value: D };
+      initialLastFetchStartTime?: number;
     }
   | undefined {
   if (!scenario || scenario === 'idle') {
@@ -207,6 +208,7 @@ function resolveTestOptions<D>(
     return {
       initialData: { value: serverInitialData },
       initialStatus: 'success',
+      initialLastFetchStartTime: Date.now() - 10_000,
     };
   }
 
@@ -220,11 +222,13 @@ function resolveTestOptions<D>(
       initialData: { value: cacheData },
       initialStatus: 'success',
       initialRefetchOnMount: 'lowPriority',
+      initialLastFetchStartTime: Date.now() - 10_000,
     };
   }
 
   return {
     initialData: { value: scenario.loadedWithStaleData },
     initialStatus: 'success',
+    initialLastFetchStartTime: Date.now() - 10_000,
   };
 }

--- a/tests/mocks/documentStoreTestEnv.ts
+++ b/tests/mocks/documentStoreTestEnv.ts
@@ -11,9 +11,14 @@ import {
 } from './testEnvUtils';
 
 export type DocumentStoreTestScenario<D> =
+  /** App just opened, no data fetched yet. */
   | 'idle'
-  | 'loadedFromServer'
-  | { idleWithLocalCache: 'sameAsServer' | D };
+  /** App already opened before and data was fetched successfully. */
+  | 'loaded'
+  /** App started with data restored from local cache, pending server revalidation. */
+  | { idleWithLocalCache: 'sameAsServer' | D }
+  /** Data was loaded previously but is now outdated (server has newer data). */
+  | { loadedWithStaleData: D };
 
 export type DocumentStoreTestEnvOptions<D> = {
   dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
@@ -198,21 +203,28 @@ function resolveTestOptions<D>(
     return undefined;
   }
 
-  if (scenario === 'loadedFromServer') {
+  if (scenario === 'loaded') {
     return {
       initialData: { value: serverInitialData },
       initialStatus: 'success',
     };
   }
 
-  const cacheData =
-    scenario.idleWithLocalCache === 'sameAsServer'
-      ? serverInitialData
+  if ('idleWithLocalCache' in scenario) {
+    const cacheData =
+      scenario.idleWithLocalCache === 'sameAsServer' ?
+        serverInitialData
       : scenario.idleWithLocalCache;
 
+    return {
+      initialData: { value: cacheData },
+      initialStatus: 'success',
+      initialRefetchOnMount: 'lowPriority',
+    };
+  }
+
   return {
-    initialData: { value: cacheData },
+    initialData: { value: scenario.loadedWithStaleData },
     initialStatus: 'success',
-    initialRefetchOnMount: 'lowPriority',
   };
 }

--- a/tests/mocks/testEnvUtils.ts
+++ b/tests/mocks/testEnvUtils.ts
@@ -1,6 +1,8 @@
 import type { ScheduleFetchResults } from '../../src/requestScheduler';
 import type { StoreError } from '../../src/utils/storeShared';
 
+export const TEST_INITIAL_TIME = new Date('2025-01-01').getTime();
+
 /**
  * Custom error class that carries path and method information for testing
  */

--- a/tests/request-schedulling/document-await-fetch.test.ts
+++ b/tests/request-schedulling/document-await-fetch.test.ts
@@ -1,29 +1,6 @@
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { StoreFetchError } from '../../src/utils/storeShared';
-import {
-  createDocumentStoreTestEnv as createDocumentStoreTestEnvBase,
-  type DocumentStoreTestEnvOptions,
-} from '../mocks/documentStoreTestEnv';
-
-function createDocumentStoreTestEnv<D>(
-  serverInitialData: D,
-  options: DocumentStoreTestEnvOptions<D> = {},
-) {
-  const resolvedInitialStateData =
-    options.initialStateData === undefined ?
-      'sameAsServer'
-    : options.initialStateData;
-  const resolvedDisableInitialInvalidation =
-    options.disableInitialInvalidation === undefined ?
-      true
-    : options.disableInitialInvalidation;
-
-  return createDocumentStoreTestEnvBase(serverInitialData, {
-    initialStateData: resolvedInitialStateData,
-    disableInitialInvalidation: resolvedDisableInitialInvalidation,
-    ...options,
-  });
-}
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -36,7 +13,8 @@ afterEach(() => {
 describe('awaitFetch basic behavior', () => {
   test('returns data on successful fetch', async () => {
     const env = createDocumentStoreTestEnv(42, {
-      initialStateData: null,
+      testScenario: 'idle',
+      usesRealTimeUpdates: true,
     });
 
     const resultPromise = env.apiStore.awaitFetch();
@@ -55,7 +33,8 @@ describe('awaitFetch basic behavior', () => {
 
   test('returns error on failed fetch', async () => {
     const env = createDocumentStoreTestEnv(42, {
-      initialStateData: null,
+      testScenario: 'idle',
+      usesRealTimeUpdates: true,
     });
 
     env.errorInNextFetch({
@@ -81,7 +60,10 @@ describe('awaitFetch basic behavior', () => {
   });
 
   test('triggers new fetch even when data exists', async () => {
-    const env = createDocumentStoreTestEnv(0);
+    const env = createDocumentStoreTestEnv(0, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // Initial data is already present
     expect(env.store.state.data).toEqual({ value: 0 });
@@ -105,7 +87,10 @@ describe('awaitFetch basic behavior', () => {
 
 describe('awaitFetch coalescing behavior', () => {
   test('multiple concurrent awaitFetch calls coalesce into single fetch', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // Start multiple awaitFetch calls concurrently
     const promise1 = env.apiStore.awaitFetch();
@@ -139,6 +124,8 @@ describe('awaitFetch coalescing behavior', () => {
 
   test('awaitFetch during coalescing window joins the window', async () => {
     const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
       baseCoalescingWindowMs: 50,
     });
 
@@ -169,7 +156,10 @@ describe('awaitFetch coalescing behavior', () => {
   });
 
   test('awaitFetch during ongoing fetch waits for completion then schedules another', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // Start first awaitFetch
     const promise1 = env.apiStore.awaitFetch();
@@ -204,7 +194,10 @@ describe('awaitFetch coalescing behavior', () => {
 
 describe('awaitFetch edge cases', () => {
   test('sequential awaitFetch calls each trigger their own fetch', async () => {
-    const env = createDocumentStoreTestEnv(1);
+    const env = createDocumentStoreTestEnv(1, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // First awaitFetch
     const promise1 = env.apiStore.awaitFetch();
@@ -226,7 +219,10 @@ describe('awaitFetch edge cases', () => {
   });
 
   test('awaitFetch returns latest data after server changes during fetch', async () => {
-    const env = createDocumentStoreTestEnv(1);
+    const env = createDocumentStoreTestEnv(1, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // Start awaitFetch
     const fetchPromise = env.apiStore.awaitFetch();
@@ -249,7 +245,10 @@ describe('awaitFetch edge cases', () => {
   });
 
   test('awaitFetch with immediate error', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     env.errorInNextFetch({
       message: 'Immediate failure',
@@ -274,7 +273,10 @@ describe('awaitFetch edge cases', () => {
   });
 
   test('awaitFetch preserves previous data on error', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     // First successful fetch
     const result1 = env.apiStore.awaitFetch();
@@ -318,6 +320,8 @@ describe('awaitFetch edge cases', () => {
 describe('awaitFetch timing', () => {
   test('awaitFetch waits for coalescing window before starting fetch', async () => {
     const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
       baseCoalescingWindowMs: 50,
     });
 
@@ -338,7 +342,10 @@ describe('awaitFetch timing', () => {
   });
 
   test('awaitFetch resolves only after fetch completes', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
     env.setNextFetchDurations(500);
 
     let resolved = false;
@@ -363,7 +370,10 @@ describe('awaitFetch timing', () => {
   });
 
   test('awaitFetch waits for scheduled fetch after mutation completes', async () => {
-    const env = createDocumentStoreTestEnv(0);
+    const env = createDocumentStoreTestEnv(0, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     const mutationPromise = env.performClientUpdateAction(1, {
       duration: 1200,
@@ -394,6 +404,8 @@ describe('awaitFetch timing', () => {
 
   test('three awaitFetch calls triggered outside each coalescing window coalesce during ongoing fetch', async () => {
     const env = createDocumentStoreTestEnv(1, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
       baseCoalescingWindowMs: 50,
     });
 
@@ -452,7 +464,10 @@ describe('awaitFetch timing', () => {
 
 describe('awaitFetch timeout', () => {
   test('awaitFetch times out after default 30 seconds', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
     // Set a very long fetch duration
     env.setNextFetchDurations(60_000);
 
@@ -471,7 +486,10 @@ describe('awaitFetch timeout', () => {
   });
 
   test('awaitFetch times out after custom timeout', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
     // Set a fetch duration longer than custom timeout
     env.setNextFetchDurations(10_000);
 
@@ -489,7 +507,10 @@ describe('awaitFetch timeout', () => {
   });
 
   test('awaitFetch completes before timeout returns data', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
     env.setNextFetchDurations(100);
 
     const resultPromise = env.apiStore.awaitFetch({ timeoutMs: 5_000 });
@@ -506,7 +527,10 @@ describe('awaitFetch timeout', () => {
   });
 
   test('awaitFetch with zero timeout times out immediately', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
 
     const resultPromise = env.apiStore.awaitFetch({ timeoutMs: 0 });
 
@@ -522,7 +546,10 @@ describe('awaitFetch timeout', () => {
   });
 
   test('multiple awaitFetch calls with different timeouts', async () => {
-    const env = createDocumentStoreTestEnv(42);
+    const env = createDocumentStoreTestEnv(42, {
+      testScenario: 'loaded',
+      usesRealTimeUpdates: true,
+    });
     env.setNextFetchDurations(3_000);
 
     // First call with short timeout - should timeout

--- a/tests/request-schedulling/document-base-coalescing.test.ts
+++ b/tests/request-schedulling/document-base-coalescing.test.ts
@@ -1,29 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, expect, test, vi } from 'vitest';
-import {
-  createDocumentStoreTestEnv as createDocumentStoreTestEnvBase,
-  type DocumentStoreTestEnvOptions,
-} from '../mocks/documentStoreTestEnv';
-
-function createDocumentStoreTestEnv<D>(
-  serverInitialData: D,
-  options: DocumentStoreTestEnvOptions<D> = {},
-) {
-  const resolvedInitialStateData =
-    options.initialStateData === undefined ?
-      'sameAsServer'
-    : options.initialStateData;
-  const resolvedDisableInitialInvalidation =
-    options.disableInitialInvalidation === undefined ?
-      true
-    : options.disableInitialInvalidation;
-
-  return createDocumentStoreTestEnvBase(serverInitialData, {
-    initialStateData: resolvedInitialStateData,
-    disableInitialInvalidation: resolvedDisableInitialInvalidation,
-    ...options,
-  });
-}
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -36,6 +13,8 @@ afterEach(() => {
 test('multiple high priority fetches within the same request base coalescing window', async () => {
   // Expected: high priority requests coalesce into a single fetch if triggered within high base request delay window.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
   });
 
@@ -74,6 +53,8 @@ test('multiple high priority fetches within the same request base coalescing win
 test('mixed priority fetches within the same request base coalescing window', async () => {
   // Expected: highPriority and lowPriority requests coalesce into a single fetch if triggered within base coalescing window.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
   });
 
@@ -119,6 +100,8 @@ test('mixed priority fetches within the same request base coalescing window', as
 test('multiple low priority fetches within the same request base coalescing window', async () => {
   // Expected: low priority requests coalesce into a single fetch if triggered within base coalescing window.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
   });
 
@@ -164,6 +147,8 @@ test('multiple low priority fetches within the same request base coalescing wind
 test('realtime update fetches mixed with other priority fetches within the same request base coalescing window', async () => {
   // Expected: realtime update fetches also coalesce into a single fetch if triggered within a base coalescing window.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
     dynamicRealtimeThrottleMs: () => 2_000,
   });
@@ -200,6 +185,8 @@ test('realtime update fetches mixed with other priority fetches within the same 
 test('realtime updates starts coalescing window', async () => {
   // Expected: realtime update fetches start a coalescing window if triggered within a base coalescing window.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
     dynamicRealtimeThrottleMs: () => 2_000,
   });
@@ -236,6 +223,8 @@ test('realtime updates starts coalescing window', async () => {
 test('delayed realtime update fetches also are coalesced', async () => {
   // Expected: delayed realtime update requests are also coalesced into a single fetch
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
     dynamicRealtimeThrottleMs: () => 2_000,
   });
@@ -280,6 +269,8 @@ test('delayed realtime update fetches also are coalesced', async () => {
 test('delayed realtime update request also starts coalescing window', async () => {
   // Expected: delayed realtime update requests also start a coalescing window
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
     dynamicRealtimeThrottleMs: () => 2_000,
   });
@@ -324,6 +315,8 @@ test('delayed realtime update request also starts coalescing window', async () =
 test('medium priority triggers coalescing window after delay expires', async () => {
   // Expected: medium priority triggers a coalescing window after its delay expires
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
     mediumPriorityDelayMs: 100,
   });
@@ -361,6 +354,8 @@ test('medium priority triggers coalescing window after delay expires', async () 
 test('medium priority is cancelled when fetch starts from active coalescing window', async () => {
   // Expected: medium priority uses delay mechanism but is cancelled when coalescing window's fetch starts
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 50,
     mediumPriorityDelayMs: 100,
   });
@@ -401,6 +396,8 @@ test('medium priority is cancelled when fetch starts from active coalescing wind
 test('mixed medium and high priority fetches within coalescing window', async () => {
   // Expected: medium priority (after delay) and high priority coalesce into single fetch
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 50,
     mediumPriorityDelayMs: 100,
   });
@@ -442,6 +439,8 @@ test('mixed medium and high priority fetches within coalescing window', async ()
 test('medium priority with short delay is cancelled by fetch from coalescing window', async () => {
   // Expected: medium priority with short delay is cancelled when coalescing window fetch starts
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
     mediumPriorityDelayMs: 100,
   });

--- a/tests/request-schedulling/document-fetch-orchestration.test.ts
+++ b/tests/request-schedulling/document-fetch-orchestration.test.ts
@@ -1,26 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import {
-  createDocumentStoreTestEnv as createDocumentStoreTestEnvBase,
-  type DocumentStoreTestEnvOptions,
-} from '../mocks/documentStoreTestEnv';
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
 import {
   DEFAULT_FETCH_DURATION_MS,
   DEFAULT_MUTATION_DURATION_MS,
 } from '../mocks/serverMock';
-
-function createDocumentStoreTestEnv<D>(
-  serverInitialData: D,
-  {
-    initialStateData = 'sameAsServer',
-    disableInitialInvalidation = true,
-  }: DocumentStoreTestEnvOptions<D> = {},
-) {
-  return createDocumentStoreTestEnvBase(serverInitialData, {
-    initialStateData,
-    disableInitialInvalidation,
-  });
-}
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -35,7 +19,7 @@ afterEach(() => {
 });
 
 test('simple mutation with revalidation and optimistic update', async () => {
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -69,7 +53,7 @@ test('simple mutation with revalidation and optimistic update', async () => {
 });
 
 test('simple mutation with optimistic update', async () => {
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -98,7 +82,7 @@ test('simple mutation with optimistic update', async () => {
 });
 
 test('simple mutation without optimistic update', async () => {
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -129,7 +113,7 @@ test('simple mutation without optimistic update', async () => {
 });
 
 test('prevent overfetch of low priority fetches', async () => {
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -172,7 +156,7 @@ test('prevent overfetch of low priority fetches', async () => {
 });
 
 test('multiple mutations with revalidation in sequence', async () => {
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -218,7 +202,7 @@ test('multiple mutations with revalidation in sequence', async () => {
 
 test('multiple mutations with revalidation in sequence, causing concurrent updates', async () => {
   // mutations should abort in progress fetches
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -273,7 +257,7 @@ test('multiple mutations with revalidation in sequence, causing concurrent updat
 
 test('multiple mutations with revalidation in sequence 2', async () => {
   // mutations should abort in progress fetches, stress test
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -375,7 +359,7 @@ test('multiple mutations with revalidation in sequence 2', async () => {
 
 test('multiple mutations with revalidation in sequence 3', async () => {
   // mutations should abort in progress fetches, no initial low priority fetch
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -459,7 +443,7 @@ test('multiple mutations with revalidation in sequence 3', async () => {
 test('high priority fetch during mutation', async () => {
   // Expected: high priority fetch triggered during mutation should be scheduled
   // to run after the mutation completes, preventing stale data commits.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -502,7 +486,7 @@ test('high priority fetch during mutation', async () => {
 test('multiple concurrent mutations with revalidation', async () => {
   // Expected: overlapping mutations schedule a single revalidation fetch that
   // skips redundant requests and commits only once with the latest data.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -552,7 +536,7 @@ test('multiple concurrent mutations with revalidation', async () => {
 
 test('multiple high priority fetches', async () => {
   // Expected: high priority requests coalesce into a running fetch plus one scheduled fetch.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -599,7 +583,7 @@ test('multiple high priority fetches', async () => {
 
 test('throttle low priority updates', async () => {
   // Expected: low priority requests are throttled so only the first and last execute.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -650,7 +634,7 @@ test('throttle low priority updates', async () => {
 
 test('throttle low priority after a fast fetch completes', async () => {
   // Expected: low priority throttling uses the fetch start time, even if it finishes quickly.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -693,7 +677,7 @@ test('throttle low priority after a fast fetch completes', async () => {
 test('multiple mutations with low priority fetch between', async () => {
   // Expected: low priority fetch is scheduled and coalesced with mutation revalidation,
   // resulting in a single fetch commit.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -745,7 +729,7 @@ test('very slow mutation revalidation then mutation', async () => {
   // Expected: long revalidation fetch overlaps a second mutation, causing the
   // first fetch to be aborted and a fresh fetch to commit the latest value.
   // First revalidation (2000ms) > second mutation (200ms) + second revalidation (200ms)
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -805,7 +789,8 @@ test('very slow mutation revalidation then mutation', async () => {
 test('fetch error', async () => {
   // Expected: first fetch succeeds, second fetch errors and UI enters error state.
   const env = createDocumentStoreTestEnv(0, {
-    initialStateData: null,
+    testScenario: 'idle',
+    usesRealTimeUpdates: true,
   });
 
   renderHook(() => {
@@ -844,7 +829,7 @@ test('fetch error', async () => {
 test('low priority fetch during mutation outside throttle window', async () => {
   // Expected: low priority fetch triggered during mutation should be scheduled
   // to run after the mutation completes when outside the throttle window.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -887,7 +872,7 @@ test('low priority fetch during mutation outside throttle window', async () => {
 test('low priority fetch during mutation inside throttle window', async () => {
   // Expected: low priority fetch triggered during mutation should be skipped
   // when inside the throttle window from a previous fetch.
-  const env = createDocumentStoreTestEnv(0);
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);

--- a/tests/request-schedulling/document-fetch-orchestration.test.ts
+++ b/tests/request-schedulling/document-fetch-orchestration.test.ts
@@ -5,13 +5,14 @@ import {
   DEFAULT_FETCH_DURATION_MS,
   DEFAULT_MUTATION_DURATION_MS,
 } from '../mocks/serverMock';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
 });
 
 beforeEach(() => {
-  vi.setSystemTime(0);
+  vi.setSystemTime(TEST_INITIAL_TIME);
 });
 
 afterEach(() => {

--- a/tests/request-schedulling/document-medium-priority-fetch.test.ts
+++ b/tests/request-schedulling/document-medium-priority-fetch.test.ts
@@ -1,29 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, expect, test, vi } from 'vitest';
-import {
-  createDocumentStoreTestEnv as createDocumentStoreTestEnvBase,
-  type DocumentStoreTestEnvOptions,
-} from '../mocks/documentStoreTestEnv';
-
-function createDocumentStoreTestEnv<D>(
-  serverInitialData: D,
-  options: DocumentStoreTestEnvOptions<D> = {},
-) {
-  const resolvedInitialStateData =
-    options.initialStateData === undefined ?
-      'sameAsServer'
-    : options.initialStateData;
-  const resolvedDisableInitialInvalidation =
-    options.disableInitialInvalidation === undefined ?
-      true
-    : options.disableInitialInvalidation;
-
-  return createDocumentStoreTestEnvBase(serverInitialData, {
-    initialStateData: resolvedInitialStateData,
-    disableInitialInvalidation: resolvedDisableInitialInvalidation,
-    ...options,
-  });
-}
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -35,6 +12,8 @@ afterEach(() => {
 
 test('medium priority fetch runs after delay when no other fetch occurs', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -64,6 +43,8 @@ test('medium priority fetch runs after delay when no other fetch occurs', async 
 
 test('medium priority fetch is cancelled when high priority fetch starts', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -97,6 +78,8 @@ test('medium priority fetch is cancelled when high priority fetch starts', async
 
 test('medium priority fetch is cancelled when low priority fetch starts', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -132,6 +115,8 @@ test('medium priority is NOT cancelled by mutation - schedules when delay expire
   // Medium priority should only be cancelled by other fetches, not by mutations
   // When the delay expires during a mutation, it should schedule itself like high priority
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -171,6 +156,8 @@ test('medium priority is NOT cancelled by mutation - schedules when delay expire
 
 test('multiple medium priority calls reset the timer', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -207,6 +194,8 @@ test('multiple medium priority calls reset the timer', async () => {
 
 test('medium priority during in-progress fetch schedules when delay expires', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -252,6 +241,8 @@ test('medium priority with long delay runs normally after in-progress fetch comp
   // When medium priority has a delay longer than the in-progress fetch duration,
   // it should run normally via coalescing (not via scheduled state)
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 1000,
   });
 
@@ -295,6 +286,8 @@ test('medium priority with long delay runs normally after in-progress fetch comp
 
 test('medium priority uses coalescing window after delay expires', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
     baseCoalescingWindowMs: 50,
   });
@@ -332,6 +325,8 @@ test('medium priority uses coalescing window after delay expires', async () => {
 
 test('custom delay per call overrides global delay', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
   });
 
@@ -363,6 +358,8 @@ test('custom delay per call overrides global delay', async () => {
 
 test('medium priority during coalescing window is cancelled when fetch starts', async () => {
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     mediumPriorityDelayMs: 300,
     baseCoalescingWindowMs: 50,
   });

--- a/tests/request-schedulling/document-realtime-updates.test.ts
+++ b/tests/request-schedulling/document-realtime-updates.test.ts
@@ -1,29 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import {
-  createDocumentStoreTestEnv as createDocumentStoreTestEnvBase,
-  type DocumentStoreTestEnvOptions,
-} from '../mocks/documentStoreTestEnv';
-
-function createDocumentStoreTestEnv<D>(
-  serverInitialData: D,
-  options: DocumentStoreTestEnvOptions<D> = {},
-) {
-  const resolvedInitialStateData =
-    options.initialStateData === undefined ?
-      'sameAsServer'
-    : options.initialStateData;
-  const resolvedDisableInitialInvalidation =
-    options.disableInitialInvalidation === undefined ?
-      true
-    : options.disableInitialInvalidation;
-
-  return createDocumentStoreTestEnvBase(serverInitialData, {
-    initialStateData: resolvedInitialStateData,
-    disableInitialInvalidation: resolvedDisableInitialInvalidation,
-    ...options,
-  });
-}
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -45,7 +22,7 @@ function dynamicRealtimeThrottleMs(lastDuration: number): number {
 test('dynamically throttle realtime updates', async () => {
   // Expected: slow RTU fetch increases throttle window, causing coalescing of RTUs
   // and eventual commits for the latest updates.
-  const env = createDocumentStoreTestEnv(0, { dynamicRealtimeThrottleMs });
+  const env = createDocumentStoreTestEnv(0, { testScenario: 'loaded', usesRealTimeUpdates: true, dynamicRealtimeThrottleMs });
 
   renderHook(() => {
     env.trackUIChanges(env.apiStore.useDocument().data?.value);
@@ -113,6 +90,8 @@ test('dynamically throttle multiple realtime updates at same time with delay inf
   // Expected: dynamic throttle shortens for recent fetches, allowing two RTU fetches
   // while coalescing multiple RTU signals into the last update.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs(lastFetchDuration: number) {
       return lastFetchDuration < 700 ? 100 : 500;
     },
@@ -184,6 +163,8 @@ test('dynamically throttle multiple realtime updates at same time with delay inf
 test('simple mutation that triggers a RTU', async () => {
   // Expected: mutation triggers RTU fetch after optimistic commit, committing the server state.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs: (lastDuration) =>
       lastDuration > 300 ? 300 : 100,
   });
@@ -236,6 +217,8 @@ test('slow mutation then external RTU while mutation RTU is running', async () =
   // Expected: external RTU schedules another fetch while mutation RTU is in flight,
   // both fetches eventually commit in order.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs: (lastDuration) =>
       lastDuration > 1000 ? 500 : 200,
   });
@@ -316,6 +299,8 @@ test('slow mutation then new mutation while prev mutation RTU is running', async
   // Expected: new mutation aborts in-flight RTU fetch, then schedules a new RTU fetch
   // that commits the latest mutation result.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs: (lastDuration) =>
       lastDuration > 1000 ? 500 : 200,
   });
@@ -395,6 +380,8 @@ test('slow mutation then new mutation while prev mutation is running', async () 
   // Expected: overlapping mutations each trigger RTU scheduling, but only one RTU fetch runs,
   // committing the latest data.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs: (lastDuration) =>
       lastDuration > 1000 ? 500 : 200,
   });
@@ -468,6 +455,8 @@ test('slow mutation then new mutation while prev mutation is running', async () 
 test('rtu mutations without optimistic updates', async () => {
   // Expected: no optimistic UI commits, RTU fetches drive UI updates after server change.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs: (lastDuration) =>
       lastDuration > 1000 ? 500 : 200,
   });
@@ -550,6 +539,8 @@ test('schedule rtu updates then schedule a fetch right before the rtu starts', a
   // Expected: low priority fetch starts before RTU fetch, so RTU is skipped and
   // the low priority fetch commits the server state.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs() {
       return 500;
     },
@@ -618,6 +609,8 @@ test('schedule rtu updates then schedule a fetch right before the rtu starts', a
 test('mutation that triggers multiple rtu updates', async () => {
   // Expected: burst of RTU fetch requests is coalesced into a single scheduled RTU fetch.
   const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
     dynamicRealtimeThrottleMs() {
       return 500;
     },

--- a/tests/request-schedulling/document-realtime-updates.test.ts
+++ b/tests/request-schedulling/document-realtime-updates.test.ts
@@ -1,13 +1,14 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
 });
 
 beforeEach(() => {
-  vi.setSystemTime(0);
+  vi.setSystemTime(TEST_INITIAL_TIME);
 });
 
 afterEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "types": ["vite/client", "vitest/globals"]
   },
   "include": ["src/**/*", "tests/**/*", "types/**/*"],
   "exclude": ["src-old/**/*", "test-old/**/*"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     testTimeout: 5_000,
     environment: 'happy-dom',
     allowOnly: isDev,
+    globals: true,
     setupFiles: ['./vitest.setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Refactor document store to expose an internal test-only config and standardize test environments. Tests were updated to use a unified testScenario/usesRealTimeUpdates API and a fixed TEST_INITIAL_TIME for deterministic timing and RTU behavior.
### Changes

- Add internal '~test' option to createDocumentStore to inject initialData, initialStatus, initialRefetchOnMount, initialError and initialLastFetchStartTime for tests
- Remove legacy public test-related options: getInitialData, disableInitialInvalidation and disableRefetchOnMount from DocumentStoreOptions
- Introduce usesRealTimeUpdates flag to opt a store into realtime WS invalidation and influence refetch-on-mount behavior
- Pass testOptions.initialLastFetchStartTime into the scheduler to make throttling/timing deterministic in tests
- Replace ad-hoc test helpers with createDocumentStoreTestEnv that accepts a new testScenario union ('idle' | 'loaded' | { idleWithLocalCache } | { loadedWithStaleData }) and resolves concrete test options
- Update createDocumentStoreTestEnv to provide '~test' options to the store and to conditionally hook/unhook server WS events when usesRealTimeUpdates is true
- Add TEST_INITIAL_TIME constant and use it in tests (vi.setSystemTime) so timing-based tests are deterministic
- Update numerous tests to use the new testScenario and usesRealTimeUpdates parameters and remove duplicated wrapper helpers and legacy options

### Testing Notes

Run the full test suite (vitest) — focus on document-store-related suites: basic-functionality, hooks, and request-scheduling. Verify the following scenarios: - testScenario 'idle' (no initial data) and 'loaded' (initial data present) behave as before (status/refetchOnMount, awaitFetch/coalescing). - idleWithLocalCache and loadedWithStaleData produce an initial success state with a lowPriority refetchOnMount when applicable. - Real-time updates only trigger when usesRealTimeUpdates is true (WS events should be ignored otherwise). - Timing-sensitive behavior (throttling, coalescing, awaitFetch timeouts) is deterministic thanks to TEST_INITIAL_TIME and initialLastFetchStartTime. If any failures occur, run the failing test with --run and inspect timings/refetchOnMount values to confirm testOptions were applied.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
