### PR TITLE
Add offset pagination with chunked invalidation and coalescing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,11 @@ Tests use Vitest with `happy-dom` environment. Test files follow the pattern `sr
 - Prefer using vitest fake timers
 - Use `createLoggerStore` util for create a human readable values timelines for snapshot testing
 - Use realistic times to match real usage, use as reference the default fetch durations used in the server mocks
+- Use utility functions from `tests/utils/genericTestUtils.ts` when possible:
+  - `flushAllTimers()`: wraps `vi.runAllTimersAsync()` in `act()` — use instead of calling `vi.runAllTimersAsync()` directly
+  - `advanceTime(ms)`: wraps `vi.advanceTimersByTimeAsync(ms)` in `act()` — use instead of calling `vi.advanceTimersByTimeAsync()` directly
+  - `range(start, end)`: creates an array of numbers from start to end (inclusive)
+  - `pick(obj, keys)`: picks specific keys from an object
 
 ## TypeScript Configuration
 

--- a/src/listQueryStore/createFetchApi.ts
+++ b/src/listQueryStore/createFetchApi.ts
@@ -19,6 +19,7 @@ import { executeItemBatchFetch } from './executeItemBatchFetch';
 import { executeQueryFetch } from './executeQueryFetch';
 import {
   type FieldsInput,
+  type OffsetPaginationConfig,
   type PartialResourcesConfig,
   type QueryFetchPayload,
   type TSFDListQuery,
@@ -41,6 +42,20 @@ type ItemFetchData<ItemPayload extends ValidPayload> = {
   fields?: string[];
 };
 
+export type NormalizedFetchListFn<
+  ItemState extends ValidStoreState,
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+> = (
+  payload: QueryPayload,
+  offset: number,
+  limit: number,
+  options: { signal: AbortSignal; fields?: string[] },
+) => Promise<{
+  items: { itemPayload: ItemPayload; data: ItemState }[];
+  hasMore: boolean;
+}>;
+
 export type CreateFetchApiOptions<
   ItemState extends ValidStoreState,
   QueryPayload extends ValidPayload,
@@ -48,14 +63,12 @@ export type CreateFetchApiOptions<
   TPartialResources extends PartialResourcesConfig<ItemState> | undefined,
 > = {
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>;
-  fetchListFn: (
-    payload: QueryPayload,
-    size: number,
-    options: { signal: AbortSignal; fields?: string[] },
-  ) => Promise<{
-    items: { itemPayload: ItemPayload; data: ItemState }[];
-    hasMore: boolean;
-  }>;
+  normalizedFetchListFn: NormalizedFetchListFn<
+    ItemState,
+    QueryPayload,
+    ItemPayload
+  >;
+  offsetPagination: OffsetPaginationConfig | undefined;
   fetchItemFn?: (
     payload: ItemPayload,
     options: { signal: AbortSignal; fields?: string[] },
@@ -91,7 +104,8 @@ export function createFetchApi<
   TPartialResources extends PartialResourcesConfig<ItemState> | undefined,
 >({
   store,
-  fetchListFn,
+  normalizedFetchListFn,
+  offsetPagination,
   fetchItemFn,
   batchFetchItemFn,
   getItemsBatchKey,
@@ -187,11 +201,12 @@ export function createFetchApi<
             requests,
             fetchCtx,
             store,
-            fetchListFn,
+            normalizedFetchListFn,
             errorNormalizer,
             getItemKey,
             updateItemSchedulerTiming,
             partialResources,
+            offsetPagination,
           );
         },
         lowPriorityThrottleMs,
@@ -200,21 +215,34 @@ export function createFetchApi<
         mediumPriorityDelayMs,
         on: onSchedulerEvent,
         initialLastFetchStartTime,
-        coalescePayload: (existing, incoming) => ({
-          ...incoming,
-          type:
+        coalescePayload: (existing, incoming) => {
+          const minOffset = Math.min(existing.offset, incoming.offset);
+          const maxEnd = Math.max(
+            existing.offset + existing.limit,
+            incoming.offset + incoming.limit,
+          );
+
+          // 'loadMore' wins: in size mode both are full re-fetches so loadMore has bigger size;
+          // in offset mode the combined range already covers the full extent.
+          const coalescedType =
             existing.type === 'loadMore' || incoming.type === 'loadMore'
               ? 'loadMore'
-              : 'load',
-          size: Math.max(existing.size, incoming.size),
-          // Preserve fields requested by all coalesced hooks.
-          fields:
-            !existing.fields || !incoming.fields
-              ? undefined
-              : Array.from(
-                  new Set([...existing.fields, ...incoming.fields]),
-                ).sort(),
-        }),
+              : 'load';
+
+          return {
+            ...incoming,
+            type: coalescedType,
+            offset: minOffset,
+            limit: maxEnd - minOffset,
+            // Preserve fields requested by all coalesced hooks.
+            fields:
+              !existing.fields || !incoming.fields
+                ? undefined
+                : Array.from(
+                    new Set([...existing.fields, ...incoming.fields]),
+                  ).sort(),
+          };
+        },
         usesRealTimeUpdates,
       });
       querySchedulers.set(queryKey, scheduler);
@@ -525,7 +553,8 @@ export function createFetchApi<
         {
           type: 'load',
           payload: param,
-          size: querySize,
+          offset: 0,
+          limit: querySize,
           fields,
         },
         options,
@@ -570,17 +599,27 @@ export function createFetchApi<
       typeof sizeOrOptions === 'number'
         ? sizeOrOptions
         : (sizeOrOptions?.size ?? defaultQuerySize);
-    const newSize = queryState.items.length + loadSize;
+
+    const fetchPayload: QueryFetchPayload<QueryPayload> = offsetPagination
+      ? {
+          type: 'loadMore',
+          payload: params,
+          offset: queryState.items.length,
+          limit: loadSize,
+          fields: fieldsToFetch,
+        }
+      : {
+          type: 'loadMore',
+          payload: params,
+          offset: 0,
+          limit: queryState.items.length + loadSize,
+          fields: fieldsToFetch,
+        };
 
     return getOrCreateQueryScheduler(queryKey).scheduleFetch(
       queryKey,
       'highPriority',
-      {
-        type: 'loadMore',
-        payload: params,
-        size: newSize,
-        fields: fieldsToFetch,
-      },
+      fetchPayload,
     );
   }
 
@@ -618,7 +657,7 @@ export function createFetchApi<
 
     const result = await getOrCreateQueryScheduler(queryKey).awaitFetch(
       queryKey,
-      { type: 'load', payload: params, size, fields },
+      { type: 'load', payload: params, offset: 0, limit: size, fields },
       { timeoutMs: options.timeoutMs },
     );
 

--- a/src/listQueryStore/executeQueryFetch.ts
+++ b/src/listQueryStore/executeQueryFetch.ts
@@ -1,3 +1,4 @@
+import { createAsyncQueue } from '@ls-stack/utils/asyncQueue';
 import { deepEqual } from '@ls-stack/utils/deepEqual';
 import { klona } from 'klona/json';
 import { unknownToError } from 't-result';
@@ -181,8 +182,16 @@ export async function executeQueryFetch<
             });
           }
 
-          const chunkResults = await Promise.all(
-            chunks.map((chunk) =>
+          const queue = createAsyncQueue<
+            FetchListFnReturn<ItemState, ItemPayload>
+          >({
+            concurrency: offsetPagination.maxParallel ?? 3,
+            stopOnError: true,
+            rejectPendingOnError: true,
+          });
+
+          const chunkResultPromises = chunks.map((chunk) =>
+            queue.resultifyAdd(() =>
               normalizedFetchListFn(payload, chunk.offset, chunk.limit, {
                 signal: fetchCtx.signal,
                 fields,
@@ -190,8 +199,11 @@ export async function executeQueryFetch<
             ),
           );
 
-          allItems = chunkResults.flatMap((r) => r.items);
-          const lastChunk = chunkResults[chunkResults.length - 1];
+          const chunkResults = await Promise.all(chunkResultPromises);
+          const successResults = chunkResults.map((r) => r.unwrap());
+
+          allItems = successResults.flatMap((r) => r.items);
+          const lastChunk = successResults[successResults.length - 1];
           hasMore = lastChunk ? lastChunk.hasMore : false;
         } else {
           const result = await normalizedFetchListFn(payload, offset, limit, {

--- a/src/listQueryStore/executeQueryFetch.ts
+++ b/src/listQueryStore/executeQueryFetch.ts
@@ -220,9 +220,11 @@ export async function executeQueryFetch<
           return;
         }
 
-        // In offset mode, loadMore appends to existing items
+        // In offset mode, append only when loadMore range starts after head.
+        // Coalesced loadMore+load can produce type='loadMore' with offset=0,
+        // which must replace the list to avoid stale head items.
         const appendToExisting =
-          !!offsetPagination && fetchPayload.type === 'loadMore';
+          !!offsetPagination && fetchPayload.type === 'loadMore' && offset > 0;
 
         store.produceState(
           (draft) => {

--- a/src/listQueryStore/executeQueryFetch.ts
+++ b/src/listQueryStore/executeQueryFetch.ts
@@ -3,6 +3,7 @@ import { klona } from 'klona/json';
 import { unknownToError } from 't-result';
 import { Store } from 't-state';
 import { BatchRequest, FetchContext } from '../requestScheduler';
+import { NormalizedFetchListFn } from './createFetchApi';
 import { reusePrevIfEqual } from '../utils/reusePrevIfEqual';
 import {
   StoreError,
@@ -11,10 +12,86 @@ import {
 } from '../utils/storeShared';
 import {
   type FetchListFnReturn,
+  type OffsetPaginationConfig,
   type PartialResourcesConfig,
   type QueryFetchPayload,
   type TSFDListQueryState,
 } from './types';
+
+function applyFetchedItems<
+  ItemState extends ValidStoreState,
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+>(
+  draft: TSFDListQueryState<ItemState, QueryPayload, ItemPayload>,
+  queryKey: string,
+  items: FetchListFnReturn<ItemState, ItemPayload>['items'],
+  hasMore: boolean,
+  fields: string[] | undefined,
+  getItemKey: (params: ItemPayload) => string,
+  partialResources: PartialResourcesConfig<ItemState> | undefined,
+  appendToExisting: boolean,
+) {
+  const query = draft.queries[queryKey];
+  if (!query) return;
+
+  query.status = 'success';
+  query.wasLoaded = true;
+  query.hasMore = hasMore;
+
+  if (!appendToExisting) {
+    query.items = [];
+  }
+
+  const existingItemKeys = appendToExisting ? new Set(query.items) : undefined;
+
+  for (const { data, itemPayload } of items) {
+    const itemKey = getItemKey(itemPayload);
+
+    if (partialResources) {
+      const prev = draft.items[itemKey] ?? undefined;
+      const merged = partialResources.mergeItems(prev, data);
+      draft.items[itemKey] = reusePrevIfEqual({
+        current: merged,
+        prev,
+      });
+
+      if (fields && fields.length > 0) {
+        const existingFields = draft.itemLoadedFields[itemKey] ?? [];
+        const fieldSet = new Set([...existingFields, ...fields]);
+        draft.itemLoadedFields[itemKey] = Array.from(fieldSet).sort();
+      } else {
+        draft.itemLoadedFields[itemKey] = Object.keys(merged).sort();
+      }
+    } else {
+      draft.items[itemKey] = reusePrevIfEqual({
+        current: data,
+        prev: draft.items[itemKey] ?? undefined,
+      });
+    }
+
+    // Deduplicate: skip items already in the list when appending
+    if (!existingItemKeys || !existingItemKeys.has(itemKey)) {
+      query.items.push(itemKey);
+      existingItemKeys?.add(itemKey);
+    }
+
+    const itemQuery = draft.itemQueries[itemKey];
+
+    if (
+      !itemQuery ||
+      (itemQuery.status !== 'loading' && itemQuery.status !== 'refetching')
+    ) {
+      draft.itemQueries[itemKey] = {
+        error: null,
+        refetchOnMount: false,
+        status: 'success',
+        wasLoaded: true,
+        payload: itemPayload,
+      };
+    }
+  }
+}
 
 export async function executeQueryFetch<
   ItemState extends ValidStoreState,
@@ -24,15 +101,16 @@ export async function executeQueryFetch<
   requests: BatchRequest<QueryFetchPayload<QueryPayload>>[],
   fetchCtx: FetchContext,
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
-  fetchListFn: (
-    payload: QueryPayload,
-    size: number,
-    options: { signal: AbortSignal; fields?: string[] },
-  ) => Promise<FetchListFnReturn<ItemState, ItemPayload>>,
+  normalizedFetchListFn: NormalizedFetchListFn<
+    ItemState,
+    QueryPayload,
+    ItemPayload
+  >,
   errorNormalizer: (exception: Error) => StoreError,
   getItemKey: (params: ItemPayload) => string,
   updateItemSchedulerTiming: (itemKey: string, startTime: number) => void,
   partialResources?: PartialResourcesConfig<ItemState>,
+  offsetPagination?: OffsetPaginationConfig,
 ): Promise<Map<string, boolean>> {
   const results = new Map<string, boolean>();
 
@@ -75,77 +153,81 @@ export async function executeQueryFetch<
 
   const fetchPromises = requests.map(
     async ({ requestId: queryKey, payload: fetchPayload }) => {
-      const { payload, size, fields } = fetchPayload;
+      const { payload, offset, limit, fields } = fetchPayload;
 
       try {
-        const { items, hasMore } = await fetchListFn(payload, size, {
-          signal: fetchCtx.signal,
-          fields,
-        });
+        // Determine if we need chunked invalidation (offset mode, load type, limit > maxInvalidationLimit)
+        const useChunkedInvalidation =
+          offsetPagination &&
+          fetchPayload.type === 'load' &&
+          limit > offsetPagination.maxInvalidationLimit;
+
+        let allItems: FetchListFnReturn<ItemState, ItemPayload>['items'];
+        let hasMore: boolean;
+
+        if (useChunkedInvalidation) {
+          // Split into multiple parallel chunk requests
+          const maxChunkLimit = offsetPagination.maxInvalidationLimit;
+          const chunks: { offset: number; limit: number }[] = [];
+          for (
+            let chunkOffset = offset;
+            chunkOffset < offset + limit;
+            chunkOffset += maxChunkLimit
+          ) {
+            chunks.push({
+              offset: chunkOffset,
+              limit: Math.min(maxChunkLimit, offset + limit - chunkOffset),
+            });
+          }
+
+          const chunkResults = await Promise.all(
+            chunks.map((chunk) =>
+              normalizedFetchListFn(payload, chunk.offset, chunk.limit, {
+                signal: fetchCtx.signal,
+                fields,
+              }),
+            ),
+          );
+
+          allItems = chunkResults.flatMap((r) => r.items);
+          const lastChunk = chunkResults[chunkResults.length - 1];
+          hasMore = lastChunk ? lastChunk.hasMore : false;
+        } else {
+          const result = await normalizedFetchListFn(payload, offset, limit, {
+            signal: fetchCtx.signal,
+            fields,
+          });
+
+          allItems = result.items;
+          hasMore = result.hasMore;
+        }
 
         if (fetchCtx.shouldAbort()) {
           results.set(queryKey, false);
           return;
         }
 
+        // In offset mode, loadMore appends to existing items
+        const appendToExisting =
+          !!offsetPagination && fetchPayload.type === 'loadMore';
+
         store.produceState(
           (draft) => {
-            const query = draft.queries[queryKey];
-            if (!query) return;
-
-            query.status = 'success';
-            query.wasLoaded = true;
-            query.hasMore = hasMore;
-            query.items = [];
-
-            for (const { data, itemPayload } of items) {
-              const itemKey = getItemKey(itemPayload);
-
-              if (partialResources) {
-                const prev = draft.items[itemKey] ?? undefined;
-                const merged = partialResources.mergeItems(prev, data);
-                draft.items[itemKey] = reusePrevIfEqual({
-                  current: merged,
-                  prev,
-                });
-
-                if (fields && fields.length > 0) {
-                  const existingFields = draft.itemLoadedFields[itemKey] ?? [];
-                  const fieldSet = new Set([...existingFields, ...fields]);
-                  draft.itemLoadedFields[itemKey] = Array.from(fieldSet).sort();
-                } else {
-                  draft.itemLoadedFields[itemKey] = Object.keys(merged).sort();
-                }
-              } else {
-                draft.items[itemKey] = reusePrevIfEqual({
-                  current: data,
-                  prev: draft.items[itemKey] ?? undefined,
-                });
-              }
-
-              query.items.push(itemKey);
-
-              const itemQuery = draft.itemQueries[itemKey];
-
-              if (
-                !itemQuery ||
-                (itemQuery.status !== 'loading' &&
-                  itemQuery.status !== 'refetching')
-              ) {
-                draft.itemQueries[itemKey] = {
-                  error: null,
-                  refetchOnMount: false,
-                  status: 'success',
-                  wasLoaded: true,
-                  payload: itemPayload,
-                };
-              }
-            }
+            applyFetchedItems(
+              draft,
+              queryKey,
+              allItems,
+              hasMore,
+              fields,
+              getItemKey,
+              partialResources,
+              appendToExisting,
+            );
           },
           { action: 'query-fetch-success' },
         );
 
-        for (const { itemPayload } of items) {
+        for (const { itemPayload } of allItems) {
           updateItemSchedulerTiming(
             getItemKey(itemPayload),
             fetchCtx.getStartTime(),

--- a/src/listQueryStore/executeQueryFetch.ts
+++ b/src/listQueryStore/executeQueryFetch.ts
@@ -43,7 +43,7 @@ function applyFetchedItems<
     query.items = [];
   }
 
-  const existingItemKeys = appendToExisting ? new Set(query.items) : undefined;
+  const existingItemKeys = new Set(query.items);
 
   for (const { data, itemPayload } of items) {
     const itemKey = getItemKey(itemPayload);
@@ -70,10 +70,11 @@ function applyFetchedItems<
       });
     }
 
-    // Deduplicate: skip items already in the list when appending
-    if (!existingItemKeys || !existingItemKeys.has(itemKey)) {
+    // Deduplicate: skip items already in the list (handles both append
+    // and chunked invalidation where parallel chunks may return overlapping items)
+    if (!existingItemKeys.has(itemKey)) {
       query.items.push(itemKey);
-      existingItemKeys?.add(itemKey);
+      existingItemKeys.add(itemKey);
     }
 
     const itemQuery = draft.itemQueries[itemKey];

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -23,6 +23,7 @@ import {
   type ListQueryStoreInitialData,
   type ListQueryUseMultipleItemsQuery,
   type ListQueryUseMultipleListQueriesQuery,
+  type OffsetPaginationConfig,
   type OnListQueryInvalidate,
   type OnListQueryItemInvalidate,
   type OptimisticListUpdate,
@@ -61,12 +62,14 @@ export type ListQueryStore<
   ItemPayload extends ValidPayload,
   TPartialResources extends PartialResourcesConfig<ItemState> | undefined =
     undefined,
+  TOffsetPagination extends OffsetPaginationConfig | undefined = undefined,
 > = ReturnType<
   typeof createListQueryStore<
     ItemState,
     QueryPayload,
     ItemPayload,
-    TPartialResources
+    TPartialResources,
+    TOffsetPagination
   >
 >;
 
@@ -74,7 +77,27 @@ const noFetchItemFnError = 'No fetchItemFn was provided';
 const noPartialResourcesFieldsOptionError =
   'fields option is required when partialResources is enabled';
 
-export type ListQueryStoreOptions<
+type FetchListFnSizeMode<
+  ItemState extends ValidStoreState,
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+> = (
+  payload: QueryPayload,
+  size: number,
+  options: { signal: AbortSignal; fields?: string[] },
+) => Promise<FetchListFnReturn<ItemState, ItemPayload>>;
+
+type FetchListFnOffsetMode<
+  ItemState extends ValidStoreState,
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+> = (
+  payload: QueryPayload,
+  pagination: { offset: number; limit: number },
+  options: { signal: AbortSignal; fields?: string[] },
+) => Promise<FetchListFnReturn<ItemState, ItemPayload>>;
+
+type ListQueryStoreOptionsBase<
   ItemState extends ValidStoreState,
   QueryPayload extends ValidPayload,
   ItemPayload extends ValidPayload,
@@ -82,11 +105,6 @@ export type ListQueryStoreOptions<
     undefined,
 > = {
   debugName?: string;
-  fetchListFn: (
-    payload: QueryPayload,
-    size: number,
-    options: { signal: AbortSignal; fields?: string[] },
-  ) => Promise<FetchListFnReturn<ItemState, ItemPayload>>;
   fetchItemFn?: (
     payload: ItemPayload,
     options: { signal: AbortSignal; fields?: string[] },
@@ -130,12 +148,40 @@ export type ListQueryStoreOptions<
   partialResources?: TPartialResources;
 };
 
+export type ListQueryStoreOptions<
+  ItemState extends ValidStoreState,
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+  TPartialResources extends PartialResourcesConfig<ItemState> | undefined =
+    undefined,
+  TOffsetPagination extends OffsetPaginationConfig | undefined = undefined,
+> = ListQueryStoreOptionsBase<
+  ItemState,
+  QueryPayload,
+  ItemPayload,
+  TPartialResources
+> &
+  ([TOffsetPagination] extends [undefined]
+    ? {
+        fetchListFn: FetchListFnSizeMode<ItemState, QueryPayload, ItemPayload>;
+        offsetPagination?: undefined;
+      }
+    : {
+        fetchListFn: FetchListFnOffsetMode<
+          ItemState,
+          QueryPayload,
+          ItemPayload
+        >;
+        offsetPagination: TOffsetPagination;
+      });
+
 export function createListQueryStore<
   ItemState extends ValidStoreState,
   QueryPayload extends ValidPayload,
   ItemPayload extends ValidPayload,
   TPartialResources extends PartialResourcesConfig<ItemState> | undefined =
     undefined,
+  TOffsetPagination extends OffsetPaginationConfig | undefined = undefined,
 >({
   debugName,
   fetchListFn,
@@ -159,13 +205,41 @@ export function createListQueryStore<
   getQueryKey: customGetQueryKey,
   getItemKey: customGetItemKey,
   partialResources,
+  ...rest
 }: ListQueryStoreOptions<
   ItemState,
   QueryPayload,
   ItemPayload,
-  TPartialResources
+  TPartialResources,
+  TOffsetPagination
 >) {
   type HasPR = [TPartialResources] extends [undefined] ? false : true;
+
+  const offsetPagination: OffsetPaginationConfig | undefined =
+    'offsetPagination' in rest ? rest.offsetPagination : undefined;
+
+  // Normalize fetchListFn to internal form: (payload, offset, limit, options) => Promise<...>
+  // We use __LEGIT_CAST__ because the conditional union type of fetchListFn
+  // (size mode vs offset mode) cannot be narrowed via 'offsetPagination' at runtime —
+  // TypeScript sees the union but the runtime check is on a separate option.
+  const fetchListFnAsUnknown =
+    __LEGIT_CAST__<
+      (...args: unknown[]) => Promise<FetchListFnReturn<ItemState, ItemPayload>>
+    >(fetchListFn);
+
+  const normalizedFetchListFn = offsetPagination
+    ? (
+        payload: QueryPayload,
+        offset: number,
+        limit: number,
+        options: { signal: AbortSignal; fields?: string[] },
+      ) => fetchListFnAsUnknown(payload, { offset, limit }, options)
+    : (
+        payload: QueryPayload,
+        _offset: number,
+        limit: number,
+        options: { signal: AbortSignal; fields?: string[] },
+      ) => fetchListFnAsUnknown(payload, limit, options);
   type State = TSFDListQueryState<ItemState, QueryPayload, ItemPayload>;
   type FetchFieldsOption = HasPR extends true
     ? { fields: FieldsInput }
@@ -356,7 +430,8 @@ export function createListQueryStore<
     resetSchedulers,
   } = createFetchApi<ItemState, QueryPayload, ItemPayload, TPartialResources>({
     store,
-    fetchListFn,
+    normalizedFetchListFn,
+    offsetPagination,
     fetchItemFn,
     batchFetchItemFn,
     getItemsBatchKey,

--- a/src/listQueryStore/types.ts
+++ b/src/listQueryStore/types.ts
@@ -170,6 +170,8 @@ export type QueryFetchPayload<QueryPayload extends ValidPayload> = {
 
 export type OffsetPaginationConfig = {
   maxInvalidationLimit: number;
+  /** Max parallel chunk requests during chunked invalidation (default: 3) */
+  maxParallel?: number;
 };
 
 export type PartialResourcesConfig<ItemState extends ValidStoreState> = {

--- a/src/listQueryStore/types.ts
+++ b/src/listQueryStore/types.ts
@@ -163,8 +163,13 @@ export type OptimisticListUpdate<
 export type QueryFetchPayload<QueryPayload extends ValidPayload> = {
   type: 'load' | 'loadMore';
   payload: QueryPayload;
-  size: number;
+  offset: number;
+  limit: number;
   fields?: string[];
+};
+
+export type OffsetPaginationConfig = {
+  maxInvalidationLimit: number;
 };
 
 export type PartialResourcesConfig<ItemState extends ValidStoreState> = {

--- a/tests/hooks/list-query-hooks-2.test.tsx
+++ b/tests/hooks/list-query-hooks-2.test.tsx
@@ -313,6 +313,7 @@ test('load a query and a few ms after load a item with different data', async ()
 
   expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
     - limit: 50
+      offset: 0
       results:
         - data: { id: 1, name: 'User 1' }
           itemId: 'users||1'
@@ -399,6 +400,7 @@ test('load a item and a few ms after load a query with different data', async ()
       result: { id: 1, name: 'User 1' }
       type: 'fetch'
     - limit: 50
+      offset: 0
       results:
         - data: { id: 1, name: 'User 1 changed' }
           itemId: 'users||1'

--- a/tests/hooks/list-query-hooks-2.test.tsx
+++ b/tests/hooks/list-query-hooks-2.test.tsx
@@ -312,7 +312,8 @@ test('load a query and a few ms after load a item with different data', async ()
   `);
 
   expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-    - limit: 50
+    - duration: 800
+      limit: 50
       offset: 0
       results:
         - data: { id: 1, name: 'User 1' }
@@ -325,9 +326,12 @@ test('load a query and a few ms after load a item with different data', async ()
           itemId: 'users||4'
         - data: { id: 5, name: 'User 5' }
           itemId: 'users||5'
+      startedAt: 10
       type: 'list'
-    - itemId: 'users||1'
+    - duration: 800
+      itemId: 'users||1'
       result: { id: 1, name: 'User 1 changed' }
+      startedAt: 1010
       type: 'fetch'
   `);
 
@@ -396,10 +400,13 @@ test('load a item and a few ms after load a query with different data', async ()
   `);
 
   expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-    - itemId: 'users||1'
+    - duration: 800
+      itemId: 'users||1'
       result: { id: 1, name: 'User 1' }
+      startedAt: 10
       type: 'fetch'
-    - limit: 50
+    - duration: 800
+      limit: 50
       offset: 0
       results:
         - data: { id: 1, name: 'User 1 changed' }
@@ -412,6 +419,7 @@ test('load a item and a few ms after load a query with different data', async ()
           itemId: 'users||4'
         - data: { id: 5, name: 'User 5' }
           itemId: 'users||5'
+      startedAt: 1010
       type: 'list'
   `);
 

--- a/tests/list-query-features/list-query-offset-pagination.test.ts
+++ b/tests/list-query-features/list-query-offset-pagination.test.ts
@@ -242,6 +242,37 @@ describe('offset pagination - basic loadMore', () => {
       - '"products||6'
       - '"products||7'
     `);
+
+    expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+      - limit: 5
+        offset: 0
+        results:
+          - data: { id: 1, name: 'Product 1' }
+            itemId: 'products||1'
+          - data: { id: 2, name: 'Product 2' }
+            itemId: 'products||2'
+          - data: { id: 3, name: 'Product 3' }
+            itemId: 'products||3'
+          - data: { id: 4, name: 'Product 4' }
+            itemId: 'products||4'
+          - data: { id: 5, name: 'Product 5' }
+            itemId: 'products||5'
+        type: 'list'
+      - limit: 5
+        offset: 5
+        results:
+          - data: { id: 3, name: 'Product 3' }
+            itemId: 'products||3'
+          - data: { id: 4, name: 'Product 4' }
+            itemId: 'products||4'
+          - data: { id: 5, name: 'Product 5' }
+            itemId: 'products||5'
+          - data: { id: 6, name: 'Product 6' }
+            itemId: 'products||6'
+          - data: { id: 7, name: 'Product 7' }
+            itemId: 'products||7'
+        type: 'list'
+    `);
   });
 
   test('loadMore shows loadingMore status', async () => {
@@ -688,6 +719,73 @@ describe('offset pagination - chunked invalidation', () => {
       status: 'error'
       wasLoaded: '✅'
     `);
+  });
+
+  test('chunked invalidation deduplicates items when data shifts between chunks', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load 10 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
+    ).toBe(10);
+
+    // Queue start delays: chunk 1 (offset 0) gets no delay, chunk 2 (offset 5)
+    // gets a 500ms delay. This creates a window between chunk completions where
+    // we can mutate server data to simulate items shifting.
+    env.serverTable.addListFetchStartDelay(0);
+    env.serverTable.addListFetchStartDelay(500);
+
+    // Trigger chunked invalidation (10 items / max 5 = 2 chunks)
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+
+    // Advance past coalescing window (15ms) + chunk 1 completion (800ms)
+    await vi.advanceTimersByTimeAsync(815);
+
+    // Chunk 1 (offset 0, limit 5) already resolved with original data: [1,2,3,4,5]
+    // Now prepend a new item, shifting all items right by 1 position
+    env.serverTable.setItem(
+      'products||99',
+      { id: 99, name: 'New Item' },
+      { prepend: true },
+    );
+
+    // Server order is now: [99, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]
+    // Chunk 2 (offset 5, limit 5) will read positions 5-9 = [5, 6, 7, 8, 9]
+    // Item 5 overlaps with chunk 1!
+
+    // Advance past chunk 2 completion (500ms delay + 800ms fetch = 1300ms total)
+    await vi.advanceTimersByTimeAsync(500);
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+
+    // Items should be deduplicated — item 5 appears only once
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+    `);
+    expect(query?.status).toBe('success');
   });
 });
 

--- a/tests/list-query-features/list-query-offset-pagination.test.ts
+++ b/tests/list-query-features/list-query-offset-pagination.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'vitest';
 import { createListQueryStoreTestEnv } from '../mocks/listQueryStoreTestEnv';
 import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
-import { flushAllTimers, range } from '../utils/genericTestUtils';
+import { advanceTime, flushAllTimers, range } from '../utils/genericTestUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -76,7 +76,8 @@ describe('offset pagination - basic loadMore', () => {
       (h) => h.type === 'list',
     );
     expect(listFetches).toMatchInlineSnapshot(`
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { id: 1, name: 'Product 1' }
@@ -89,8 +90,10 @@ describe('offset pagination - basic loadMore', () => {
             itemId: 'products||4'
           - data: { id: 5, name: 'Product 5' }
             itemId: 'products||5'
+        startedAt: 10
         type: 'list'
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 5
         results:
           - data: { id: 6, name: 'Product 6' }
@@ -103,6 +106,7 @@ describe('offset pagination - basic loadMore', () => {
             itemId: 'products||9'
           - data: { id: 10, name: 'Product 10' }
             itemId: 'products||10'
+        startedAt: 820
         type: 'list'
     `);
   });
@@ -244,7 +248,8 @@ describe('offset pagination - basic loadMore', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { id: 1, name: 'Product 1' }
@@ -257,8 +262,10 @@ describe('offset pagination - basic loadMore', () => {
             itemId: 'products||4'
           - data: { id: 5, name: 'Product 5' }
             itemId: 'products||5'
+        startedAt: 10
         type: 'list'
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 5
         results:
           - data: { id: 3, name: 'Product 3' }
@@ -271,6 +278,7 @@ describe('offset pagination - basic loadMore', () => {
             itemId: 'products||6'
           - data: { id: 7, name: 'Product 7' }
             itemId: 'products||7'
+        startedAt: 820
         type: 'list'
     `);
   });
@@ -594,26 +602,30 @@ describe('offset pagination - chunked invalidation', () => {
         - '"products||15'
       `);
 
-    // Store fetch counts before invalidation
-    const startedBefore = env.serverTable.numOfStartedFetches;
-    const finishedBefore = env.serverTable.numOfFinishedFetches;
+    env.serverTable.fetchHistory.length = 0;
 
     // Trigger chunked invalidation (15 items / maxInvalidationLimit 5 = 3 chunks)
     env.apiStore.scheduleListQueryFetch('highPriority', {
       tableId: 'products',
     });
-
-    // Advance past coalescing window to start the fetch
-    await vi.advanceTimersByTimeAsync(15);
-
-    // All 3 chunks should have started in parallel (none finished yet)
-    expect(env.serverTable.numOfStartedFetches - startedBefore).toBe(3);
-    expect(env.serverTable.numOfFinishedFetches - finishedBefore).toBe(0);
-
     await flushAllTimers();
 
-    // All 3 chunks should be complete
-    expect(env.serverTable.numOfFinishedFetches - finishedBefore).toBe(3);
+    // All 3 chunks started at the same time (parallel) with default maxParallel: 3
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(
+      listFetches.map(({ offset, limit, startedAt, duration }) => ({
+        offset,
+        limit,
+        startedAt,
+        duration,
+      })),
+    ).toMatchInlineSnapshot(`
+      - { duration: 800, limit: 5, offset: 0, startedAt: 2440 }
+      - { duration: 800, limit: 5, offset: 5, startedAt: 2440 }
+      - { duration: 800, limit: 5, offset: 10, startedAt: 2440 }
+    `);
   });
 
   test('chunked invalidation preserves deterministic item ordering', async () => {
@@ -786,6 +798,119 @@ describe('offset pagination - chunked invalidation', () => {
       - '"products||9'
     `);
     expect(query?.status).toBe('success');
+  });
+
+  test('maxParallel limits concurrent chunk requests', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5, maxParallel: 2 },
+    });
+
+    // Load 15 items (3 loadMores)
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
+    ).toBe(15);
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Trigger chunked invalidation (15 items / maxInvalidationLimit 5 = 3 chunks)
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    // With maxParallel: 2, chunks 1 & 2 start together, chunk 3 starts after they finish
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(
+      listFetches.map(({ offset, limit, startedAt, duration }) => ({
+        offset,
+        limit,
+        startedAt,
+        duration,
+      })),
+    ).toMatchInlineSnapshot(`
+      - { duration: 800, limit: 5, offset: 0, startedAt: 2440 }
+      - { duration: 800, limit: 5, offset: 5, startedAt: 2440 }
+      - { duration: 800, limit: 5, offset: 10, startedAt: 3240 }
+    `);
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+      - '"products||11'
+      - '"products||12'
+      - '"products||13'
+      - '"products||14'
+      - '"products||15'
+    `);
+    expect(query?.status).toBe('success');
+  });
+
+  test('chunk error skips remaining chunks', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5, maxParallel: 1 },
+    });
+
+    // Load 15 items (3 pages)
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
+    ).toBe(15);
+
+    const startedBefore = env.serverTable.numOfStartedFetches;
+
+    // Make the first chunk fail
+    env.serverTable.setNextListFetchError('chunk error');
+
+    // Trigger chunked invalidation (3 chunks, maxParallel: 1 → sequential)
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    // Only 1 chunk should have been started — the remaining 2 were skipped
+    expect(env.serverTable.numOfStartedFetches - startedBefore).toBe(1);
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query?.status).toBe('error');
+    expect(query?.error).toMatchInlineSnapshot(`
+      code: 500
+      id: 'fetch-error'
+      message: 'chunk error'
+    `);
   });
 });
 
@@ -1098,6 +1223,79 @@ describe('offset pagination - awaitListQueryFetch', () => {
           itemPayload: 'products||2'
         - data: { id: 3, name: 'Product 3' }
           itemPayload: 'products||3'
+    `);
+  });
+
+  test('awaitListQueryFetch with chunked requests preserves order when chunks resolve out of order', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Stagger chunk start delays so they finish in reverse order:
+    // Chunk 0 (offset 0, limit 5): 600ms delay + 800ms fetch = finishes at 1400ms
+    // Chunk 1 (offset 5, limit 5): 300ms delay + 800ms fetch = finishes at 1100ms
+    // Chunk 2 (offset 10, limit 5): no delay + 800ms fetch = finishes at 800ms
+    env.serverTable.addListFetchStartDelay(600);
+    env.serverTable.addListFetchStartDelay(300);
+
+    const fetchPromise = env.apiStore.awaitListQueryFetch(
+      { tableId: 'products' },
+      { size: 15 },
+    );
+
+    await flushAllTimers();
+
+    const result = await fetchPromise;
+
+    // fetchHistory records entries at completion time, so the order reflects
+    // the actual completion order (reverse): chunk 2 first, chunk 0 last
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 10 }
+      - { limit: 5, offset: 5 }
+      - { limit: 5, offset: 0 }
+    `);
+
+    // Despite chunks completing in reverse order (10, 5, 0),
+    // the result must have items in the correct sequential order (1..15)
+    expect(result).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - data: { id: 1, name: 'Product 1' }
+          itemPayload: 'products||1'
+        - data: { id: 2, name: 'Product 2' }
+          itemPayload: 'products||2'
+        - data: { id: 3, name: 'Product 3' }
+          itemPayload: 'products||3'
+        - data: { id: 4, name: 'Product 4' }
+          itemPayload: 'products||4'
+        - data: { id: 5, name: 'Product 5' }
+          itemPayload: 'products||5'
+        - data: { id: 6, name: 'Product 6' }
+          itemPayload: 'products||6'
+        - data: { id: 7, name: 'Product 7' }
+          itemPayload: 'products||7'
+        - data: { id: 8, name: 'Product 8' }
+          itemPayload: 'products||8'
+        - data: { id: 9, name: 'Product 9' }
+          itemPayload: 'products||9'
+        - data: { id: 10, name: 'Product 10' }
+          itemPayload: 'products||10'
+        - data: { id: 11, name: 'Product 11' }
+          itemPayload: 'products||11'
+        - data: { id: 12, name: 'Product 12' }
+          itemPayload: 'products||12'
+        - data: { id: 13, name: 'Product 13' }
+          itemPayload: 'products||13'
+        - data: { id: 14, name: 'Product 14' }
+          itemPayload: 'products||14'
+        - data: { id: 15, name: 'Product 15' }
+          itemPayload: 'products||15'
     `);
   });
 

--- a/tests/list-query-features/list-query-offset-pagination.test.ts
+++ b/tests/list-query-features/list-query-offset-pagination.test.ts
@@ -1,0 +1,717 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import { createListQueryStoreTestEnv } from '../mocks/listQueryStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import { flushAllTimers, range } from '../utils/genericTestUtils';
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+beforeEach(() => {
+  vi.setSystemTime(TEST_INITIAL_TIME);
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+});
+
+describe('offset pagination - basic loadMore', () => {
+  const serverData = {
+    products: range(1, 20).map((id) => ({ id, name: `Product ${id}` })),
+  };
+
+  test('loadMore fetches only the new page (not all items from the start)', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    // Initial fetch: offset 0, limit 5
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    const queryAfterInitial = env.apiStore.getQueryState({
+      tableId: 'products',
+    });
+    expect(queryAfterInitial?.items.length).toBe(5);
+    expect(queryAfterInitial?.hasMore).toBe(true);
+
+    // loadMore: should fetch offset 5, limit 5 (only new page)
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    const queryAfterLoadMore = env.apiStore.getQueryState({
+      tableId: 'products',
+    });
+    expect(queryAfterLoadMore?.items.length).toBe(10);
+    expect(queryAfterLoadMore?.hasMore).toBe(true);
+
+    // Verify server received offset-based requests
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches).toMatchInlineSnapshot(`
+      - limit: 5
+        results:
+          - data: { id: 1, name: 'Product 1' }
+            itemId: 'products||1'
+          - data: { id: 2, name: 'Product 2' }
+            itemId: 'products||2'
+          - data: { id: 3, name: 'Product 3' }
+            itemId: 'products||3'
+          - data: { id: 4, name: 'Product 4' }
+            itemId: 'products||4'
+          - data: { id: 5, name: 'Product 5' }
+            itemId: 'products||5'
+        type: 'list'
+      - limit: 5
+        results:
+          - data: { id: 6, name: 'Product 6' }
+            itemId: 'products||6'
+          - data: { id: 7, name: 'Product 7' }
+            itemId: 'products||7'
+          - data: { id: 8, name: 'Product 8' }
+            itemId: 'products||8'
+          - data: { id: 9, name: 'Product 9' }
+            itemId: 'products||9'
+          - data: { id: 10, name: 'Product 10' }
+            itemId: 'products||10'
+        type: 'list'
+    `);
+  });
+
+  test('loadMore appends items without duplicates', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 3,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      3,
+    );
+    await flushAllTimers();
+
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+      payload: { tableId: 'products' }
+      refetchOnMount: '❌'
+      status: 'success'
+      wasLoaded: '✅'
+    `);
+  });
+
+  test('loadMore deduplicates items that shifted between pages', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    // Load first page: items 1-5
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    // Simulate 3 items inserted at the top of the list between page loads.
+    // Reconstruct the server data so 3 new items appear first, shifting
+    // existing items right by 3 positions.
+    const existingEntries = env.serverTable
+      .entries()
+      .filter(([id]) => id.startsWith('products||'));
+    for (const [id] of existingEntries) {
+      env.serverTable.removeItem(id);
+    }
+    // New items at positions 0, 1, 2
+    env.serverTable.setItem('products||21', { id: 21, name: 'New 21' });
+    env.serverTable.setItem('products||22', { id: 22, name: 'New 22' });
+    env.serverTable.setItem('products||23', { id: 23, name: 'New 23' });
+    // Original items now start at position 3
+    for (const [id, data] of existingEntries) {
+      env.serverTable.setItem(id, data);
+    }
+    // Server order: [21, 22, 23, 1, 2, 3, 4, 5, 6, 7, ...]
+    // loadMore (offset 5, limit 5) → positions 5-9 = items 3, 4, 5, 6, 7
+    // Items 3, 4, 5 overlap with page 1
+
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    // 5 from page 1 + 2 new unique (6, 7) — items 3, 4, 5 deduplicated
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+    `);
+  });
+
+  test('loadMore shows loadingMore status', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    env.apiStore.loadMore({ tableId: 'products' });
+
+    // Wait for coalescing window
+    await vi.advanceTimersByTimeAsync(15);
+
+    const queryDuring = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryDuring?.status).toBe('loadingMore');
+
+    await flushAllTimers();
+
+    const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryAfter).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+      payload: { tableId: 'products' }
+      refetchOnMount: '❌'
+      status: 'success'
+      wasLoaded: '✅'
+    `);
+  });
+});
+
+describe('offset pagination - chunked invalidation', () => {
+  const serverData = {
+    products: range(1, 30).map((id) => ({ id, name: `Product ${id}` })),
+  };
+
+  test('invalidation splits into multiple requests when totalLoaded > maxInvalidationLimit', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load initial 5 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    // Load more to have 10 items total
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    // Load more to have 15 items total
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    const queryBefore = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryBefore?.items.length).toBe(15);
+
+    // Reset history to track only invalidation fetches
+    env.serverTable.fetchHistory.length = 0;
+
+    // Trigger invalidation (scheduleListQueryFetch with highPriority on already loaded query)
+    // This should refetch all 15 items but split into chunks of 5
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+
+    await flushAllTimers();
+
+    // Should have 3 chunk requests (15 / 5 = 3)
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.length).toBe(3);
+
+    // Verify chunks have correct offset/limit
+    expect(listFetches[0]?.limit).toBe(5);
+    expect(listFetches[1]?.limit).toBe(5);
+    expect(listFetches[2]?.limit).toBe(5);
+
+    const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryAfter).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+        - '"products||11'
+        - '"products||12'
+        - '"products||13'
+        - '"products||14'
+        - '"products||15'
+      payload: { tableId: 'products' }
+      refetchOnMount: '❌'
+      status: 'success'
+      wasLoaded: '✅'
+    `);
+  });
+
+  test('invalidation does NOT chunk when totalLoaded <= maxInvalidationLimit', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 10 },
+    });
+
+    // Load initial 5 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Trigger invalidation - 5 items, maxInvalidationLimit = 10
+    // Should be a single request
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.length).toBe(1);
+    expect(listFetches[0]?.limit).toBe(5);
+  });
+
+  test('chunks are fetched in parallel', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load 15 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
+    ).toBe(15);
+
+    // Store fetch counts before invalidation
+    const startedBefore = env.serverTable.numOfStartedFetches;
+    const finishedBefore = env.serverTable.numOfFinishedFetches;
+
+    // Trigger chunked invalidation (15 items / maxInvalidationLimit 5 = 3 chunks)
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+
+    // Advance past coalescing window to start the fetch
+    await vi.advanceTimersByTimeAsync(15);
+
+    // All 3 chunks should have started in parallel (none finished yet)
+    expect(env.serverTable.numOfStartedFetches - startedBefore).toBe(3);
+    expect(env.serverTable.numOfFinishedFetches - finishedBefore).toBe(0);
+
+    await flushAllTimers();
+
+    // All 3 chunks should be complete
+    expect(env.serverTable.numOfFinishedFetches - finishedBefore).toBe(3);
+  });
+
+  test('chunked invalidation preserves deterministic item ordering', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load 15 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    // Trigger chunked invalidation
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+      - '"products||11'
+      - '"products||12'
+      - '"products||13'
+      - '"products||14'
+      - '"products||15'
+    `);
+  });
+
+  test('chunk error causes full query error', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load 10 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
+    ).toBe(10);
+
+    // Set error for next list fetch (will affect one of the chunks)
+    env.serverTable.setNextListFetchError('chunk error');
+
+    // Trigger invalidation - should split into 2 chunks, one will fail
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query).toMatchInlineSnapshot(`
+      error: { code: 500, id: 'fetch-error', message: 'chunk error' }
+      hasMore: '✅'
+      items:
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+      payload: { tableId: 'products' }
+      refetchOnMount: '❌'
+      status: 'error'
+      wasLoaded: '✅'
+    `);
+  });
+});
+
+describe('offset pagination - coalescing', () => {
+  const serverData = {
+    products: range(1, 20).map((id) => ({ id, name: `Product ${id}` })),
+  };
+
+  test('loadMore wins over load when coalesced', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+      baseCoalescingWindowMs: 50,
+    });
+
+    // Load initial 5 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    // Trigger loadMore and load in same coalescing window
+    env.apiStore.loadMore({ tableId: 'products' });
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+
+    await vi.advanceTimersByTimeAsync(60);
+
+    // 'loadMore' wins → status should be 'loadingMore' (not 'refetching')
+    const queryDuring = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryDuring?.status).toBe('loadingMore');
+
+    await flushAllTimers();
+
+    const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryAfter?.status).toBe('success');
+  });
+
+  test('coalesced offset ranges merge correctly', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+      baseCoalescingWindowMs: 50,
+    });
+
+    // Load initial 5 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    // Multiple loadMores within coalescing window
+    env.apiStore.loadMore({ tableId: 'products' }, 3);
+    env.apiStore.loadMore({ tableId: 'products' }, 5);
+
+    await flushAllTimers();
+
+    // The second loadMore is coalesced, result should use the larger range
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    // Items from offset 0..5 (initial) + offset 5..10 (loadMore with limit 5, coalesced max)
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+    `);
+  });
+});
+
+describe('offset pagination - refetch after loadMore keeps size', () => {
+  const serverData = {
+    products: range(1, 20).map((id) => ({ id, name: `Product ${id}` })),
+  };
+
+  test('refetch after loadMore refetches the full loaded size', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    // Load 5 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    // Load 5 more
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
+    ).toBe(10);
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Refetch should request all 10 items (offset: 0, limit: 10)
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+      payload: { tableId: 'products' }
+      refetchOnMount: '❌'
+      status: 'success'
+      wasLoaded: '✅'
+    `);
+
+    // Should be a single request since 10 <= maxInvalidationLimit (100)
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.length).toBe(1);
+    expect(listFetches[0]?.limit).toBe(10);
+  });
+});
+
+describe('offset pagination - awaitListQueryFetch', () => {
+  const serverData = {
+    products: range(1, 20).map((id) => ({ id, name: `Product ${id}` })),
+  };
+
+  test('awaitListQueryFetch returns items and hasMore correctly', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    const fetchPromise = env.apiStore.awaitListQueryFetch(
+      { tableId: 'products' },
+      { size: 5 },
+    );
+
+    await flushAllTimers();
+
+    const result = await fetchPromise;
+
+    expect(result).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - data: { id: 1, name: 'Product 1' }
+          itemPayload: 'products||1'
+        - data: { id: 2, name: 'Product 2' }
+          itemPayload: 'products||2'
+        - data: { id: 3, name: 'Product 3' }
+          itemPayload: 'products||3'
+        - data: { id: 4, name: 'Product 4' }
+          itemPayload: 'products||4'
+        - data: { id: 5, name: 'Product 5' }
+          itemPayload: 'products||5'
+    `);
+  });
+
+  test('awaitListQueryFetch returns hasMore false when all items fetched', async () => {
+    const smallServerData = {
+      products: range(1, 3).map((id) => ({ id, name: `Product ${id}` })),
+    };
+
+    const env = createListQueryStoreTestEnv(smallServerData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    const fetchPromise = env.apiStore.awaitListQueryFetch(
+      { tableId: 'products' },
+      { size: 5 },
+    );
+
+    await flushAllTimers();
+
+    const result = await fetchPromise;
+
+    expect(result).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '❌'
+      items:
+        - data: { id: 1, name: 'Product 1' }
+          itemPayload: 'products||1'
+        - data: { id: 2, name: 'Product 2' }
+          itemPayload: 'products||2'
+        - data: { id: 3, name: 'Product 3' }
+          itemPayload: 'products||3'
+    `);
+  });
+
+  test('awaitListQueryFetch returns error on fetch failure', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    env.serverTable.setNextListFetchError('network failure');
+
+    const fetchPromise = env.apiStore.awaitListQueryFetch(
+      { tableId: 'products' },
+      { size: 5 },
+    );
+
+    await flushAllTimers();
+
+    const result = await fetchPromise;
+
+    expect(result).toMatchInlineSnapshot(`
+      error{Error}: { message: 'network failure', name: 'StoreFetchError' }
+      hasMore: '❌'
+      items: []
+    `);
+  });
+});

--- a/tests/list-query-features/list-query-offset-pagination.test.ts
+++ b/tests/list-query-features/list-query-offset-pagination.test.ts
@@ -945,7 +945,7 @@ describe('offset pagination - coalescing', () => {
       5,
     );
 
-    await vi.advanceTimersByTimeAsync(60);
+    await advanceTime(60);
 
     // 'loadMore' wins → status should be 'loadingMore' (not 'refetching')
     const queryDuring = env.apiStore.getQueryState({ tableId: 'products' });
@@ -970,6 +970,73 @@ describe('offset pagination - coalescing', () => {
     `);
 
     // Verify a single coalesced fetch was made with the merged offset/limit
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+        - { limit: 10, offset: 0 }
+      `);
+  });
+
+  test('coalesced loadMore+load replaces list when merged range starts at offset 0', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+      baseCoalescingWindowMs: 50,
+    });
+
+    // Initial page: [1,2,3,4,5]
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    // Simulate 3 new items inserted at the head before coalesced fetch starts.
+    // Use reverse insertion order with prepend to get final order: 21, 22, 23.
+    env.serverTable.setItem(
+      'products||23',
+      { id: 23, name: 'New 23' },
+      { prepend: true },
+    );
+    env.serverTable.setItem(
+      'products||22',
+      { id: 22, name: 'New 22' },
+      { prepend: true },
+    );
+    env.serverTable.setItem(
+      'products||21',
+      { id: 21, name: 'New 21' },
+      { prepend: true },
+    );
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Coalesced payload becomes offset 0, limit 10.
+    env.apiStore.loadMore({ tableId: 'products' });
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||21'
+      - '"products||22'
+      - '"products||23'
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+    `);
+
     const listFetches = env.serverTable.fetchHistory.filter(
       (h) => h.type === 'list',
     );
@@ -1255,10 +1322,10 @@ describe('offset pagination - awaitListQueryFetch', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 10 }
-      - { limit: 5, offset: 5 }
-      - { limit: 5, offset: 0 }
-    `);
+        - { limit: 5, offset: 10 }
+        - { limit: 5, offset: 5 }
+        - { limit: 5, offset: 0 }
+      `);
 
     // Despite chunks completing in reverse order (10, 5, 0),
     // the result must have items in the correct sequential order (1..15)

--- a/tests/list-query-features/list-query-offset-pagination.test.ts
+++ b/tests/list-query-features/list-query-offset-pagination.test.ts
@@ -45,7 +45,9 @@ describe('offset pagination - basic loadMore', () => {
     const queryAfterInitial = env.apiStore.getQueryState({
       tableId: 'products',
     });
-    expect(queryAfterInitial?.items.length).toBe(5);
+    expect(queryAfterInitial?.items).toMatchInlineSnapshot(
+      `['"products||1', '"products||2', '"products||3', '"products||4', '"products||5']`,
+    );
     expect(queryAfterInitial?.hasMore).toBe(true);
 
     // loadMore: should fetch offset 5, limit 5 (only new page)
@@ -55,7 +57,18 @@ describe('offset pagination - basic loadMore', () => {
     const queryAfterLoadMore = env.apiStore.getQueryState({
       tableId: 'products',
     });
-    expect(queryAfterLoadMore?.items.length).toBe(10);
+    expect(queryAfterLoadMore?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+    `);
     expect(queryAfterLoadMore?.hasMore).toBe(true);
 
     // Verify server received offset-based requests
@@ -64,6 +77,7 @@ describe('offset pagination - basic loadMore', () => {
     );
     expect(listFetches).toMatchInlineSnapshot(`
       - limit: 5
+        offset: 0
         results:
           - data: { id: 1, name: 'Product 1' }
             itemId: 'products||1'
@@ -77,6 +91,7 @@ describe('offset pagination - basic loadMore', () => {
             itemId: 'products||5'
         type: 'list'
       - limit: 5
+        offset: 5
         results:
           - data: { id: 6, name: 'Product 6' }
             itemId: 'products||6'
@@ -130,6 +145,52 @@ describe('offset pagination - basic loadMore', () => {
       status: 'success'
       wasLoaded: '✅'
     `);
+  });
+
+  test('loadMore is skipped when hasMore is false', async () => {
+    const smallServerData = {
+      products: range(1, 3).map((id) => ({ id, name: `Product ${id}` })),
+    };
+
+    const env = createListQueryStoreTestEnv(smallServerData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+    });
+
+    // Load all 3 items (less than defaultQuerySize, so hasMore = false)
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    const queryBefore = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryBefore?.hasMore).toBe(false);
+    expect(queryBefore?.items).toMatchInlineSnapshot(
+      `['"products||1', '"products||2', '"products||3']`,
+    );
+
+    // Reset history to verify no new fetch is made
+    env.serverTable.fetchHistory.length = 0;
+
+    // loadMore should be skipped since hasMore is false
+    const result = env.apiStore.loadMore({ tableId: 'products' });
+    expect(result).toBe('skipped');
+
+    await flushAllTimers();
+
+    // No fetch should have been made
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches).toMatchInlineSnapshot('[]');
+
+    // Items unchanged
+    const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryAfter?.items).toMatchInlineSnapshot(
+      `['"products||1', '"products||2', '"products||3']`,
+    );
   });
 
   test('loadMore deduplicates items that shifted between pages', async () => {
@@ -257,7 +318,23 @@ describe('offset pagination - chunked invalidation', () => {
     await flushAllTimers();
 
     const queryBefore = env.apiStore.getQueryState({ tableId: 'products' });
-    expect(queryBefore?.items.length).toBe(15);
+    expect(queryBefore?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+      - '"products||11'
+      - '"products||12'
+      - '"products||13'
+      - '"products||14'
+      - '"products||15'
+    `);
 
     // Reset history to track only invalidation fetches
     env.serverTable.fetchHistory.length = 0;
@@ -270,16 +347,16 @@ describe('offset pagination - chunked invalidation', () => {
 
     await flushAllTimers();
 
-    // Should have 3 chunk requests (15 / 5 = 3)
+    // Should have 3 chunk requests (15 / 5 = 3) with correct offset/limit
     const listFetches = env.serverTable.fetchHistory.filter(
       (h) => h.type === 'list',
     );
-    expect(listFetches.length).toBe(3);
-
-    // Verify chunks have correct offset/limit
-    expect(listFetches[0]?.limit).toBe(5);
-    expect(listFetches[1]?.limit).toBe(5);
-    expect(listFetches[2]?.limit).toBe(5);
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 0 }
+      - { limit: 5, offset: 5 }
+      - { limit: 5, offset: 10 }
+    `);
 
     const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
     expect(queryAfter).toMatchInlineSnapshot(`
@@ -334,8 +411,119 @@ describe('offset pagination - chunked invalidation', () => {
     const listFetches = env.serverTable.fetchHistory.filter(
       (h) => h.type === 'list',
     );
-    expect(listFetches.length).toBe(1);
-    expect(listFetches[0]?.limit).toBe(5);
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 0 }
+    `);
+  });
+
+  test('invalidation does NOT chunk when totalLoaded equals maxInvalidationLimit', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load exactly 5 items (== maxInvalidationLimit)
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Trigger invalidation — 5 items, maxInvalidationLimit = 5
+    // Condition is `limit > max` (strictly greater), so 5 == 5 should NOT chunk
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 0 }
+    `);
+  });
+
+  test('chunked invalidation handles remainder chunk correctly', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 4,
+      offsetPagination: { maxInvalidationLimit: 5 },
+    });
+
+    // Load 12 items (3 loadMores of 4)
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      4,
+    );
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+    env.apiStore.loadMore({ tableId: 'products' });
+    await flushAllTimers();
+
+    expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
+      .toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+      - '"products||11'
+      - '"products||12'
+    `);
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Trigger invalidation — 12 items / maxInvalidationLimit 5
+    // Should produce 3 chunks: {0,5}, {5,5}, {10,2}
+    env.apiStore.scheduleListQueryFetch('highPriority', {
+      tableId: 'products',
+    });
+    await flushAllTimers();
+
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 0 }
+      - { limit: 5, offset: 5 }
+      - { limit: 2, offset: 10 }
+    `);
+
+    const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
+    expect(queryAfter).toMatchInlineSnapshot(`
+      error: null
+      hasMore: '✅'
+      items:
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+        - '"products||11'
+        - '"products||12'
+      payload: { tableId: 'products' }
+      refetchOnMount: '❌'
+      status: 'success'
+      wasLoaded: '✅'
+    `);
   });
 
   test('chunks are fetched in parallel', async () => {
@@ -356,9 +544,24 @@ describe('offset pagination - chunked invalidation', () => {
     env.apiStore.loadMore({ tableId: 'products' });
     await flushAllTimers();
 
-    expect(
-      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
-    ).toBe(15);
+    expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
+      .toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+      - '"products||11'
+      - '"products||12'
+      - '"products||13'
+      - '"products||14'
+      - '"products||15'
+    `);
 
     // Store fetch counts before invalidation
     const startedBefore = env.serverTable.numOfStartedFetches;
@@ -442,9 +645,19 @@ describe('offset pagination - chunked invalidation', () => {
     env.apiStore.loadMore({ tableId: 'products' });
     await flushAllTimers();
 
-    expect(
-      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
-    ).toBe(10);
+    expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
+      .toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+    `);
 
     // Set error for next list fetch (will affect one of the chunks)
     env.serverTable.setNextListFetchError('chunk error');
@@ -498,6 +711,9 @@ describe('offset pagination - coalescing', () => {
     );
     await flushAllTimers();
 
+    // Reset history to track only coalesced fetch
+    env.serverTable.fetchHistory.length = 0;
+
     // Trigger loadMore and load in same coalescing window
     env.apiStore.loadMore({ tableId: 'products' });
     env.apiStore.scheduleListQueryFetch(
@@ -516,6 +732,28 @@ describe('offset pagination - coalescing', () => {
 
     const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
     expect(queryAfter?.status).toBe('success');
+    // Merged request should cover the combined range and fetch all 10 items
+    expect(queryAfter?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+    `);
+
+    // Verify a single coalesced fetch was made with the merged offset/limit
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 10, offset: 0 }
+    `);
   });
 
   test('coalesced offset ranges merge correctly', async () => {
@@ -533,15 +771,77 @@ describe('offset pagination - coalescing', () => {
     );
     await flushAllTimers();
 
+    // Reset history to track only the coalesced fetch
+    env.serverTable.fetchHistory.length = 0;
+
     // Multiple loadMores within coalescing window
+    // loadMore(..., 3) → offset 5, limit 3
+    // loadMore(..., 5) → offset 5, limit 5
+    // Merged result should be offset 5, limit 5 (max of the two limits)
     env.apiStore.loadMore({ tableId: 'products' }, 3);
     env.apiStore.loadMore({ tableId: 'products' }, 5);
 
     await flushAllTimers();
 
-    // The second loadMore is coalesced, result should use the larger range
+    // Verify the coalesced fetch used the merged (larger) limit
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 5 }
+    `);
+
     const query = env.apiStore.getQueryState({ tableId: 'products' });
-    // Items from offset 0..5 (initial) + offset 5..10 (loadMore with limit 5, coalesced max)
+    expect(query?.items).toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+    `);
+  });
+
+  test('coalesced merge uses larger limit regardless of order', async () => {
+    const env = createListQueryStoreTestEnv(serverData, {
+      defaultQuerySize: 5,
+      offsetPagination: { maxInvalidationLimit: 100 },
+      baseCoalescingWindowMs: 50,
+    });
+
+    // Load initial 5 items
+    env.apiStore.scheduleListQueryFetch(
+      'highPriority',
+      { tableId: 'products' },
+      5,
+    );
+    await flushAllTimers();
+
+    env.serverTable.fetchHistory.length = 0;
+
+    // Reverse order: larger limit first, smaller second
+    // loadMore(..., 5) → offset 5, limit 5
+    // loadMore(..., 3) → offset 5, limit 3
+    // Merge should still use limit 5 (not 3 from last-write-wins)
+    env.apiStore.loadMore({ tableId: 'products' }, 5);
+    env.apiStore.loadMore({ tableId: 'products' }, 3);
+
+    await flushAllTimers();
+
+    const listFetches = env.serverTable.fetchHistory.filter(
+      (h) => h.type === 'list',
+    );
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 5, offset: 5 }
+    `);
+
+    const query = env.apiStore.getQueryState({ tableId: 'products' });
     expect(query?.items).toMatchInlineSnapshot(`
       - '"products||1'
       - '"products||2'
@@ -580,9 +880,19 @@ describe('offset pagination - refetch after loadMore keeps size', () => {
     env.apiStore.loadMore({ tableId: 'products' });
     await flushAllTimers();
 
-    expect(
-      env.apiStore.getQueryState({ tableId: 'products' })?.items.length,
-    ).toBe(10);
+    expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
+      .toMatchInlineSnapshot(`
+      - '"products||1'
+      - '"products||2'
+      - '"products||3'
+      - '"products||4'
+      - '"products||5'
+      - '"products||6'
+      - '"products||7'
+      - '"products||8'
+      - '"products||9'
+      - '"products||10'
+    `);
 
     env.serverTable.fetchHistory.length = 0;
 
@@ -617,8 +927,10 @@ describe('offset pagination - refetch after loadMore keeps size', () => {
     const listFetches = env.serverTable.fetchHistory.filter(
       (h) => h.type === 'list',
     );
-    expect(listFetches.length).toBe(1);
-    expect(listFetches[0]?.limit).toBe(10);
+    expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
+      .toMatchInlineSnapshot(`
+      - { limit: 10, offset: 0 }
+    `);
   });
 });
 

--- a/tests/list-query-features/list-query-offset-pagination.test.ts
+++ b/tests/list-query-features/list-query-offset-pagination.test.ts
@@ -353,10 +353,10 @@ describe('offset pagination - chunked invalidation', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 0 }
-      - { limit: 5, offset: 5 }
-      - { limit: 5, offset: 10 }
-    `);
+        - { limit: 5, offset: 0 }
+        - { limit: 5, offset: 5 }
+        - { limit: 5, offset: 10 }
+      `);
 
     const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
     expect(queryAfter).toMatchInlineSnapshot(`
@@ -413,8 +413,8 @@ describe('offset pagination - chunked invalidation', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 0 }
-    `);
+        - { limit: 5, offset: 0 }
+      `);
   });
 
   test('invalidation does NOT chunk when totalLoaded equals maxInvalidationLimit', async () => {
@@ -445,8 +445,8 @@ describe('offset pagination - chunked invalidation', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 0 }
-    `);
+        - { limit: 5, offset: 0 }
+      `);
   });
 
   test('chunked invalidation handles remainder chunk correctly', async () => {
@@ -469,19 +469,19 @@ describe('offset pagination - chunked invalidation', () => {
 
     expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
       .toMatchInlineSnapshot(`
-      - '"products||1'
-      - '"products||2'
-      - '"products||3'
-      - '"products||4'
-      - '"products||5'
-      - '"products||6'
-      - '"products||7'
-      - '"products||8'
-      - '"products||9'
-      - '"products||10'
-      - '"products||11'
-      - '"products||12'
-    `);
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+        - '"products||11'
+        - '"products||12'
+      `);
 
     env.serverTable.fetchHistory.length = 0;
 
@@ -497,10 +497,10 @@ describe('offset pagination - chunked invalidation', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 0 }
-      - { limit: 5, offset: 5 }
-      - { limit: 2, offset: 10 }
-    `);
+        - { limit: 5, offset: 0 }
+        - { limit: 5, offset: 5 }
+        - { limit: 2, offset: 10 }
+      `);
 
     const queryAfter = env.apiStore.getQueryState({ tableId: 'products' });
     expect(queryAfter).toMatchInlineSnapshot(`
@@ -546,22 +546,22 @@ describe('offset pagination - chunked invalidation', () => {
 
     expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
       .toMatchInlineSnapshot(`
-      - '"products||1'
-      - '"products||2'
-      - '"products||3'
-      - '"products||4'
-      - '"products||5'
-      - '"products||6'
-      - '"products||7'
-      - '"products||8'
-      - '"products||9'
-      - '"products||10'
-      - '"products||11'
-      - '"products||12'
-      - '"products||13'
-      - '"products||14'
-      - '"products||15'
-    `);
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+        - '"products||11'
+        - '"products||12'
+        - '"products||13'
+        - '"products||14'
+        - '"products||15'
+      `);
 
     // Store fetch counts before invalidation
     const startedBefore = env.serverTable.numOfStartedFetches;
@@ -647,17 +647,17 @@ describe('offset pagination - chunked invalidation', () => {
 
     expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
       .toMatchInlineSnapshot(`
-      - '"products||1'
-      - '"products||2'
-      - '"products||3'
-      - '"products||4'
-      - '"products||5'
-      - '"products||6'
-      - '"products||7'
-      - '"products||8'
-      - '"products||9'
-      - '"products||10'
-    `);
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+      `);
 
     // Set error for next list fetch (will affect one of the chunks)
     env.serverTable.setNextListFetchError('chunk error');
@@ -752,8 +752,8 @@ describe('offset pagination - coalescing', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 10, offset: 0 }
-    `);
+        - { limit: 10, offset: 0 }
+      `);
   });
 
   test('coalesced offset ranges merge correctly', async () => {
@@ -789,8 +789,8 @@ describe('offset pagination - coalescing', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 5 }
-    `);
+        - { limit: 5, offset: 5 }
+      `);
 
     const query = env.apiStore.getQueryState({ tableId: 'products' });
     expect(query?.items).toMatchInlineSnapshot(`
@@ -838,8 +838,8 @@ describe('offset pagination - coalescing', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 5, offset: 5 }
-    `);
+        - { limit: 5, offset: 5 }
+      `);
 
     const query = env.apiStore.getQueryState({ tableId: 'products' });
     expect(query?.items).toMatchInlineSnapshot(`
@@ -882,17 +882,17 @@ describe('offset pagination - refetch after loadMore keeps size', () => {
 
     expect(env.apiStore.getQueryState({ tableId: 'products' })?.items)
       .toMatchInlineSnapshot(`
-      - '"products||1'
-      - '"products||2'
-      - '"products||3'
-      - '"products||4'
-      - '"products||5'
-      - '"products||6'
-      - '"products||7'
-      - '"products||8'
-      - '"products||9'
-      - '"products||10'
-    `);
+        - '"products||1'
+        - '"products||2'
+        - '"products||3'
+        - '"products||4'
+        - '"products||5'
+        - '"products||6'
+        - '"products||7'
+        - '"products||8'
+        - '"products||9'
+        - '"products||10'
+      `);
 
     env.serverTable.fetchHistory.length = 0;
 
@@ -929,8 +929,8 @@ describe('offset pagination - refetch after loadMore keeps size', () => {
     );
     expect(listFetches.map(({ offset, limit }) => ({ offset, limit })))
       .toMatchInlineSnapshot(`
-      - { limit: 10, offset: 0 }
-    `);
+        - { limit: 10, offset: 0 }
+      `);
   });
 });
 

--- a/tests/list-query-features/list-query-partial-resources-2.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-2.test.ts
@@ -124,7 +124,8 @@ describe('list then load item: cross-source field accumulation', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         limit: 50
         offset: 0
         results:
@@ -148,6 +149,7 @@ describe('list then load item: cross-source field accumulation', () => {
             itemId: 'users||9'
           - data: { address: 'Address 10', id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
     `);
   });
@@ -229,7 +231,8 @@ describe('list then load item: cross-source field accumulation', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -253,10 +256,13 @@ describe('list then load item: cross-source field accumulation', () => {
             itemId: 'users||9'
           - data: { id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'name', 'address', 'country']
+      - duration: 800
+        fields: ['id', 'name', 'address', 'country']
         itemId: 'users||1'
         result: { address: 'Address 1', country: 'Country 1', id: 1, name: 'User 1' }
+        startedAt: 820
         type: 'fetch'
     `);
   });
@@ -321,7 +327,8 @@ describe('list then load item: cross-source field accumulation', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -345,6 +352,7 @@ describe('list then load item: cross-source field accumulation', () => {
             itemId: 'users||9'
           - data: { id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
     `);
   });
@@ -415,7 +423,8 @@ describe('load more with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 3
         offset: 0
         results:
@@ -425,8 +434,10 @@ describe('load more with partial resources', () => {
             itemId: 'users||2'
           - data: { id: 3, name: 'User 3' }
             itemId: 'users||3'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 6
         offset: 0
         results:
@@ -442,6 +453,7 @@ describe('load more with partial resources', () => {
             itemId: 'users||5'
           - data: { id: 6, name: 'User 6' }
             itemId: 'users||6'
+        startedAt: 820
         type: 'list'
     `);
   });
@@ -488,13 +500,17 @@ describe('concurrent fetches with different fields', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         itemId: 'users||1'
         result: { id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
-      - fields: ['id', 'address', 'country']
+      - duration: 800
+        fields: ['id', 'address', 'country']
         itemId: 'users||2'
         result: { address: 'Address 2', country: 'Country 2', id: 2 }
+        startedAt: 10
         type: 'fetch'
     `);
   });

--- a/tests/list-query-features/list-query-partial-resources-2.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-2.test.ts
@@ -126,6 +126,7 @@ describe('list then load item: cross-source field accumulation', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name', 'address']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -230,6 +231,7 @@ describe('list then load item: cross-source field accumulation', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -321,6 +323,7 @@ describe('list then load item: cross-source field accumulation', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -414,6 +417,7 @@ describe('load more with partial resources', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 3
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -424,6 +428,7 @@ describe('load more with partial resources', () => {
         type: 'list'
       - fields: ['id', 'name']
         limit: 6
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'

--- a/tests/list-query-features/list-query-partial-resources-3.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-3.test.ts
@@ -108,6 +108,7 @@ describe('list query field accumulation edge cases', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -134,6 +135,7 @@ describe('list query field accumulation edge cases', () => {
         filters:
           - { field: 'id', op: 'gt', value: 5 }
         limit: 50
+        offset: 0
         results:
           - data: { id: 6, name: 'User 6' }
             itemId: 'users||6'
@@ -196,6 +198,7 @@ describe('list query field accumulation edge cases', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['address', 'id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -283,6 +286,7 @@ describe('list query field accumulation edge cases', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -307,6 +311,7 @@ describe('list query field accumulation edge cases', () => {
         type: 'list'
       - fields: ['id', 'address']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1 }
             itemId: 'users||1'

--- a/tests/list-query-features/list-query-partial-resources-3.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-3.test.ts
@@ -106,7 +106,8 @@ describe('list query field accumulation edge cases', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -130,8 +131,10 @@ describe('list query field accumulation edge cases', () => {
             itemId: 'users||9'
           - data: { id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         filters:
           - { field: 'id', op: 'gt', value: 5 }
         limit: 50
@@ -147,6 +150,7 @@ describe('list query field accumulation edge cases', () => {
             itemId: 'users||9'
           - data: { id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
     `);
   });
@@ -196,7 +200,8 @@ describe('list query field accumulation edge cases', () => {
     ).toMatchInlineSnapshot(`['address', 'id', 'name']`);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         limit: 50
         offset: 0
         results:
@@ -220,6 +225,7 @@ describe('list query field accumulation edge cases', () => {
             itemId: 'users||9'
           - data: { address: 'Address 10', id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
     `);
   });
@@ -284,7 +290,8 @@ describe('list query field accumulation edge cases', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -308,8 +315,10 @@ describe('list query field accumulation edge cases', () => {
             itemId: 'users||9'
           - data: { id: 10, name: 'User 10' }
             itemId: 'users||10'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'address']
+      - duration: 800
+        fields: ['id', 'address']
         limit: 50
         offset: 0
         results:
@@ -333,6 +342,7 @@ describe('list query field accumulation edge cases', () => {
             itemId: 'users||9'
           - data: { address: 'Address 10', id: 10 }
             itemId: 'users||10'
+        startedAt: 820
         type: 'list'
     `);
   });

--- a/tests/list-query-features/list-query-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-partial-resources.test.ts
@@ -296,6 +296,7 @@ describe('useListQuery with partial resources', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -395,6 +396,7 @@ describe('useListQuery with partial resources', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -409,6 +411,7 @@ describe('useListQuery with partial resources', () => {
         type: 'list'
       - fields: ['id', 'name', 'address']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -476,6 +479,7 @@ describe('useListQuery with partial resources', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name', 'address']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -932,6 +936,7 @@ describe('invalidateQueryAndItems with fields', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name', 'address']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -946,6 +951,7 @@ describe('invalidateQueryAndItems with fields', () => {
         type: 'list'
       - fields: ['id', 'address']
         limit: 50
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1 }
             itemId: 'users||1'
@@ -1008,6 +1014,7 @@ describe('invalidateQueryAndItems with fields', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'
@@ -1022,6 +1029,7 @@ describe('invalidateQueryAndItems with fields', () => {
         type: 'list'
       - fields: ['id', 'name']
         limit: 50
+        offset: 0
         results:
           - data: { id: 1, name: 'User 1' }
             itemId: 'users||1'

--- a/tests/list-query-features/list-query-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-partial-resources.test.ts
@@ -96,9 +96,11 @@ describe('useItem with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
     `);
   });
@@ -139,8 +141,10 @@ describe('useItem with partial resources', () => {
     }
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'users||1'
+      - duration: 800
+        itemId: 'users||1'
         result: { address: 'Address 1', age: 10, country: 'Country 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
     `);
   });
@@ -198,13 +202,17 @@ describe('useItem with partial resources', () => {
     ).toMatchInlineSnapshot(`['address', 'country', 'id', 'name']`);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
-      - fields: ['id', 'name', 'address', 'country']
+      - duration: 800
+        fields: ['id', 'name', 'address', 'country']
         itemId: 'users||1'
         result: { address: 'Address 1', country: 'Country 1', id: 1, name: 'User 1' }
+        startedAt: 820
         type: 'fetch'
     `);
   });
@@ -259,9 +267,11 @@ describe('useItem with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address', 'country']
+      - duration: 800
+        fields: ['id', 'name', 'address', 'country']
         itemId: 'users||1'
         result: { address: 'Address 1', country: 'Country 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
     `);
   });
@@ -294,7 +304,8 @@ describe('useListQuery with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -308,6 +319,7 @@ describe('useListQuery with partial resources', () => {
             itemId: 'users||4'
           - data: { id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 10
         type: 'list'
     `);
   });
@@ -394,7 +406,8 @@ describe('useListQuery with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -408,8 +421,10 @@ describe('useListQuery with partial resources', () => {
             itemId: 'users||4'
           - data: { id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         limit: 50
         offset: 0
         results:
@@ -423,6 +438,7 @@ describe('useListQuery with partial resources', () => {
             itemId: 'users||4'
           - data: { address: 'Address 5', id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 820
         type: 'list'
     `);
   });
@@ -477,7 +493,8 @@ describe('useListQuery with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         limit: 50
         offset: 0
         results:
@@ -491,6 +508,7 @@ describe('useListQuery with partial resources', () => {
             itemId: 'users||4'
           - data: { address: 'Address 5', id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 10
         type: 'list'
     `);
   });
@@ -558,13 +576,17 @@ describe('cross-hook field loading', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         itemId: 'users||1'
         result: { id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
-      - fields: ['id', 'address']
+      - duration: 800
+        fields: ['id', 'address']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1 }
+        startedAt: 820
         type: 'fetch'
     `);
   });
@@ -621,9 +643,11 @@ describe('cross-hook field loading', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
     `);
   });
@@ -658,9 +682,11 @@ describe('deleteItemState with partial resources', () => {
     expect(env.store.state.items[storeItemKey]).toBeNull();
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         itemId: 'users||1'
         result: { id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
     `);
   });
@@ -700,9 +726,11 @@ describe('updateItemState with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
     `);
   });
@@ -776,13 +804,17 @@ describe('invalidateQueryAndItems with fields', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
-      - fields: ['address']
+      - duration: 800
+        fields: ['address']
         itemId: 'users||1'
         result: { address: 'Address 1' }
+        startedAt: 820
         type: 'fetch'
     `);
   });
@@ -849,13 +881,17 @@ describe('invalidateQueryAndItems with fields', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         itemId: 'users||1'
         result: { address: 'Address 1', id: 1, name: 'User 1' }
+        startedAt: 820
         type: 'fetch'
     `);
   });
@@ -934,7 +970,8 @@ describe('invalidateQueryAndItems with fields', () => {
       "
     `);
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name', 'address']
+      - duration: 800
+        fields: ['id', 'name', 'address']
         limit: 50
         offset: 0
         results:
@@ -948,8 +985,10 @@ describe('invalidateQueryAndItems with fields', () => {
             itemId: 'users||4'
           - data: { address: 'Address 5', id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'address']
+      - duration: 800
+        fields: ['id', 'address']
         limit: 50
         offset: 0
         results:
@@ -963,6 +1002,7 @@ describe('invalidateQueryAndItems with fields', () => {
             itemId: 'users||4'
           - data: { address: 'Address 5', id: 5 }
             itemId: 'users||5'
+        startedAt: 820
         type: 'list'
     `);
   });
@@ -1012,7 +1052,8 @@ describe('invalidateQueryAndItems with fields', () => {
       "
     `);
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -1026,8 +1067,10 @@ describe('invalidateQueryAndItems with fields', () => {
             itemId: 'users||4'
           - data: { id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 10
         type: 'list'
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 50
         offset: 0
         results:
@@ -1041,6 +1084,7 @@ describe('invalidateQueryAndItems with fields', () => {
             itemId: 'users||4'
           - data: { id: 5, name: 'User 5' }
             itemId: 'users||5'
+        startedAt: 820
         type: 'list'
     `);
   });
@@ -1100,13 +1144,17 @@ describe('RTU with partial resources', () => {
     `);
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         itemId: 'users||1'
         result: { id: 1, name: 'User 1' }
+        startedAt: 10
         type: 'fetch'
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         itemId: 'users||1'
         result: { id: 1, name: 'Updated User 1' }
+        startedAt: 820
         type: 'fetch'
     `);
   });

--- a/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
@@ -309,6 +309,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
 
     await vi.advanceTimersByTimeAsync(60);
 
+    // 'loadMore' type wins over 'load' in size mode coalescePayload → status is 'loadingMore'
     const queryDuringFetch = env.apiStore.getQueryState({ tableId: 'table1' });
     expect(queryDuringFetch?.status).toBe('loadingMore');
 

--- a/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
@@ -80,7 +80,8 @@ describe('query coalescing with partial resources', () => {
     await flushAllTimers();
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 4
         offset: 0
         results:
@@ -92,6 +93,7 @@ describe('query coalescing with partial resources', () => {
             itemId: 'table1||3'
           - data: { id: 4, name: 'Item 4' }
             itemId: 'table1||4'
+        startedAt: 50
         type: 'list'
     `);
     expect(env.serverTable.numOfFinishedFetches).toBe(1);
@@ -125,7 +127,8 @@ describe('query coalescing with partial resources', () => {
     await flushAllTimers();
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         limit: 5
         offset: 0
         results:
@@ -139,6 +142,7 @@ describe('query coalescing with partial resources', () => {
             itemId: 'table1||4'
           - data: { address: 'Address 5', id: 5, name: 'Item 5' }
             itemId: 'table1||5'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -180,7 +184,8 @@ describe('query coalescing with partial resources', () => {
     }
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { address: 'Address 1', country: 'Country 1', id: 1, name: 'Item 1' }
@@ -193,6 +198,7 @@ describe('query coalescing with partial resources', () => {
             itemId: 'table1||4'
           - data: { address: 'Address 5', country: 'Country 5', id: 5, name: 'Item 5' }
             itemId: 'table1||5'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -258,7 +264,8 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
     await flushAllTimers();
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id']
+      - duration: 800
+        fields: ['id']
         limit: 2
         offset: 0
         results:
@@ -266,8 +273,10 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
             itemId: 'table1||1'
           - data: { id: 2 }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
-      - fields: ['address', 'id', 'name']
+      - duration: 800
+        fields: ['address', 'id', 'name']
         limit: 6
         offset: 0
         results:
@@ -283,6 +292,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
             itemId: 'table1||5'
           - data: { address: 'Address 6', id: 6, name: 'Item 6' }
             itemId: 'table1||6'
+        startedAt: 900
         type: 'list'
     `);
   });
@@ -321,7 +331,8 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
     await flushAllTimers();
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - fields: ['id', 'name']
+      - duration: 800
+        fields: ['id', 'name']
         limit: 2
         offset: 0
         results:
@@ -329,8 +340,10 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
-      - fields: ['address', 'country', 'id']
+      - duration: 800
+        fields: ['address', 'country', 'id']
         limit: 4
         offset: 0
         results:
@@ -342,6 +355,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
             itemId: 'table1||3'
           - data: { address: 'Address 4', country: 'Country 4', id: 4 }
             itemId: 'table1||4'
+        startedAt: 900
         type: 'list'
     `);
 

--- a/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
@@ -82,6 +82,7 @@ describe('query coalescing with partial resources', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 4
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -126,6 +127,7 @@ describe('query coalescing with partial resources', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['address', 'id', 'name']
         limit: 5
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -179,6 +181,7 @@ describe('query coalescing with partial resources', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 5
+        offset: 0
         results:
           - data: { address: 'Address 1', country: 'Country 1', id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -257,6 +260,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id']
         limit: 2
+        offset: 0
         results:
           - data: { id: 1 }
             itemId: 'table1||1'
@@ -265,6 +269,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
         type: 'list'
       - fields: ['address', 'id', 'name']
         limit: 6
+        offset: 0
         results:
           - data: { address: 'Address 1', id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -318,6 +323,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - fields: ['id', 'name']
         limit: 2
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -326,6 +332,7 @@ describe('size and field coalescing in scheduledRequests during active fetch', (
         type: 'list'
       - fields: ['address', 'country', 'id']
         limit: 4
+        offset: 0
         results:
           - data: { address: 'Address 1', country: 'Country 1', id: 1 }
             itemId: 'table1||1'

--- a/tests/mocks/listQueryStoreTestEnv.ts
+++ b/tests/mocks/listQueryStoreTestEnv.ts
@@ -1,7 +1,14 @@
 import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
+import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { act } from 'react';
-import { createListQueryStore } from '../../src/listQueryStore/listQueryStore';
-import type { PartialResourcesConfig } from '../../src/listQueryStore/types';
+import {
+  createListQueryStore,
+  type ListQueryStoreOptions,
+} from '../../src/listQueryStore/listQueryStore';
+import type {
+  OffsetPaginationConfig,
+  PartialResourcesConfig,
+} from '../../src/listQueryStore/types';
 import type { FetchType } from '../../src/requestScheduler';
 import { createServerTableMock, type FilterOperator } from './serverTableMock';
 import {
@@ -56,6 +63,7 @@ export function createListQueryStoreTestEnv<
   TRow extends Row = Row,
   TPartialResources extends PartialResourcesConfig<TRow> | undefined =
     undefined,
+  TOffsetPagination extends OffsetPaginationConfig | undefined = undefined,
 >(
   serverInitialData: Tables<TRow>,
   {
@@ -72,6 +80,7 @@ export function createListQueryStoreTestEnv<
     disableFetchItemFn,
     optimisticListUpdates,
     partialResources,
+    offsetPagination,
   }: {
     dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
     baseCoalescingWindowMs?: number;
@@ -91,6 +100,7 @@ export function createListQueryStoreTestEnv<
       typeof createListQueryStore<TRow, ListQueryParams, ListQueryItemPayload>
     >[0]['optimisticListUpdates'];
     partialResources?: TPartialResources;
+    offsetPagination?: TOffsetPagination;
   } = {},
 ) {
   const {
@@ -194,12 +204,34 @@ export function createListQueryStoreTestEnv<
 
   const testOptions = resolveTestOptions(testScenario, serverTable);
 
-  const listQueryStore = createListQueryStore<
-    TRow,
-    ListQueryParams,
-    ListQueryItemPayload,
-    TPartialResources
-  >({
+  async function fetchFromServer(
+    { tableId, filters }: ListQueryParams,
+    offset: number | undefined,
+    limit: number,
+    signal: AbortSignal,
+    fields: string[] | undefined,
+  ) {
+    const result = await serverTable.list(
+      {
+        tableId,
+        filters,
+        fields: partialResources ? fields : undefined,
+        offset,
+        limit,
+      },
+      signal,
+    );
+
+    return {
+      items: result.items.map(({ itemId, data }) => ({
+        itemPayload: itemId,
+        data,
+      })),
+      hasMore: result.hasMore,
+    };
+  }
+
+  const baseOptions = {
     errorNormalizer: normalizeError,
     lowPriorityThrottleMs,
     baseCoalescingWindowMs,
@@ -213,34 +245,59 @@ export function createListQueryStoreTestEnv<
     optimisticListUpdates,
     partialResources,
     '~test': testOptions,
-    onSchedulerEvent: (event) => {
+    onSchedulerEvent: (
+      event: import('../../src/requestScheduler').RequestSchedulerEvents,
+    ) => {
       logSchedulerEvent(event, addAction);
-    },
-    fetchListFn: async ({ tableId, filters }, size, { signal, fields }) => {
-      const result = await serverTable.list(
-        {
-          tableId,
-          filters,
-          fields: partialResources ? fields : undefined,
-          limit: size,
-        },
-        signal,
-      );
-
-      return {
-        items: result.items.map(({ itemId, data }) => ({
-          itemPayload: itemId,
-          data,
-        })),
-        hasMore: result.hasMore,
-      };
     },
     fetchItemFn: disableFetchItemFn
       ? undefined
-      : async (payload, { signal, fields }) => {
+      : async (
+          payload: ListQueryItemPayload,
+          { signal, fields }: { signal: AbortSignal; fields?: string[] },
+        ) => {
           return serverTable.fetch(payload, signal, { fields });
         },
-  });
+  };
+
+  // TypeScript cannot narrow generic params from a runtime check, so we use
+  // __LEGIT_CAST__ on the options object to satisfy the conditional type.
+  const storeOptions = offsetPagination
+    ? {
+        ...baseOptions,
+        offsetPagination,
+        fetchListFn: async (
+          payload: ListQueryParams,
+          { offset, limit }: { offset: number; limit: number },
+          { signal, fields }: { signal: AbortSignal; fields?: string[] },
+        ) => fetchFromServer(payload, offset, limit, signal, fields),
+      }
+    : {
+        ...baseOptions,
+        fetchListFn: async (
+          payload: ListQueryParams,
+          size: number,
+          { signal, fields }: { signal: AbortSignal; fields?: string[] },
+        ) => fetchFromServer(payload, undefined, size, signal, fields),
+      };
+
+  const listQueryStore = createListQueryStore<
+    TRow,
+    ListQueryParams,
+    ListQueryItemPayload,
+    TPartialResources,
+    TOffsetPagination
+  >(
+    __LEGIT_CAST__<
+      ListQueryStoreOptions<
+        TRow,
+        ListQueryParams,
+        ListQueryItemPayload,
+        TPartialResources,
+        TOffsetPagination
+      >
+    >(storeOptions),
+  );
 
   if (usesRealTimeUpdates) {
     serverTable.wsEvents.on('data_changed', ({ payload }) => {

--- a/tests/mocks/serverTableMock.ts
+++ b/tests/mocks/serverTableMock.ts
@@ -3,7 +3,7 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { sleep } from '@ls-stack/utils/sleep';
 import { evtmitter } from 'evtmitter';
 import type { StoreError } from '../../src/utils/storeShared';
-import { FetchError } from './testEnvUtils';
+import { FetchError, TEST_INITIAL_TIME } from './testEnvUtils';
 
 export const DEFAULT_FETCH_DURATION_MS = 800;
 export const DEFAULT_MUTATION_DURATION_MS = 1200;
@@ -139,6 +139,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         itemId: string;
         fields: string[] | undefined;
         result: ItemData | 'error' | 'aborted';
+        startedAt: number;
+        duration: number;
       }
     | {
         type: 'list';
@@ -148,6 +150,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         fields: string[] | undefined;
         filters: FilterOperator[] | undefined;
         batchKey: string | undefined;
+        startedAt: number;
+        duration: number;
         results:
           | Array<{ itemId: string; data: ItemData | 'error' }>
           | 'aborted';
@@ -191,6 +195,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     options?: { fields?: string[] },
   ): Promise<ItemData> {
     const fetchId = addAction ? getFetchId() : undefined;
+    const fetchStartedAt = Date.now() - TEST_INITIAL_TIME;
 
     if (addAction) {
       addAction('>fetch-started', { id: fetchId, itemId });
@@ -215,6 +220,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         itemId,
         fields: options?.fields,
         result: 'error',
+        startedAt: fetchStartedAt,
+        duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
       });
       if (addAction) {
         numOfFinishedFetches++;
@@ -248,6 +255,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         itemId,
         fields: options?.fields,
         result: 'aborted',
+        startedAt: fetchStartedAt,
+        duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
       });
       if (addAction) {
         numOfFinishedFetches++;
@@ -262,6 +271,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         itemId,
         fields: options?.fields,
         result: 'error',
+        startedAt: fetchStartedAt,
+        duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
       });
       if (addAction) {
         numOfFinishedFetches++;
@@ -279,6 +290,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       itemId,
       fields: options?.fields,
       result,
+      startedAt: fetchStartedAt,
+      duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
     });
     if (addAction) {
       numOfFinishedFetches++;
@@ -306,6 +319,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       batchKey,
     } = options ?? {};
     const listId = addAction ? getFetchId() : undefined;
+    const fetchStartedAt = Date.now() - TEST_INITIAL_TIME;
 
     if (addAction) {
       const filterInfo = filterItemIds ? { itemIds: filterItemIds } : undefined;
@@ -354,6 +368,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         filters,
         fields,
         batchKey,
+        startedAt: fetchStartedAt,
+        duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
       });
       if (addAction) {
         numOfFinishedFetches++;
@@ -374,6 +390,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         filters,
         fields,
         batchKey,
+        startedAt: fetchStartedAt,
+        duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
       });
       if (addAction) {
         numOfFinishedFetches++;
@@ -395,6 +413,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         filters,
         fields,
         batchKey,
+        startedAt: fetchStartedAt,
+        duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
       });
 
       if (addAction) {
@@ -462,6 +482,8 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       fields,
       filters,
       batchKey,
+      startedAt: fetchStartedAt,
+      duration: Date.now() - TEST_INITIAL_TIME - fetchStartedAt,
     });
 
     if (addAction) {

--- a/tests/mocks/serverTableMock.ts
+++ b/tests/mocks/serverTableMock.ts
@@ -142,6 +142,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     | {
         type: 'list';
         itemIds: string[] | undefined;
+        offset: number;
         limit: number | undefined;
         fields: string[] | undefined;
         filters: FilterOperator[] | undefined;
@@ -340,6 +341,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       fetchHistory.push({
         type: 'list',
         itemIds: filterItemIds,
+        offset,
         limit,
         results: 'aborted',
         filters,
@@ -359,6 +361,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       fetchHistory.push({
         type: 'list',
         itemIds: filterItemIds,
+        offset,
         limit,
         results: 'aborted',
         filters,
@@ -379,6 +382,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
       fetchHistory.push({
         type: 'list',
         itemIds: filterItemIds,
+        offset,
         results: 'aborted',
         limit,
         filters,
@@ -442,6 +446,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     fetchHistory.push({
       type: 'list',
       itemIds: filterItemIds,
+      offset,
       limit,
       results: resultItems.map(({ itemId, data }) => ({
         itemId,

--- a/tests/mocks/serverTableMock.ts
+++ b/tests/mocks/serverTableMock.ts
@@ -125,6 +125,7 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
   const defaultFetchDuration = DEFAULT_FETCH_DURATION_MS;
   const nextFetchErrors = new Map<string, FetchErrorConfig>();
   let nextListFetchError: FetchErrorConfig | null = null;
+  const listFetchStartDelays: number[] = [];
 
   // Fetch tracking state
   let numOfStartedFetches = 0;
@@ -323,6 +324,12 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     }
     signal?.addEventListener('abort', onAbort);
 
+    // Apply queued start delay (simulates network latency between requests)
+    const startDelay = listFetchStartDelays.shift();
+    if (startDelay !== undefined && startDelay > 0) {
+      await sleep(startDelay);
+    }
+
     // Calculate max duration from filtered items
     let maxDuration = defaultFetchDuration;
     if (filterItemIds) {
@@ -479,14 +486,24 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
   function setItem(
     itemId: string,
     data: ItemData,
-    options?: { triggerRTUEvent?: boolean },
+    options?: { triggerRTUEvent?: boolean; prepend?: boolean },
   ): void {
     const tableId = getTableId(itemId);
     if (tableId) {
       knownTableIds.add(tableId);
     }
 
-    items.set(itemId, data);
+    if (options?.prepend) {
+      // Rebuild Map with new item first to maintain insertion-order semantics
+      const existing = new Map(items);
+      items.clear();
+      items.set(itemId, data);
+      for (const [key, value] of existing) {
+        if (key !== itemId) items.set(key, value);
+      }
+    } else {
+      items.set(itemId, data);
+    }
 
     const history = itemHistory.get(itemId);
     if (history) {
@@ -797,6 +814,9 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
         itemId,
         typeof error === 'string' ? { message: error } : error,
       );
+    },
+    addListFetchStartDelay(delayMs: number) {
+      listFetchStartDelays.push(delayMs);
     },
     setNextListFetchError(error: FetchErrorConfig | string) {
       nextListFetchError =

--- a/tests/request-schedulling/collection-batch-coalescing.test.ts
+++ b/tests/request-schedulling/collection-batch-coalescing.test.ts
@@ -50,6 +50,7 @@ describe('batch coalescing basic behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2', 'item3']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -124,6 +125,7 @@ describe('batch coalescing basic behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2', 'item3']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -165,6 +167,7 @@ describe('maxBatchSize behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -210,6 +213,7 @@ describe('maxBatchSize behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -218,6 +222,7 @@ describe('maxBatchSize behavior', () => {
         type: 'list'
       - batchKey: '__default__'
         itemIds: ['item3', 'item4']
+        offset: 0
         results:
           - data: { v: 3 }
             itemId: 'item3'
@@ -270,6 +275,7 @@ describe('requests during ongoing fetch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -430,6 +436,7 @@ describe('awaitFetch with batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2', 'item3']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -552,6 +559,7 @@ describe('awaitFetch with batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -590,6 +598,7 @@ describe('priority handling in batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2', 'item3']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -629,6 +638,7 @@ describe('priority handling in batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2', 'item3']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -682,6 +692,7 @@ describe('batch with UI hooks', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'
@@ -757,6 +768,7 @@ describe('duplicate item requests in batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['item1', 'item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'item1'

--- a/tests/request-schedulling/collection-batch-coalescing.test.ts
+++ b/tests/request-schedulling/collection-batch-coalescing.test.ts
@@ -49,6 +49,7 @@ describe('batch coalescing basic behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2', 'item3']
         offset: 0
         results:
@@ -58,6 +59,7 @@ describe('batch coalescing basic behavior', () => {
             itemId: 'item2'
           - data: { v: 3 }
             itemId: 'item3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -88,8 +90,10 @@ describe('batch coalescing basic behavior', () => {
 
     // Single item uses fetchFn, not batch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'item1'
+      - duration: 800
+        itemId: 'item1'
         result: { v: 1 }
+        startedAt: 50
         type: 'fetch'
     `);
 
@@ -124,6 +128,7 @@ describe('batch coalescing basic behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2', 'item3']
         offset: 0
         results:
@@ -133,6 +138,7 @@ describe('batch coalescing basic behavior', () => {
             itemId: 'item2'
           - data: { v: 3 }
             itemId: 'item3'
+        startedAt: 100
         type: 'list'
     `);
 
@@ -166,6 +172,7 @@ describe('maxBatchSize behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2']
         offset: 0
         results:
@@ -173,6 +180,7 @@ describe('maxBatchSize behavior', () => {
             itemId: 'item1'
           - data: { v: 2 }
             itemId: 'item2'
+        startedAt: 0
         type: 'list'
     `);
 
@@ -212,6 +220,7 @@ describe('maxBatchSize behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2']
         offset: 0
         results:
@@ -219,8 +228,10 @@ describe('maxBatchSize behavior', () => {
             itemId: 'item1'
           - data: { v: 2 }
             itemId: 'item2'
+        startedAt: 0
         type: 'list'
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item3', 'item4']
         offset: 0
         results:
@@ -228,6 +239,7 @@ describe('maxBatchSize behavior', () => {
             itemId: 'item3'
           - data: { v: 4 }
             itemId: 'item4'
+        startedAt: 900
         type: 'list'
     `);
 
@@ -274,6 +286,7 @@ describe('requests during ongoing fetch', () => {
     // First list fetch, then item3 as individual fetch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2']
         offset: 0
         results:
@@ -281,9 +294,12 @@ describe('requests during ongoing fetch', () => {
             itemId: 'item1'
           - data: { v: 2 }
             itemId: 'item2'
+        startedAt: 50
         type: 'list'
-      - itemId: 'item3'
+      - duration: 800
+        itemId: 'item3'
         result: { v: 3 }
+        startedAt: 900
         type: 'fetch'
     `);
 
@@ -342,11 +358,15 @@ describe('mutation handling', () => {
     expect(env.apiStore.getItemState('item2')?.data?.value).toEqual({ v: 2 });
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'item2'
+      - duration: 800
+        itemId: 'item2'
         result: { v: 2 }
+        startedAt: 50
         type: 'fetch'
-      - itemId: 'item1'
+      - duration: 800
+        itemId: 'item1'
         result: { v: 100 }
+        startedAt: 1250
         type: 'fetch'
     `);
 
@@ -435,6 +455,7 @@ describe('awaitFetch with batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2', 'item3']
         offset: 0
         results:
@@ -444,6 +465,7 @@ describe('awaitFetch with batch', () => {
             itemId: 'item2'
           - data: { v: 3 }
             itemId: 'item3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -523,8 +545,10 @@ describe('awaitFetch with batch', () => {
 
     // Only one fetch (single item, so uses fetchFn)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'item1'
+      - duration: 800
+        itemId: 'item1'
         result: { v: 1 }
+        startedAt: 50
         type: 'fetch'
     `);
 
@@ -558,6 +582,7 @@ describe('awaitFetch with batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2']
         offset: 0
         results:
@@ -565,6 +590,7 @@ describe('awaitFetch with batch', () => {
             itemId: 'item1'
           - data: { v: 2 }
             itemId: 'item2'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -597,6 +623,7 @@ describe('priority handling in batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2', 'item3']
         offset: 0
         results:
@@ -606,6 +633,7 @@ describe('priority handling in batch', () => {
             itemId: 'item2'
           - data: { v: 3 }
             itemId: 'item3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -637,6 +665,7 @@ describe('priority handling in batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2', 'item3']
         offset: 0
         results:
@@ -646,6 +675,7 @@ describe('priority handling in batch', () => {
             itemId: 'item2'
           - data: { v: 3 }
             itemId: 'item3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -691,6 +721,7 @@ describe('batch with UI hooks', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2']
         offset: 0
         results:
@@ -698,6 +729,7 @@ describe('batch with UI hooks', () => {
             itemId: 'item1'
           - data: { v: 2 }
             itemId: 'item2'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -731,8 +763,10 @@ describe('duplicate item requests in batch', () => {
 
     // Single item, so uses fetchFn not batchFetchFn
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'item1'
+      - duration: 800
+        itemId: 'item1'
         result: { v: 1 }
+        startedAt: 50
         type: 'fetch'
     `);
 
@@ -767,6 +801,7 @@ describe('duplicate item requests in batch', () => {
     // Should have exactly 2 items in batch (deduplicated)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['item1', 'item2']
         offset: 0
         results:
@@ -774,6 +809,7 @@ describe('duplicate item requests in batch', () => {
             itemId: 'item1'
           - data: { v: 2 }
             itemId: 'item2'
+        startedAt: 50
         type: 'list'
     `);
 

--- a/tests/request-schedulling/collection-batch-key-grouping.test.ts
+++ b/tests/request-schedulling/collection-batch-key-grouping.test.ts
@@ -64,6 +64,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
         itemIds: ['api1-item1', 'api1-item2', 'api1-item3']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'api1-item1'
@@ -108,6 +109,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
         itemIds: ['api1-item1', 'api1-item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'api1-item1'
@@ -116,6 +118,7 @@ describe('batch key grouping', () => {
         type: 'list'
       - batchKey: 'api2'
         itemIds: ['api2-item1', 'api2-item2']
+        offset: 0
         results:
           - data: { v: 10 }
             itemId: 'api2-item1'
@@ -161,6 +164,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
         itemIds: ['api1-item1', 'api1-item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'api1-item1'
@@ -217,6 +221,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
         itemIds: ['api1-item1', 'api1-item2']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'api1-item1'
@@ -256,6 +261,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['api1-item1', 'api1-item2', 'api2-item1']
+        offset: 0
         results:
           - data: { v: 1 }
             itemId: 'api1-item1'

--- a/tests/request-schedulling/collection-batch-key-grouping.test.ts
+++ b/tests/request-schedulling/collection-batch-key-grouping.test.ts
@@ -63,6 +63,7 @@ describe('batch key grouping', () => {
     // All items with same batch key should be in one batch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
+        duration: 800
         itemIds: ['api1-item1', 'api1-item2', 'api1-item3']
         offset: 0
         results:
@@ -72,6 +73,7 @@ describe('batch key grouping', () => {
             itemId: 'api1-item2'
           - data: { v: 3 }
             itemId: 'api1-item3'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -108,6 +110,7 @@ describe('batch key grouping', () => {
     // Items should be split into two separate batch fetches
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
+        duration: 800
         itemIds: ['api1-item1', 'api1-item2']
         offset: 0
         results:
@@ -115,8 +118,10 @@ describe('batch key grouping', () => {
             itemId: 'api1-item1'
           - data: { v: 2 }
             itemId: 'api1-item2'
+        startedAt: 50
         type: 'list'
       - batchKey: 'api2'
+        duration: 800
         itemIds: ['api2-item1', 'api2-item2']
         offset: 0
         results:
@@ -124,6 +129,7 @@ describe('batch key grouping', () => {
             itemId: 'api2-item1'
           - data: { v: 20 }
             itemId: 'api2-item2'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -163,6 +169,7 @@ describe('batch key grouping', () => {
     // api1 items batched, api2-item1 individual fetch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
+        duration: 800
         itemIds: ['api1-item1', 'api1-item2']
         offset: 0
         results:
@@ -170,9 +177,12 @@ describe('batch key grouping', () => {
             itemId: 'api1-item1'
           - data: { v: 2 }
             itemId: 'api1-item2'
+        startedAt: 50
         type: 'list'
-      - itemId: 'api2-item1'
+      - duration: 800
+        itemId: 'api2-item1'
         result: { v: 10 }
+        startedAt: 50
         type: 'fetch'
     `);
   });
@@ -220,6 +230,7 @@ describe('batch key grouping', () => {
     // api1 items batched, api2 items fetched individually
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'api1'
+        duration: 800
         itemIds: ['api1-item1', 'api1-item2']
         offset: 0
         results:
@@ -227,12 +238,17 @@ describe('batch key grouping', () => {
             itemId: 'api1-item1'
           - data: { v: 2 }
             itemId: 'api1-item2'
+        startedAt: 50
         type: 'list'
-      - itemId: 'api2-item1'
+      - duration: 800
+        itemId: 'api2-item1'
         result: { v: 10 }
+        startedAt: 50
         type: 'fetch'
-      - itemId: 'api2-item2'
+      - duration: 800
+        itemId: 'api2-item2'
         result: { v: 20 }
+        startedAt: 50
         type: 'fetch'
     `);
   });
@@ -260,6 +276,7 @@ describe('batch key grouping', () => {
     // All items should go into a single batch (default key)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['api1-item1', 'api1-item2', 'api2-item1']
         offset: 0
         results:
@@ -269,6 +286,7 @@ describe('batch key grouping', () => {
             itemId: 'api1-item2'
           - data: { v: 10 }
             itemId: 'api2-item1'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -289,8 +307,10 @@ describe('batch key grouping', () => {
 
     // Single item uses fetchFn, not batchFetchFn
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'api1-item1'
+      - duration: 800
+        itemId: 'api1-item1'
         result: { v: 1 }
+        startedAt: 50
         type: 'fetch'
     `);
   });

--- a/tests/request-schedulling/list-query-item-batch-coalescing.test.ts
+++ b/tests/request-schedulling/list-query-item-batch-coalescing.test.ts
@@ -62,6 +62,7 @@ describe('batch coalescing basic behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table1||3']
         offset: 0
         results:
@@ -71,6 +72,7 @@ describe('batch coalescing basic behavior', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -101,8 +103,10 @@ describe('batch coalescing basic behavior', () => {
 
     // Single item uses fetchFn, not batch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'table1||1'
+      - duration: 800
+        itemId: 'table1||1'
         result: { id: 1, name: 'Item 1' }
+        startedAt: 50
         type: 'fetch'
     `);
 
@@ -134,6 +138,7 @@ describe('batch coalescing basic behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table1||3']
         offset: 0
         results:
@@ -143,6 +148,7 @@ describe('batch coalescing basic behavior', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 100
         type: 'list'
     `);
 
@@ -172,6 +178,7 @@ describe('maxItemBatchSize behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -179,6 +186,7 @@ describe('maxItemBatchSize behavior', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 0
         type: 'list'
     `);
 
@@ -225,6 +233,7 @@ describe('maxItemBatchSize behavior', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -232,8 +241,10 @@ describe('maxItemBatchSize behavior', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 0
         type: 'list'
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||3', 'table1||4']
         offset: 0
         results:
@@ -241,6 +252,7 @@ describe('maxItemBatchSize behavior', () => {
             itemId: 'table1||3'
           - data: { id: 4, name: 'Item 4' }
             itemId: 'table1||4'
+        startedAt: 900
         type: 'list'
     `);
 
@@ -284,6 +296,7 @@ describe('requests during ongoing fetch', () => {
     // First list fetch, then table1||3 as individual fetch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -291,9 +304,12 @@ describe('requests during ongoing fetch', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
-      - itemId: 'table1||3'
+      - duration: 800
+        itemId: 'table1||3'
         result: { id: 3, name: 'Item 3' }
+        startedAt: 900
         type: 'fetch'
     `);
 
@@ -362,11 +378,15 @@ describe('mutation handling', () => {
     });
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'table1||2'
+      - duration: 800
+        itemId: 'table1||2'
         result: { id: 2, name: 'Item 2' }
+        startedAt: 50
         type: 'fetch'
-      - itemId: 'table1||1'
+      - duration: 800
+        itemId: 'table1||1'
         result: { id: 1, name: 'Updated' }
+        startedAt: 1250
         type: 'fetch'
     `);
 
@@ -450,6 +470,7 @@ describe('awaitItemFetch with batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table1||3']
         offset: 0
         results:
@@ -459,6 +480,7 @@ describe('awaitItemFetch with batch', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -532,8 +554,10 @@ describe('awaitItemFetch with batch', () => {
 
     // Only one fetch (single item, so uses fetchFn)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'table1||1'
+      - duration: 800
+        itemId: 'table1||1'
         result: { id: 1, name: 'Item 1' }
+        startedAt: 50
         type: 'fetch'
     `);
 
@@ -564,6 +588,7 @@ describe('awaitItemFetch with batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -571,6 +596,7 @@ describe('awaitItemFetch with batch', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -599,6 +625,7 @@ describe('priority handling in batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table1||3']
         offset: 0
         results:
@@ -608,6 +635,7 @@ describe('priority handling in batch', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -636,6 +664,7 @@ describe('priority handling in batch', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table1||3']
         offset: 0
         results:
@@ -645,6 +674,7 @@ describe('priority handling in batch', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -703,6 +733,7 @@ describe('batch with UI hooks', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -710,6 +741,7 @@ describe('batch with UI hooks', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -740,8 +772,10 @@ describe('duplicate item requests in batch', () => {
 
     // Single item, so uses fetchFn not batchFetchFn
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'table1||1'
+      - duration: 800
+        itemId: 'table1||1'
         result: { id: 1, name: 'Item 1' }
+        startedAt: 50
         type: 'fetch'
     `);
 
@@ -773,6 +807,7 @@ describe('duplicate item requests in batch', () => {
     // Should have exactly 2 items in batch (deduplicated)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -780,6 +815,7 @@ describe('duplicate item requests in batch', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
     `);
 

--- a/tests/request-schedulling/list-query-item-batch-coalescing.test.ts
+++ b/tests/request-schedulling/list-query-item-batch-coalescing.test.ts
@@ -63,6 +63,7 @@ describe('batch coalescing basic behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2', 'table1||3']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -134,6 +135,7 @@ describe('batch coalescing basic behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2', 'table1||3']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -171,6 +173,7 @@ describe('maxItemBatchSize behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -223,6 +226,7 @@ describe('maxItemBatchSize behavior', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -231,6 +235,7 @@ describe('maxItemBatchSize behavior', () => {
         type: 'list'
       - batchKey: '__default__'
         itemIds: ['table1||3', 'table1||4']
+        offset: 0
         results:
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
@@ -280,6 +285,7 @@ describe('requests during ongoing fetch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -445,6 +451,7 @@ describe('awaitItemFetch with batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2', 'table1||3']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -558,6 +565,7 @@ describe('awaitItemFetch with batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -592,6 +600,7 @@ describe('priority handling in batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2', 'table1||3']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -628,6 +637,7 @@ describe('priority handling in batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2', 'table1||3']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -694,6 +704,7 @@ describe('batch with UI hooks', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -763,6 +774,7 @@ describe('duplicate item requests in batch', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'

--- a/tests/request-schedulling/list-query-item-batch-key-grouping.test.ts
+++ b/tests/request-schedulling/list-query-item-batch-key-grouping.test.ts
@@ -72,6 +72,7 @@ describe('batch key grouping', () => {
     // All items with same batch key should be in one batch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table1||3']
         offset: 0
         results:
@@ -81,6 +82,7 @@ describe('batch key grouping', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -111,6 +113,7 @@ describe('batch key grouping', () => {
     // Items should be split into two separate batch fetches by table
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -118,8 +121,10 @@ describe('batch key grouping', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
       - batchKey: 'table2'
+        duration: 800
         itemIds: ['table2||10', 'table2||20']
         offset: 0
         results:
@@ -127,6 +132,7 @@ describe('batch key grouping', () => {
             itemId: 'table2||10'
           - data: { id: 20, name: 'Item 20' }
             itemId: 'table2||20'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -160,6 +166,7 @@ describe('batch key grouping', () => {
     // table1 items batched, table2||10 individual fetch
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -167,9 +174,12 @@ describe('batch key grouping', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
-      - itemId: 'table2||10'
+      - duration: 800
+        itemId: 'table2||10'
         result: { id: 10, name: 'Item 10' }
+        startedAt: 50
         type: 'fetch'
     `);
   });
@@ -212,6 +222,7 @@ describe('batch key grouping', () => {
     // table1 items batched together, table2 items fetched individually
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
+        duration: 800
         itemIds: ['table1||1', 'table1||2']
         offset: 0
         results:
@@ -219,12 +230,17 @@ describe('batch key grouping', () => {
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
-      - itemId: 'table2||10'
+      - duration: 800
+        itemId: 'table2||10'
         result: { id: 10, name: 'Item 10' }
+        startedAt: 50
         type: 'fetch'
-      - itemId: 'table2||20'
+      - duration: 800
+        itemId: 'table2||20'
         result: { id: 20, name: 'Item 20' }
+        startedAt: 50
         type: 'fetch'
     `);
   });
@@ -245,6 +261,7 @@ describe('batch key grouping', () => {
     // All items should go into a single batch (default key)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
+        duration: 800
         itemIds: ['table1||1', 'table1||2', 'table2||10']
         offset: 0
         results:
@@ -254,6 +271,7 @@ describe('batch key grouping', () => {
             itemId: 'table1||2'
           - data: { id: 10, name: 'Item 10' }
             itemId: 'table2||10'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -271,8 +289,10 @@ describe('batch key grouping', () => {
 
     // Single item uses fetchItemFn, not batchFetchItemFn
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - itemId: 'table1||1'
+      - duration: 800
+        itemId: 'table1||1'
         result: { id: 1, name: 'Item 1' }
+        startedAt: 50
         type: 'fetch'
     `);
   });

--- a/tests/request-schedulling/list-query-item-batch-key-grouping.test.ts
+++ b/tests/request-schedulling/list-query-item-batch-key-grouping.test.ts
@@ -73,6 +73,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
         itemIds: ['table1||1', 'table1||2', 'table1||3']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -111,6 +112,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -119,6 +121,7 @@ describe('batch key grouping', () => {
         type: 'list'
       - batchKey: 'table2'
         itemIds: ['table2||10', 'table2||20']
+        offset: 0
         results:
           - data: { id: 10, name: 'Item 10' }
             itemId: 'table2||10'
@@ -158,6 +161,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -209,6 +213,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: 'table1'
         itemIds: ['table1||1', 'table1||2']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -241,6 +246,7 @@ describe('batch key grouping', () => {
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - batchKey: '__default__'
         itemIds: ['table1||1', 'table1||2', 'table2||10']
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'

--- a/tests/request-schedulling/list-query-size-coalescing.test.ts
+++ b/tests/request-schedulling/list-query-size-coalescing.test.ts
@@ -121,7 +121,7 @@ describe('query size coalescing', () => {
     // Advance past coalescing window to start the second fetch
     await vi.advanceTimersByTimeAsync(60);
 
-    // 'loadMore' type wins over 'load' in coalescePayload → status is 'loadingMore'
+    // 'loadMore' type wins over 'load' in size mode coalescePayload → status is 'loadingMore'
     const queryDuringFetch = env.apiStore.getQueryState({ tableId: 'table1' });
     expect(queryDuringFetch?.status).toBe('loadingMore');
 

--- a/tests/request-schedulling/list-query-size-coalescing.test.ts
+++ b/tests/request-schedulling/list-query-size-coalescing.test.ts
@@ -51,6 +51,7 @@ describe('query size coalescing', () => {
     // The fetch should have used size 5 (the max)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 5
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -82,6 +83,7 @@ describe('query size coalescing', () => {
     // The fetch should still use size 5 (the max)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 5
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -130,6 +132,7 @@ describe('query size coalescing', () => {
     // Second fetch should use size 6 (max of loadMore's 6, load's 3)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 3
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -139,6 +142,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||3'
         type: 'list'
       - limit: 6
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -184,6 +188,7 @@ describe('query size coalescing', () => {
     // The fetch should use size 4 (the max of 2, 4, 3)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 4
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -215,6 +220,7 @@ describe('query size coalescing', () => {
     // The fetch should use size 5 (max of default 3, explicit 5)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 5
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -245,6 +251,7 @@ describe('query size coalescing', () => {
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 3
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -289,6 +296,7 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
     // Assert: fetchHistory has 2 entries, second with limit: 5 (max of 5, 2)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 3
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -298,6 +306,7 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
             itemId: 'table1||3'
         type: 'list'
       - limit: 5
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -339,6 +348,7 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
     // First fetch used limit 2, second fetch uses limit 6 (max of 3, 6, 4)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
       - limit: 2
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
@@ -346,6 +356,7 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
             itemId: 'table1||2'
         type: 'list'
       - limit: 6
+        offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'

--- a/tests/request-schedulling/list-query-size-coalescing.test.ts
+++ b/tests/request-schedulling/list-query-size-coalescing.test.ts
@@ -50,7 +50,8 @@ describe('query size coalescing', () => {
 
     // The fetch should have used size 5 (the max)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -63,6 +64,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||4'
           - data: { id: 5, name: 'Item 5' }
             itemId: 'table1||5'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -82,7 +84,8 @@ describe('query size coalescing', () => {
 
     // The fetch should still use size 5 (the max)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -95,6 +98,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||4'
           - data: { id: 5, name: 'Item 5' }
             itemId: 'table1||5'
+        startedAt: 50
         type: 'list'
     `);
   });
@@ -131,7 +135,8 @@ describe('query size coalescing', () => {
 
     // Second fetch should use size 6 (max of loadMore's 6, load's 3)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 3
+      - duration: 800
+        limit: 3
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -140,8 +145,10 @@ describe('query size coalescing', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
-      - limit: 6
+      - duration: 800
+        limit: 6
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -156,6 +163,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||5'
           - data: { id: 6, name: 'Item 6' }
             itemId: 'table1||6'
+        startedAt: 900
         type: 'list'
     `);
 
@@ -187,7 +195,8 @@ describe('query size coalescing', () => {
 
     // The fetch should use size 4 (the max of 2, 4, 3)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 4
+      - duration: 800
+        limit: 4
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -198,6 +207,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||3'
           - data: { id: 4, name: 'Item 4' }
             itemId: 'table1||4'
+        startedAt: 100
         type: 'list'
     `);
 
@@ -219,7 +229,8 @@ describe('query size coalescing', () => {
 
     // The fetch should use size 5 (max of default 3, explicit 5)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -232,6 +243,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||4'
           - data: { id: 5, name: 'Item 5' }
             itemId: 'table1||5'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -250,7 +262,8 @@ describe('query size coalescing', () => {
     await flushAllTimers();
 
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 3
+      - duration: 800
+        limit: 3
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -259,6 +272,7 @@ describe('query size coalescing', () => {
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
     `);
 
@@ -295,7 +309,8 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
 
     // Assert: fetchHistory has 2 entries, second with limit: 5 (max of 5, 2)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 3
+      - duration: 800
+        limit: 3
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -304,8 +319,10 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
             itemId: 'table1||2'
           - data: { id: 3, name: 'Item 3' }
             itemId: 'table1||3'
+        startedAt: 50
         type: 'list'
-      - limit: 5
+      - duration: 800
+        limit: 5
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -318,6 +335,7 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
             itemId: 'table1||4'
           - data: { id: 5, name: 'Item 5' }
             itemId: 'table1||5'
+        startedAt: 900
         type: 'list'
     `);
   });
@@ -347,15 +365,18 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
 
     // First fetch used limit 2, second fetch uses limit 6 (max of 3, 6, 4)
     expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
-      - limit: 2
+      - duration: 800
+        limit: 2
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
             itemId: 'table1||1'
           - data: { id: 2, name: 'Item 2' }
             itemId: 'table1||2'
+        startedAt: 50
         type: 'list'
-      - limit: 6
+      - duration: 800
+        limit: 6
         offset: 0
         results:
           - data: { id: 1, name: 'Item 1' }
@@ -370,6 +391,7 @@ describe('size coalescing in scheduledRequests during active fetch (Call Site 2)
             itemId: 'table1||5'
           - data: { id: 6, name: 'Item 6' }
             itemId: 'table1||6'
+        startedAt: 900
         type: 'list'
     `);
 


### PR DESCRIPTION
## Summary

Introduce offset-based pagination option, chunked invalidation for large refetches, and coalescing improvements. Update internals to normalize list fetches and adjust store API and tests to support offset/limit semantics and parallel chunking.
### Changes

- Add OffsetPaginationConfig and support offset/limit QueryFetchPayload across the list query store.
- Introduce normalizedFetchListFn and normalize fetchListFn in createListQueryStore to support both size (legacy) and offset modes.
- Implement chunked invalidation: split large invalidations into parallel/limited chunks (maxInvalidationLimit, maxParallel) in executeQueryFetch, preserving deterministic ordering and deduplicating overlapping items.
- Coalesce load/loadMore payloads by merging offset/limit ranges so coalesced requests cover combined ranges and 'loadMore' wins when appropriate.
- Make list fetch application append-aware: only append when loadMore starts after head (offset > 0); otherwise replace list to avoid stale head items.
- Update test environment and server mock to record offset, startedAt, duration and support start delays and prepend semantics; add extensive offset-pagination tests and update many snapshots.
- Adjust types and public API: conditional ListQueryStoreOptions for size vs offset modes, updated QueryFetchPayload shape, and minor utility/type changes.
- Documentation (AGENTS.md) and many tests updated to use new utilities and to reflect the new request shape and timings.

### Testing Notes

Run the full test suite (vitest) — many tests and snapshots were updated. Key behaviors to verify manually or via tests:  - loadMore fetches only the new page (offset/limit) and appends without duplicates when items shift.  - Chunked invalidation splits large refetch ranges into correct offset/limit chunks, respects maxParallel, preserves deterministic ordering in the final list, and fails the whole query when a chunk errors.  - Coalesced load + loadMore merges ranges correctly (min offset, max end) and selects append vs replace consistently.  - awaitListQueryFetch preserves proper item order even when chunks resolve out-of-order.  - Ensure backward compatibility: size-mode (legacy) fetchListFn still works when offsetPagination is not provided.  - Spot-check updated snapshots showing offset, duration, and startedAt fields. If you have custom fetchListFn types, update to the conditional signature when enabling offsetPagination.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
