### PR TITLE
Coalesce list query requests by max size and loadMore

### DIFF
--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -251,6 +251,14 @@ export function createListQueryStore<
         mediumPriorityDelayMs,
         on: onSchedulerEvent,
         initialLastFetchStartTime,
+        coalescePayload: (existing, incoming) => ({
+          ...incoming,
+          type:
+            existing.type === 'loadMore' || incoming.type === 'loadMore'
+              ? 'loadMore'
+              : 'load',
+          size: Math.max(existing.size, incoming.size),
+        }),
       });
       querySchedulers.set(queryKey, scheduler);
     }

--- a/src/requestScheduler.ts
+++ b/src/requestScheduler.ts
@@ -127,6 +127,9 @@ export type RequestSchedulerOptions<T> = {
   maxBatchSize?: number;
   /** Initial last fetch start time for throttling (e.g., from a query that already loaded this item) */
   initialLastFetchStartTime?: number;
+  /** Coalesce payloads when the same requestId is scheduled multiple times.
+   * Called with (existing, incoming) and should return the merged payload. */
+  coalescePayload?: (existing: T, incoming: T) => T;
 };
 
 export type ScheduleFetchOptions = {
@@ -161,6 +164,9 @@ export class RequestScheduler<T> {
     | undefined;
   private readonly mediumPriorityDelayMs: number | undefined;
   private readonly maxBatchSize: number | undefined;
+  private readonly coalescePayload:
+    | ((existing: T, incoming: T) => T)
+    | undefined;
 
   private state: SchedulerState<T>;
 
@@ -172,6 +178,7 @@ export class RequestScheduler<T> {
     this.dynamicRealtimeThrottleMs = options.dynamicRealtimeThrottleMs;
     this.mediumPriorityDelayMs = options.mediumPriorityDelayMs;
     this.maxBatchSize = options.maxBatchSize;
+    this.coalescePayload = options.coalescePayload;
 
     this.state = this.createInitialState();
 
@@ -215,10 +222,10 @@ export class RequestScheduler<T> {
   get hasPendingFetch(): boolean {
     const { phase, pending } = this.state;
     return (
-      phase.type !== 'idle'
-      || pending.scheduledRequests.size > 0
-      || pending.rtuDelayed !== null
-      || pending.mediumPriorityDelayed !== null
+      phase.type !== 'idle' ||
+      pending.scheduledRequests.size > 0 ||
+      pending.rtuDelayed !== null ||
+      pending.mediumPriorityDelayed !== null
     );
   }
 
@@ -486,7 +493,9 @@ export class RequestScheduler<T> {
     const existing = phase.pendingRequests.get(requestId);
     if (existing) {
       // Update existing request with new payload/priority
-      existing.payload = payload;
+      existing.payload = this.coalescePayload
+        ? this.coalescePayload(existing.payload, payload)
+        : payload;
       existing.priority = priority;
       return 'coalesced';
     }
@@ -519,7 +528,9 @@ export class RequestScheduler<T> {
     const existing = this.state.pending.scheduledRequests.get(requestId);
     if (existing) {
       // Update existing with higher priority if needed
-      existing.payload = payload;
+      existing.payload = this.coalescePayload
+        ? this.coalescePayload(existing.payload, payload)
+        : payload;
       existing.priority = priority;
     } else {
       this.state.pending.scheduledRequests.set(requestId, {
@@ -757,8 +768,8 @@ export class RequestScheduler<T> {
         // If this was an RTU request and dynamic throttle is configured,
         // route through the RTU delay mechanism
         if (
-          request.priority === 'realtimeUpdate'
-          && this.dynamicRealtimeThrottleMs
+          request.priority === 'realtimeUpdate' &&
+          this.dynamicRealtimeThrottleMs
         ) {
           rtuRequestsToFlush.push({ requestId, payload: request.payload });
         } else {
@@ -796,7 +807,16 @@ export class RequestScheduler<T> {
     if (this.state.phase.type === 'coalescing') {
       // Merge scheduled requests into coalescing
       for (const [requestId, request] of requestsToFlush) {
-        this.state.phase.pendingRequests.set(requestId, request);
+        const existing = this.state.phase.pendingRequests.get(requestId);
+        if (existing && this.coalescePayload) {
+          existing.payload = this.coalescePayload(
+            existing.payload,
+            request.payload,
+          );
+          existing.priority = request.priority;
+        } else {
+          this.state.phase.pendingRequests.set(requestId, request);
+        }
       }
       return;
     }
@@ -828,9 +848,9 @@ export class RequestScheduler<T> {
 
     // Skip if fetch/coalescing in progress or scheduled
     if (
-      phase.type === 'fetching'
-      || phase.type === 'coalescing'
-      || pending.scheduledRequests.size > 0
+      phase.type === 'fetching' ||
+      phase.type === 'coalescing' ||
+      pending.scheduledRequests.size > 0
     ) {
       return true;
     }
@@ -895,9 +915,9 @@ export class RequestScheduler<T> {
     const { timing, phase, pending } = this.state;
 
     if (
-      !timing.lastFetchDuration
-      || !timing.lastFetchStartTime
-      || !this.dynamicRealtimeThrottleMs
+      !timing.lastFetchDuration ||
+      !timing.lastFetchStartTime ||
+      !this.dynamicRealtimeThrottleMs
     ) {
       return false;
     }

--- a/tests/mocks/serverTableMock.ts
+++ b/tests/mocks/serverTableMock.ts
@@ -119,6 +119,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     | {
         type: 'list';
         itemIds: string[] | undefined;
+        limit: number | undefined;
         results:
           | Array<{ itemId: string; data: ItemData | 'error' }>
           | 'aborted';
@@ -268,6 +269,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       fetchHistory.push({
         type: 'list',
         itemIds: filterItemIds,
+        limit,
         results: 'aborted',
       });
       if (addAction) {
@@ -283,6 +285,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       fetchHistory.push({
         type: 'list',
         itemIds: filterItemIds,
+        limit,
         results: 'aborted',
       });
       if (addAction) {
@@ -340,6 +343,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     fetchHistory.push({
       type: 'list',
       itemIds: filterItemIds,
+      limit,
       results: resultItems.map(({ itemId, data }) => ({
         itemId,
         data,

--- a/tests/request-schedulling/list-query-size-coalescing.test.ts
+++ b/tests/request-schedulling/list-query-size-coalescing.test.ts
@@ -1,0 +1,366 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import { createListQueryStoreTestEnv } from '../mocks/listQueryStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+beforeEach(() => {
+  vi.setSystemTime(TEST_INITIAL_TIME);
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+});
+
+const serverData = {
+  table1: [
+    { id: 1, name: 'Item 1' },
+    { id: 2, name: 'Item 2' },
+    { id: 3, name: 'Item 3' },
+    { id: 4, name: 'Item 4' },
+    { id: 5, name: 'Item 5' },
+    { id: 6, name: 'Item 6' },
+  ],
+};
+
+describe('query size coalescing', () => {
+  test('same query key with different sizes → max size is used in fetch', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 2,
+    });
+
+    // Schedule same query with size 2
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 2);
+    // Schedule same query with size 5 (larger)
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 5);
+
+    await vi.runAllTimersAsync();
+
+    // The fetch should have used size 5 (the max)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 5
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+          - data: { id: 5, name: 'Item 5' }
+            itemId: 'table1||5'
+        type: 'list'
+    `);
+  });
+
+  test('smaller size scheduled after larger size does not shrink the fetch', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 2,
+    });
+
+    // Schedule with large size first
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 5);
+    // Then schedule with small size
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 2);
+
+    await vi.runAllTimersAsync();
+
+    // The fetch should still use size 5 (the max)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 5
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+          - data: { id: 5, name: 'Item 5' }
+            itemId: 'table1||5'
+        type: 'list'
+    `);
+  });
+
+  test('loadMore + load coalesce for same key → becomes loadMore with max size', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 3,
+    });
+
+    // Do initial fetch to load 3 items with hasMore: true
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+    await vi.runAllTimersAsync();
+
+    const queryAfterInitial = env.apiStore.getQueryState({
+      tableId: 'table1',
+    });
+    expect(queryAfterInitial?.items.length).toBe(3);
+    expect(queryAfterInitial?.hasMore).toBe(true);
+
+    // loadMore adds defaultQuerySize (3) more → total size = 3 + 3 = 6
+    env.apiStore.loadMore({ tableId: 'table1' });
+    // Then a regular load with size 3 → querySize = max(3 items, 3) = 3
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+
+    // Advance past coalescing window to start the second fetch
+    await vi.advanceTimersByTimeAsync(60);
+
+    // 'loadMore' type wins over 'load' in coalescePayload → status is 'loadingMore'
+    const queryDuringFetch = env.apiStore.getQueryState({ tableId: 'table1' });
+    expect(queryDuringFetch?.status).toBe('loadingMore');
+
+    await vi.runAllTimersAsync();
+
+    // Second fetch should use size 6 (max of loadMore's 6, load's 3)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 3
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+        type: 'list'
+      - limit: 6
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+          - data: { id: 5, name: 'Item 5' }
+            itemId: 'table1||5'
+          - data: { id: 6, name: 'Item 6' }
+            itemId: 'table1||6'
+        type: 'list'
+    `);
+
+    const queryAfterCoalesced = env.apiStore.getQueryState({
+      tableId: 'table1',
+    });
+    // 'load' type wins → status was 'refetching' (not 'loadingMore')
+    expect(queryAfterCoalesced?.status).toBe('success');
+    expect(queryAfterCoalesced?.hasMore).toBe(false);
+    expect(queryAfterCoalesced?.items.length).toBe(6);
+  });
+
+  test('staggered arrivals with different sizes within coalescing window → max size is used', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 100,
+      defaultQuerySize: 2,
+    });
+
+    // Three requests at staggered times within the 100ms coalescing window
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 2);
+
+    await vi.advanceTimersByTimeAsync(30);
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 4);
+
+    await vi.advanceTimersByTimeAsync(30);
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+
+    await vi.runAllTimersAsync();
+
+    // The fetch should use size 4 (the max of 2, 4, 3)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 4
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+        type: 'list'
+    `);
+
+    expect(env.serverTable.fetchHistory.length).toBe(1);
+  });
+
+  test('default query size interacts correctly with explicit size', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 3,
+    });
+
+    // Schedule without explicit size → uses defaultQuerySize (3)
+    env.scheduleFetch('highPriority', { tableId: 'table1' });
+    // Schedule with explicit size 5
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 5);
+
+    await vi.runAllTimersAsync();
+
+    // The fetch should use size 5 (max of default 3, explicit 5)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 5
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+          - data: { id: 5, name: 'Item 5' }
+            itemId: 'table1||5'
+        type: 'list'
+    `);
+
+    expect(env.serverTable.fetchHistory.length).toBe(1);
+  });
+
+  test('two identical sizes still work correctly', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 3,
+    });
+
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+
+    await vi.runAllTimersAsync();
+
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 3
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+        type: 'list'
+    `);
+
+    // Only one fetch was made (coalesced)
+    expect(env.serverTable.fetchHistory.length).toBe(1);
+  });
+});
+
+describe('size coalescing in scheduledRequests during active fetch (Call Site 2)', () => {
+  test('requests during ongoing fetch coalesce sizes in scheduledRequests', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 2,
+    });
+
+    // 1. Schedule query with size 3 → starts coalescing window
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+
+    // 2. Advance past coalescing window → fetch starts
+    await vi.advanceTimersByTimeAsync(60);
+
+    // Fetch is now in progress
+    expect(env.serverTable.numOfStartedFetches).toBe(1);
+    expect(env.serverTable.numOfFinishedFetches).toBe(0);
+
+    // 3. While fetch is in progress, schedule same query with size 5 → goes to scheduledRequests
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 5);
+
+    // 4. Schedule same query again with size 2 → coalesces in scheduledRequests via Call Site 2
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 2);
+
+    // 5. Let fetch complete and scheduled requests flush
+    await vi.runAllTimersAsync();
+
+    // Assert: fetchHistory has 2 entries, second with limit: 5 (max of 5, 2)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 3
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+        type: 'list'
+      - limit: 5
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+          - data: { id: 5, name: 'Item 5' }
+            itemId: 'table1||5'
+        type: 'list'
+    `);
+  });
+
+  test('multiple requests during ongoing fetch coalesce to max size then flush', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      baseCoalescingWindowMs: 50,
+      defaultQuerySize: 2,
+    });
+
+    // 1. Schedule query with size 2 → starts coalescing window
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 2);
+
+    // 2. Advance past coalescing window → fetch starts
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(env.serverTable.numOfStartedFetches).toBe(1);
+    expect(env.serverTable.numOfFinishedFetches).toBe(0);
+
+    // 3. While fetch is in progress, schedule 3 requests with different sizes
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 3);
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 6);
+    env.scheduleFetch('highPriority', { tableId: 'table1' }, 4);
+
+    // 4. Let fetch complete and scheduled requests flush
+    await vi.runAllTimersAsync();
+
+    // First fetch used limit 2, second fetch uses limit 6 (max of 3, 6, 4)
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 2
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+        type: 'list'
+      - limit: 6
+        results:
+          - data: { id: 1, name: 'Item 1' }
+            itemId: 'table1||1'
+          - data: { id: 2, name: 'Item 2' }
+            itemId: 'table1||2'
+          - data: { id: 3, name: 'Item 3' }
+            itemId: 'table1||3'
+          - data: { id: 4, name: 'Item 4' }
+            itemId: 'table1||4'
+          - data: { id: 5, name: 'Item 5' }
+            itemId: 'table1||5'
+          - data: { id: 6, name: 'Item 6' }
+            itemId: 'table1||6'
+        type: 'list'
+    `);
+
+    expect(env.serverTable.fetchHistory.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Add configurable payload coalescing to the RequestScheduler and enable list-query-specific merging in the list query store so concurrent requests for the same list use the larger size and treat loadMore as dominant. Includes tests and mock updates to validate coalescing behavior across scheduling scenarios.
### Changes

- Add coalescePayload option to RequestScheduler and use it when merging pending or scheduled requests (src/requestScheduler.ts).
- Pass a list-query-specific coalesce function from createListQueryStore to prefer 'loadMore' and use the maximum requested size (src/listQueryStore/listQueryStore.ts).
- Extend the server table test mock to record/accept a limit field for list fetches (tests/mocks/serverTableMock.ts).
- Add comprehensive tests for size/type coalescing across coalescing windows and during active fetches (tests/request-schedulling/list-query-size-coalescing.test.ts).

### Testing Notes

Run the test suite (vitest) to exercise the new cases; specifically verify that: scheduled requests with differing sizes coalesce into a single fetch using the maximum size; a 'loadMore' and 'load' coalesce into type 'loadMore' and use the max size; staggered arrivals within the coalescing window pick the max size; requests queued while a fetch is in progress coalesce in scheduledRequests and flush as a single max-size fetch. Also check defaultQuerySize interactions and that only one fetch occurs when identical sizes are coalesced.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
