### PR TITLE
Revalidate stores on window focus; adapt coalescing & throttles

### DIFF
--- a/.claude/skills/review-tests/SKILL.md
+++ b/.claude/skills/review-tests/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: review-tests
+description: Review automated tests for correctness, reliability, maintainability, and coverage gaps. Use when asked to review tests in a PR, audit flaky tests, evaluate whether tests are meaningful, or identify missing scenarios in Vitest/TypeScript test suites.
+---
+
+# Review Tests
+
+Perform a test-focused code review. Prioritize bugs, false confidence risks, flaky behavior, and missing coverage over style nits.
+
+## Review Workflow
+
+1. Define scope and intent.
+2. Evaluate behavioral coverage.
+3. Validate assertion quality and failure signals.
+4. Check determinism and flakiness risk.
+5. Evaluate readability and long-term maintenance.
+6. Report findings ordered by severity.
+
+## 1) Define Scope And Intent
+
+- Identify the behavior each test file intends to protect.
+- Map core production paths to explicit tests.
+- Flag tests that assert implementation details without protecting behavior.
+
+## 2) Evaluate Behavioral Coverage
+
+- Check happy path, edge cases, error paths, and state transitions.
+- Check that contract changes would fail tests in useful ways.
+- Flag missing cases where production code can regress silently.
+
+## 3) Validate Assertion Quality
+
+- Prefer assertions on user-visible or API-visible outcomes.
+- Flag weak assertions (for example, only checking call count without verifying effect).
+- Check negative assertions and error assertions for precision.
+- Ensure snapshots are readable and scoped to meaningful behavior.
+
+## 4) Check Determinism And Flakiness
+
+- Flag reliance on real time, random values, network race timing, or global mutable state.
+- Ensure async behavior is awaited and timers are controlled.
+- Flag tests that depend on execution order or leaked state between tests.
+
+## 5) Evaluate Maintainability
+
+- Prefer focused tests with clear setup and intent.
+- Flag test names that are wrong, vague, or misleading relative to the actual assertions.
+- Flag brittle fixtures, duplicated setup, and opaque data builders.
+- Prefer human-readable snapshots over dense object comparisons.
+
+## 6) Report Findings
+
+- Report findings first, ordered by severity.
+- Include file and line references for each issue.
+- Explain risk, expected impact, and the minimum fix.
+- Explicitly state when no findings were identified and list remaining testing gaps.
+
+## Reference
+
+- Use `references/test-review-checklist.md` as a compact scoring checklist during reviews.

--- a/.claude/skills/review-tests/agents/openai.yaml
+++ b/.claude/skills/review-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Review Tests'
+  short_description: 'Review test quality and catch gaps'
+  default_prompt: 'Use $review-tests to review these tests for correctness, flakiness, and missing coverage with prioritized findings.'

--- a/.claude/skills/review-tests/references/test-review-checklist.md
+++ b/.claude/skills/review-tests/references/test-review-checklist.md
@@ -1,0 +1,36 @@
+# Test Review Checklist
+
+Use this checklist to evaluate test quality quickly and consistently.
+
+## Correctness
+
+- Does each test verify externally visible behavior?
+- Would a real regression fail this test?
+- Are failure expectations specific (error type/message/state), not generic?
+
+## Coverage
+
+- Are success, failure, and edge cases covered?
+- Are critical state transitions covered?
+- Are invalid inputs and boundary conditions exercised?
+
+## Reliability
+
+- Is async behavior fully awaited?
+- Are timers controlled with fake timers when timing matters?
+- Does the test avoid nondeterminism (wall clock, randomness, race timing)?
+- Does setup/teardown prevent shared-state leakage?
+
+## Maintainability
+
+- Is setup minimal and intent obvious?
+- Does each test name accurately describe the behavior it verifies?
+- Is duplication low and fixture data readable?
+- Are snapshots small, intentional, and understandable?
+
+## Severity Guide
+
+- P0: Tests give false confidence on critical behavior or mask production bugs.
+- P1: Important behavior is untested or tests are likely flaky.
+- P2: Tests are brittle, unclear, or hard to maintain.
+- P3: Minor readability or consistency issue with low risk.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@evtmitter/react": "^0.1.0",
+    "@ls-stack/browser-utils": "^0.3.0",
     "@ls-stack/react-utils": "^0.9.0",
     "@ls-stack/utils": "^3.65.0",
     "evtmitter": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@evtmitter/react':
         specifier: ^0.1.0
         version: 0.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@ls-stack/browser-utils':
+        specifier: ^0.3.0
+        version: 0.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@ls-stack/react-utils':
         specifier: ^0.9.0
         version: 0.9.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)

--- a/src/collectionStore/collectionStore.ts
+++ b/src/collectionStore/collectionStore.ts
@@ -1,3 +1,4 @@
+import { isWindowFocused, onWindowFocus } from '@ls-stack/browser-utils/window';
 import { filterAndMap } from '@ls-stack/utils/arrayUtils';
 import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { __LEGIT_ANY__ } from '@ls-stack/utils/saferTyping';
@@ -117,7 +118,12 @@ export type CollectionStoreOptions<
   lowPriorityThrottleMs: number;
   baseCoalescingWindowMs: number;
   mediumPriorityDelayMs?: number;
-  dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+  dynamicRealtimeThrottleMs?: (params: {
+    lastFetchDuration: number;
+    windowIsNotFocused: boolean;
+  }) => number;
+  revalidateOnWindowFocus?: boolean | (() => boolean);
+  backgroundCoalescingWindowMultiplier: number;
   onInvalidate?: OnCollectionItemInvalidate<ItemState, ItemPayload>;
   onSchedulerEvent?: (event: RequestSchedulerEvents) => void;
   onMutationError?: (
@@ -159,6 +165,8 @@ export function createCollectionStore<
   errorNormalizer,
   mediumPriorityDelayMs,
   dynamicRealtimeThrottleMs,
+  revalidateOnWindowFocus,
+  backgroundCoalescingWindowMultiplier,
   getCollectionItemKey: filterCollectionItemObjKey,
   onInvalidate,
   onSchedulerEvent,
@@ -228,6 +236,17 @@ export function createCollectionStore<
 
   const events = evtmitter<CollectionStoreEvents>();
 
+  const wrappedDynamicRealtimeThrottleMs = dynamicRealtimeThrottleMs
+    ? (lastFetchDuration: number) =>
+        dynamicRealtimeThrottleMs({
+          lastFetchDuration,
+          windowIsNotFocused: !isWindowFocused(),
+        })
+    : undefined;
+
+  const getCoalescingWindowMultiplier = (): number =>
+    !isWindowFocused() ? backgroundCoalescingWindowMultiplier : 1;
+
   const useBatchSchedulers = !!batchFetchFn;
 
   const batchKeySchedulers = new Map<string, RequestScheduler<ItemPayload>>();
@@ -246,12 +265,13 @@ export function createCollectionStore<
         },
         lowPriorityThrottleMs,
         baseCoalescingWindowMs,
-        dynamicRealtimeThrottleMs,
+        dynamicRealtimeThrottleMs: wrappedDynamicRealtimeThrottleMs,
         mediumPriorityDelayMs,
         maxBatchSize,
         on: onSchedulerEvent,
         initialLastFetchStartTime: testOptions?.initialLastFetchStartTime,
         usesRealTimeUpdates,
+        getCoalescingWindowMultiplier,
       });
       batchKeySchedulers.set(batchKey, scheduler);
     }
@@ -275,11 +295,12 @@ export function createCollectionStore<
         },
         lowPriorityThrottleMs,
         baseCoalescingWindowMs,
-        dynamicRealtimeThrottleMs,
+        dynamicRealtimeThrottleMs: wrappedDynamicRealtimeThrottleMs,
         mediumPriorityDelayMs,
         on: onSchedulerEvent,
         initialLastFetchStartTime: testOptions?.initialLastFetchStartTime,
         usesRealTimeUpdates,
+        getCoalescingWindowMultiplier,
       });
       perItemSchedulers.set(itemKey, itemScheduler);
     }
@@ -720,6 +741,29 @@ export function createCollectionStore<
     });
   }
 
+  // Set up window focus listener for non-realtime stores
+  let cleanupFocusListener: (() => void) | null = null;
+
+  function setupFocusListener() {
+    cleanupFocusListener?.();
+    cleanupFocusListener = null;
+
+    if (!revalidateOnWindowFocus || usesRealTimeUpdates) return;
+
+    cleanupFocusListener = onWindowFocus(() => {
+      const enabled =
+        typeof revalidateOnWindowFocus === 'function'
+          ? revalidateOnWindowFocus()
+          : revalidateOnWindowFocus;
+
+      if (enabled) {
+        invalidateItem(() => true, 'lowPriority');
+      }
+    });
+  }
+
+  setupFocusListener();
+
   function reset() {
     for (const scheduler of batchKeySchedulers.values()) {
       scheduler.reset();
@@ -734,6 +778,7 @@ export function createCollectionStore<
     invalidationWasTriggered.clear();
 
     store.setState({});
+    setupFocusListener();
   }
 
   return {

--- a/src/documentStore.ts
+++ b/src/documentStore.ts
@@ -1,4 +1,5 @@
 import { useOnEvtmitterEvent } from '@evtmitter/react';
+import { isWindowFocused, onWindowFocus } from '@ls-stack/browser-utils/window';
 import { deepEqual } from '@ls-stack/utils/deepEqual';
 import {
   __LEGIT_CAST__,
@@ -60,7 +61,12 @@ export type DocumentStoreOptions<State extends ValidStoreState> = {
   errorNormalizer: (exception: Error) => StoreError;
   lowPriorityThrottleMs: number;
   baseCoalescingWindowMs: number;
-  dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+  dynamicRealtimeThrottleMs?: (params: {
+    lastFetchDuration: number;
+    windowIsNotFocused: boolean;
+  }) => number;
+  revalidateOnWindowFocus?: boolean | (() => boolean);
+  backgroundCoalescingWindowMultiplier: number;
   mediumPriorityDelayMs?: number;
   onSchedulerEvent?: (event: RequestSchedulerEvents) => void;
   onMutationError?: (
@@ -93,6 +99,8 @@ export function createDocumentStore<State extends ValidStoreState>({
   lowPriorityThrottleMs,
   baseCoalescingWindowMs,
   dynamicRealtimeThrottleMs,
+  revalidateOnWindowFocus,
+  backgroundCoalescingWindowMultiplier,
   mediumPriorityDelayMs,
   onSchedulerEvent,
   onMutationError,
@@ -191,6 +199,14 @@ export function createDocumentStore<State extends ValidStoreState>({
     }
   }
 
+  const wrappedDynamicRealtimeThrottleMs = dynamicRealtimeThrottleMs
+    ? (lastFetchDuration: number) =>
+        dynamicRealtimeThrottleMs({
+          lastFetchDuration,
+          windowIsNotFocused: !isWindowFocused(),
+        })
+    : undefined;
+
   // Scheduler with batch-aware fetchFn (but we always use single item)
   const scheduler = new RequestScheduler<null>({
     fetchFn: async (
@@ -207,12 +223,37 @@ export function createDocumentStore<State extends ValidStoreState>({
     },
     lowPriorityThrottleMs,
     baseCoalescingWindowMs,
-    dynamicRealtimeThrottleMs,
+    dynamicRealtimeThrottleMs: wrappedDynamicRealtimeThrottleMs,
     mediumPriorityDelayMs,
     on: onSchedulerEvent,
     initialLastFetchStartTime: testOptions?.initialLastFetchStartTime,
     usesRealTimeUpdates,
+    getCoalescingWindowMultiplier: () =>
+      !isWindowFocused() ? backgroundCoalescingWindowMultiplier : 1,
   });
+
+  // Set up window focus listener for non-realtime stores
+  let cleanupFocusListener: (() => void) | null = null;
+
+  function setupFocusListener() {
+    cleanupFocusListener?.();
+    cleanupFocusListener = null;
+
+    if (!revalidateOnWindowFocus || usesRealTimeUpdates) return;
+
+    cleanupFocusListener = onWindowFocus(() => {
+      const enabled =
+        typeof revalidateOnWindowFocus === 'function'
+          ? revalidateOnWindowFocus()
+          : revalidateOnWindowFocus;
+
+      if (enabled) {
+        invalidateData('lowPriority');
+      }
+    });
+  }
+
+  setupFocusListener();
 
   function scheduleFetch(
     fetchType: FetchType,
@@ -310,6 +351,7 @@ export function createDocumentStore<State extends ValidStoreState>({
       status: 'idle',
       refetchOnMount: 'lowPriority',
     });
+    setupFocusListener();
   }
 
   function startMutation(): () => boolean {

--- a/src/listQueryStore/createFetchApi.ts
+++ b/src/listQueryStore/createFetchApi.ts
@@ -83,6 +83,7 @@ export type CreateFetchApiOptions<
   baseCoalescingWindowMs: number;
   mediumPriorityDelayMs?: number;
   dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+  getCoalescingWindowMultiplier?: () => number;
   onSchedulerEvent?: (event: RequestSchedulerEvents) => void;
   usesRealTimeUpdates: boolean;
   defaultQuerySize: number;
@@ -113,6 +114,7 @@ export function createFetchApi<
   baseCoalescingWindowMs,
   mediumPriorityDelayMs,
   dynamicRealtimeThrottleMs,
+  getCoalescingWindowMultiplier,
   onSchedulerEvent,
   usesRealTimeUpdates,
   defaultQuerySize,
@@ -237,6 +239,7 @@ export function createFetchApi<
           };
         },
         usesRealTimeUpdates,
+        getCoalescingWindowMultiplier,
       });
       querySchedulers.set(queryKey, scheduler);
     }
@@ -309,6 +312,7 @@ export function createFetchApi<
         initialLastFetchStartTime,
         coalescePayload: coalesceItemFetchPayload,
         usesRealTimeUpdates,
+        getCoalescingWindowMultiplier,
       });
       batchKeySchedulers.set(batchKey, scheduler);
     }
@@ -401,6 +405,7 @@ export function createFetchApi<
         initialLastFetchStartTime,
         coalescePayload: coalesceItemFetchPayload,
         usesRealTimeUpdates,
+        getCoalescingWindowMultiplier,
       });
       perItemSchedulers.set(itemKey, scheduler);
     }

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -1,3 +1,4 @@
+import { isWindowFocused, onWindowFocus } from '@ls-stack/browser-utils/window';
 import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { evtmitter } from 'evtmitter';
 import { Store } from 't-state';
@@ -7,13 +8,13 @@ import {
   ScheduleFetchOptions,
   ScheduleFetchResults,
 } from '../requestScheduler';
+import { type BlockWindowCloseHandler } from '../utils/performMutation';
 import {
   StoreError,
   StoreFetchError,
   ValidPayload,
   ValidStoreState,
 } from '../utils/storeShared';
-import { type BlockWindowCloseHandler } from '../utils/performMutation';
 import { createFetchApi } from './createFetchApi';
 import { createMutationApi } from './createMutationApi';
 import {
@@ -128,7 +129,12 @@ type ListQueryStoreOptionsBase<
   lowPriorityThrottleMs: number;
   baseCoalescingWindowMs: number;
   mediumPriorityDelayMs?: number;
-  dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+  dynamicRealtimeThrottleMs?: (params: {
+    lastFetchDuration: number;
+    windowIsNotFocused: boolean;
+  }) => number;
+  revalidateOnWindowFocus?: boolean | (() => boolean);
+  backgroundCoalescingWindowMultiplier: number;
   optimisticListUpdates?: OptimisticListUpdate<
     ItemState,
     QueryPayload,
@@ -203,6 +209,8 @@ export function createListQueryStore<
     baseCoalescingWindowMs,
     mediumPriorityDelayMs,
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier,
     optimisticListUpdates,
     onInvalidateQuery,
     onInvalidateItem,
@@ -432,6 +440,17 @@ export function createListQueryStore<
 
   const events = evtmitter<ListQueryStoreEvents>();
 
+  const wrappedDynamicRealtimeThrottleMs = dynamicRealtimeThrottleMs
+    ? (lastFetchDuration: number) =>
+        dynamicRealtimeThrottleMs({
+          lastFetchDuration,
+          windowIsNotFocused: !isWindowFocused(),
+        })
+    : undefined;
+
+  const getCoalescingWindowMultiplier = (): number =>
+    !isWindowFocused() ? backgroundCoalescingWindowMultiplier : 1;
+
   const {
     getQueryState,
     getQueriesKeyArray,
@@ -460,7 +479,8 @@ export function createListQueryStore<
     lowPriorityThrottleMs,
     baseCoalescingWindowMs,
     mediumPriorityDelayMs,
-    dynamicRealtimeThrottleMs,
+    dynamicRealtimeThrottleMs: wrappedDynamicRealtimeThrottleMs,
+    getCoalescingWindowMultiplier,
     onSchedulerEvent,
     usesRealTimeUpdates,
     defaultQuerySize,
@@ -638,6 +658,33 @@ export function createListQueryStore<
     );
   }
 
+  // Set up window focus listener for non-realtime stores
+  let cleanupFocusListener: (() => void) | null = null;
+
+  function setupFocusListener() {
+    cleanupFocusListener?.();
+    cleanupFocusListener = null;
+
+    if (!revalidateOnWindowFocus || usesRealTimeUpdates) return;
+
+    cleanupFocusListener = onWindowFocus(() => {
+      const enabled =
+        typeof revalidateOnWindowFocus === 'function'
+          ? revalidateOnWindowFocus()
+          : revalidateOnWindowFocus;
+
+      if (enabled) {
+        invalidateQueryAndItems({
+          queryPayload: () => true,
+          itemPayload: () => true,
+          type: 'lowPriority',
+        });
+      }
+    });
+  }
+
+  setupFocusListener();
+
   function reset() {
     resetSchedulers();
     resetInvalidationTracking();
@@ -649,6 +696,7 @@ export function createListQueryStore<
       itemLoadedFields: {},
       itemFieldInvalidationFields: {},
     });
+    setupFocusListener();
   }
 
   function scheduleListQueryFetchApiImpl(

--- a/src/requestScheduler.ts
+++ b/src/requestScheduler.ts
@@ -132,6 +132,9 @@ export type RequestSchedulerOptions<T> = {
   coalescePayload?: (existing: T, incoming: T) => T;
   /** for validation of realtimeUpdate fetch type */
   usesRealTimeUpdates: boolean;
+  /** Returns a multiplier for the coalescing window duration.
+   * E.g. return 3 when tab is in background to reduce network pressure. */
+  getCoalescingWindowMultiplier?: () => number;
 };
 
 export type ScheduleFetchOptions = {
@@ -170,6 +173,7 @@ export class RequestScheduler<T> {
     | ((existing: T, incoming: T) => T)
     | undefined;
   private readonly usesRealTimeUpdates: boolean;
+  private readonly getCoalescingWindowMultiplier: (() => number) | undefined;
 
   private state: SchedulerState<T>;
 
@@ -183,6 +187,7 @@ export class RequestScheduler<T> {
     this.maxBatchSize = options.maxBatchSize;
     this.coalescePayload = options.coalescePayload;
     this.usesRealTimeUpdates = options.usesRealTimeUpdates;
+    this.getCoalescingWindowMultiplier = options.getCoalescingWindowMultiplier;
 
     this.state = this.createInitialState();
 
@@ -459,6 +464,15 @@ export class RequestScheduler<T> {
   }
 
   // ==========================================================================
+  // Coalescing Window
+  // ==========================================================================
+
+  private getEffectiveCoalescingWindowMs(): number {
+    const multiplier = this.getCoalescingWindowMultiplier?.() ?? 1;
+    return this.baseCoalescingWindowMs * multiplier;
+  }
+
+  // ==========================================================================
   // Phase Transitions
   // ==========================================================================
 
@@ -480,7 +494,7 @@ export class RequestScheduler<T> {
 
     const timeoutId = setTimeout(() => {
       this.onCoalescingTimeout();
-    }, this.baseCoalescingWindowMs);
+    }, this.getEffectiveCoalescingWindowMs());
 
     this.state.phase = {
       type: 'coalescing',
@@ -834,7 +848,7 @@ export class RequestScheduler<T> {
     // Start coalescing window with scheduled requests
     const timeoutId = setTimeout(() => {
       this.onCoalescingTimeout();
-    }, this.baseCoalescingWindowMs);
+    }, this.getEffectiveCoalescingWindowMs());
 
     this.state.phase = {
       type: 'coalescing',

--- a/tests/hooks/document-hooks-2.test.tsx
+++ b/tests/hooks/document-hooks-2.test.tsx
@@ -253,7 +253,7 @@ test('mounting after medium priority invalidation on idle store loads data', asy
 
   expect(env.serverMock.numOfFinishedFetches).toBe(1);
 
-  expect(env.serverMock.fetches[0]?.startTime).toBe(10);
+  expect(env.serverMock.fetchHistory[0]?.startTime).toBe(10);
 
   expect(renders.snapshot).toMatchInlineSnapshot(`
     "
@@ -289,7 +289,7 @@ test('mounting after medium priority invalidation on loaded store triggers a med
 
   expect(env.serverMock.numOfFinishedFetches).toBe(1);
 
-  expect(env.serverMock.fetches[0]?.startTime).toBe(300 + 10);
+  expect(env.serverMock.fetchHistory[0]?.startTime).toBe(300 + 10);
 
   expect(renders.snapshot).toMatchInlineSnapshot(`
     "

--- a/tests/hooks/document-hooks.test.tsx
+++ b/tests/hooks/document-hooks.test.tsx
@@ -637,7 +637,7 @@ test('RTU update works', async () => {
     "
   `);
 
-  const secondFetch = env.serverMock.fetches[1];
+  const secondFetch = env.serverMock.fetchHistory[1];
 
   expect(secondFetch).toBeDefined();
   expect(

--- a/tests/hooks/list-query-hooks-mutations.test.tsx
+++ b/tests/hooks/list-query-hooks-mutations.test.tsx
@@ -625,8 +625,8 @@ test('RTU throttling', async () => {
   const env = createListQueryStoreTestEnv(initialServerData, {
     testScenario: { loaded: { tables: ['users'] } },
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs(lastDuration) {
-      if (lastDuration < 500) return 500;
+    dynamicRealtimeThrottleMs({ lastFetchDuration }) {
+      if (lastFetchDuration < 500) return 500;
 
       return 1000;
     },

--- a/tests/mocks/collectionStoreTestEnv.ts
+++ b/tests/mocks/collectionStoreTestEnv.ts
@@ -5,6 +5,10 @@ import {
 } from '../../src/collectionStore/collectionStore';
 import type { FetchType } from '../../src/requestScheduler';
 import type { BlockWindowCloseHandler } from '../../src/utils/performMutation';
+import {
+  simulateWindowBlur,
+  simulateWindowFocus,
+} from '../utils/genericTestUtils';
 import { createServerTableMock } from './serverTableMock';
 import {
   createActionTracker,
@@ -28,7 +32,12 @@ export type CollectionStoreTestScenario<D extends Record<string, unknown>> =
   | { loadedWithStaleData: Record<string, D> };
 
 export type CollectionStoreTestEnvOptions<D extends Record<string, unknown>> = {
-  dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+  dynamicRealtimeThrottleMs?: (params: {
+    lastFetchDuration: number;
+    windowIsNotFocused: boolean;
+  }) => number;
+  revalidateOnWindowFocus?: boolean | (() => boolean);
+  backgroundCoalescingWindowMultiplier?: number;
   baseCoalescingWindowMs?: number;
   mediumPriorityDelayMs?: number;
   /** Enable batch fetch mode - uses batchFetchFn instead of per-item fetchFn */
@@ -46,6 +55,8 @@ export function createCollectionStoreTestEnv<D extends Record<string, unknown>>(
   serverInitialData: Record<string, D>,
   {
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier = 1,
     baseCoalescingWindowMs = 10,
     mediumPriorityDelayMs,
     useBatchFetch,
@@ -154,6 +165,8 @@ export function createCollectionStoreTestEnv<D extends Record<string, unknown>>(
     batchFetchFn: useBatchFetch ? batchFetchFn : undefined,
     usesRealTimeUpdates,
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier,
     mediumPriorityDelayMs,
     blockWindowClose: blockWindowClose ?? null,
     '~test': testOptions,
@@ -250,6 +263,14 @@ export function createCollectionStoreTestEnv<D extends Record<string, unknown>>(
     },
     get timelineString() {
       return getTimelineString();
+    },
+    simulateWindowFocus() {
+      addAction('window-focused');
+      simulateWindowFocus();
+    },
+    simulateWindowBlur() {
+      addAction('window-blurred');
+      simulateWindowBlur();
     },
   };
 }

--- a/tests/mocks/documentStoreTestEnv.ts
+++ b/tests/mocks/documentStoreTestEnv.ts
@@ -4,6 +4,10 @@ import type { FetchType } from '../../src/requestScheduler';
 import type { BlockWindowCloseHandler } from '../../src/utils/performMutation';
 import { createServerMock, type FetchErrorConfig } from './serverMock';
 import {
+  simulateWindowBlur,
+  simulateWindowFocus,
+} from '../utils/genericTestUtils';
+import {
   createActionTracker,
   createEmojiCyclers,
   createUITracker,
@@ -23,7 +27,12 @@ export type DocumentStoreTestScenario<D> =
   | { loadedWithStaleData: D };
 
 export type DocumentStoreTestEnvOptions<D> = {
-  dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+  dynamicRealtimeThrottleMs?: (params: {
+    lastFetchDuration: number;
+    windowIsNotFocused: boolean;
+  }) => number;
+  revalidateOnWindowFocus?: boolean | (() => boolean);
+  backgroundCoalescingWindowMultiplier?: number;
   baseCoalescingWindowMs?: number;
   lowPriorityThrottleMs?: number;
   mediumPriorityDelayMs?: number;
@@ -36,6 +45,8 @@ export function createDocumentStoreTestEnv<D>(
   serverInitialData: D,
   {
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier = 1,
     baseCoalescingWindowMs = 10,
     lowPriorityThrottleMs = 200,
     mediumPriorityDelayMs,
@@ -72,6 +83,8 @@ export function createDocumentStoreTestEnv<D>(
     },
     usesRealTimeUpdates,
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier,
     mediumPriorityDelayMs,
     blockWindowClose: blockWindowClose ?? null,
     '~test': testOptions,
@@ -194,6 +207,14 @@ export function createDocumentStoreTestEnv<D>(
     },
     setServerData(value: D) {
       serverMock.setData(value);
+    },
+    simulateWindowFocus() {
+      addAction('window-focused');
+      simulateWindowFocus();
+    },
+    simulateWindowBlur() {
+      addAction('window-blurred');
+      simulateWindowBlur();
     },
   };
 }

--- a/tests/mocks/listQueryStoreTestEnv.ts
+++ b/tests/mocks/listQueryStoreTestEnv.ts
@@ -11,6 +11,10 @@ import type {
 } from '../../src/listQueryStore/types';
 import type { FetchType } from '../../src/requestScheduler';
 import type { BlockWindowCloseHandler } from '../../src/utils/performMutation';
+import {
+  simulateWindowBlur,
+  simulateWindowFocus,
+} from '../utils/genericTestUtils';
 import { createServerTableMock, type FilterOperator } from './serverTableMock';
 import {
   createActionTracker,
@@ -68,6 +72,8 @@ export function createListQueryStoreTestEnv<
   serverInitialData: Tables<TRow>,
   {
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier,
     baseCoalescingWindowMs = 10,
     mediumPriorityDelayMs,
     defaultQuerySize = 50,
@@ -83,7 +89,12 @@ export function createListQueryStoreTestEnv<
     offsetPagination,
     blockWindowClose,
   }: {
-    dynamicRealtimeThrottleMs?: (lastFetchDuration: number) => number;
+    dynamicRealtimeThrottleMs?: (params: {
+      lastFetchDuration: number;
+      windowIsNotFocused: boolean;
+    }) => number;
+    revalidateOnWindowFocus?: boolean | (() => boolean);
+    backgroundCoalescingWindowMultiplier?: number;
     baseCoalescingWindowMs?: number;
     mediumPriorityDelayMs?: number;
     defaultQuerySize?: number;
@@ -238,6 +249,8 @@ export function createListQueryStoreTestEnv<
     lowPriorityThrottleMs,
     baseCoalescingWindowMs,
     dynamicRealtimeThrottleMs,
+    revalidateOnWindowFocus,
+    backgroundCoalescingWindowMultiplier,
     mediumPriorityDelayMs,
     defaultQuerySize,
     usesRealTimeUpdates,
@@ -497,6 +510,14 @@ export function createListQueryStoreTestEnv<
     },
     get timelineString() {
       return getTimelineString();
+    },
+    simulateWindowFocus() {
+      addAction('window-focused');
+      simulateWindowFocus();
+    },
+    simulateWindowBlur() {
+      addAction('window-blurred');
+      simulateWindowBlur();
     },
   };
 }

--- a/tests/mocks/serverMock.ts
+++ b/tests/mocks/serverMock.ts
@@ -45,7 +45,7 @@ export function createServerMock<Data>(
   let numOfStartedFetches = 0;
   let numOfFinishedFetches = 0;
   let fetchIdCounter = 0;
-  const fetches: FetchHistoryEntry<Data>[] = [];
+  const fetchHistory: FetchHistoryEntry<Data>[] = [];
 
   function getFetchId() {
     return notNullish(fetchEmojis[fetchIdCounter++ % fetchEmojis.length]);
@@ -149,7 +149,7 @@ export function createServerMock<Data>(
             })
           : new Error(nextFetchError.message);
 
-        fetches.push({
+        fetchHistory.push({
           id: fetchId,
           startTime,
           endTime,
@@ -176,7 +176,7 @@ export function createServerMock<Data>(
       if (signal?.aborted) {
         onAbort();
         const endTime = Date.now() - TEST_INITIAL_TIME;
-        fetches.push({
+        fetchHistory.push({
           id: fetchId,
           startTime,
           endTime,
@@ -194,7 +194,7 @@ export function createServerMock<Data>(
       }
 
       const endTime = Date.now() - TEST_INITIAL_TIME;
-      fetches.push({
+      fetchHistory.push({
         id: fetchId,
         startTime,
         endTime,
@@ -222,6 +222,6 @@ export function createServerMock<Data>(
     get numOfFinishedFetches() {
       return numOfFinishedFetches;
     },
-    fetches,
+    fetchHistory,
   };
 }

--- a/tests/mocks/serverTableMock.ts
+++ b/tests/mocks/serverTableMock.ts
@@ -857,8 +857,6 @@ export function createServerTableMock<ItemData extends Record<string, unknown>>(
     get numOfFinishedFetches() {
       return numOfFinishedFetches;
     },
-    get fetchHistory() {
-      return fetchHistory;
-    },
+    fetchHistory,
   };
 }

--- a/tests/request-schedulling/document-base-coalescing.test.ts
+++ b/tests/request-schedulling/document-base-coalescing.test.ts
@@ -151,7 +151,7 @@ test('realtime update fetches mixed with other priority fetches within the same 
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
-    dynamicRealtimeThrottleMs: () => 2_000,
+    dynamicRealtimeThrottleMs: () => 2000,
   });
 
   renderHook(() => {
@@ -189,7 +189,7 @@ test('realtime updates starts coalescing window', async () => {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
-    dynamicRealtimeThrottleMs: () => 2_000,
+    dynamicRealtimeThrottleMs: () => 2000,
   });
 
   renderHook(() => {
@@ -227,7 +227,7 @@ test('delayed realtime update fetches also are coalesced', async () => {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
-    dynamicRealtimeThrottleMs: () => 2_000,
+    dynamicRealtimeThrottleMs: () => 2000,
   });
 
   renderHook(() => {
@@ -273,7 +273,7 @@ test('delayed realtime update request also starts coalescing window', async () =
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
     baseCoalescingWindowMs: 20,
-    dynamicRealtimeThrottleMs: () => 2_000,
+    dynamicRealtimeThrottleMs: () => 2000,
   });
 
   renderHook(() => {

--- a/tests/request-schedulling/document-realtime-updates.test.ts
+++ b/tests/request-schedulling/document-realtime-updates.test.ts
@@ -16,8 +16,12 @@ afterEach(() => {
   vi.runOnlyPendingTimers();
 });
 
-function dynamicRealtimeThrottleMs(lastDuration: number): number {
-  if (lastDuration > 300) return 300;
+function dynamicRealtimeThrottleMs({
+  lastFetchDuration,
+}: {
+  lastFetchDuration: number;
+}): number {
+  if (lastFetchDuration > 300) return 300;
   return 100;
 }
 
@@ -98,7 +102,7 @@ test('dynamically throttle multiple realtime updates at same time with delay inf
   const env = createDocumentStoreTestEnv(0, {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs(lastFetchDuration: number) {
+    dynamicRealtimeThrottleMs({ lastFetchDuration }) {
       return lastFetchDuration < 700 ? 100 : 500;
     },
   });
@@ -171,8 +175,8 @@ test('simple mutation that triggers a RTU', async () => {
   const env = createDocumentStoreTestEnv(0, {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs: (lastDuration) =>
-      lastDuration > 300 ? 300 : 100,
+    dynamicRealtimeThrottleMs: ({ lastFetchDuration }) =>
+      lastFetchDuration > 300 ? 300 : 100,
   });
 
   renderHook(() => {
@@ -225,8 +229,8 @@ test('slow mutation then external RTU while mutation RTU is running', async () =
   const env = createDocumentStoreTestEnv(0, {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs: (lastDuration) =>
-      lastDuration > 1000 ? 500 : 200,
+    dynamicRealtimeThrottleMs: ({ lastFetchDuration }) =>
+      lastFetchDuration > 1000 ? 500 : 200,
   });
 
   renderHook(() => {
@@ -307,8 +311,8 @@ test('slow mutation then new mutation while prev mutation RTU is running', async
   const env = createDocumentStoreTestEnv(0, {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs: (lastDuration) =>
-      lastDuration > 1000 ? 500 : 200,
+    dynamicRealtimeThrottleMs: ({ lastFetchDuration }) =>
+      lastFetchDuration > 1000 ? 500 : 200,
   });
 
   renderHook(() => {
@@ -388,8 +392,8 @@ test('slow mutation then new mutation while prev mutation is running', async () 
   const env = createDocumentStoreTestEnv(0, {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs: (lastDuration) =>
-      lastDuration > 1000 ? 500 : 200,
+    dynamicRealtimeThrottleMs: ({ lastFetchDuration }) =>
+      lastFetchDuration > 1000 ? 500 : 200,
   });
 
   renderHook(() => {
@@ -463,8 +467,8 @@ test('rtu mutations without optimistic updates', async () => {
   const env = createDocumentStoreTestEnv(0, {
     testScenario: 'loaded',
     usesRealTimeUpdates: true,
-    dynamicRealtimeThrottleMs: (lastDuration) =>
-      lastDuration > 1000 ? 500 : 200,
+    dynamicRealtimeThrottleMs: ({ lastFetchDuration }) =>
+      lastFetchDuration > 1000 ? 500 : 200,
   });
 
   renderHook(() => {

--- a/tests/request-schedulling/window-focus.test.ts
+++ b/tests/request-schedulling/window-focus.test.ts
@@ -1,0 +1,425 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { createCollectionStoreTestEnv } from '../mocks/collectionStoreTestEnv';
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
+import { createListQueryStoreTestEnv } from '../mocks/listQueryStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import { advanceTime, flushAllTimers } from '../utils/genericTestUtils';
+
+vi.mock('@ls-stack/browser-utils/window', () => ({
+  onWindowFocus: (handler: () => void) => {
+    window.addEventListener('focus', handler);
+    return () => window.removeEventListener('focus', handler);
+  },
+  isWindowFocused: () => !document.hidden,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(TEST_INITIAL_TIME);
+  Object.defineProperty(document, 'hidden', {
+    value: false,
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+// -- DocumentStore: revalidateOnWindowFocus ------------------------------------
+
+test('document store: focus triggers lowPriority invalidation for non-realtime store', async () => {
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    revalidateOnWindowFocus: true,
+  });
+
+  renderHook(() => {
+    env.trackUIChanges(env.apiStore.useDocument().data?.value);
+  });
+
+  await flushAllTimers();
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBe(2);
+
+  expect(env.timelineString).toMatchInlineSnapshot(`
+    "
+    time  | ui |
+    0     | 0  | ui-initialized
+    10ms  | 0  | 🔴 >fetch-started
+    810ms | 0  | 🔴 <fetch-finished (value: 0)
+    .     | 0  | window-focused
+    820ms | 0  | 🟠 >fetch-started
+    1.62s | 0  | 🟠 <fetch-finished (value: 0)
+    "
+  `);
+});
+
+test('document store: focus does nothing when revalidateOnWindowFocus is not set', async () => {
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+  });
+
+  renderHook(() => env.apiStore.useDocument().data?.value);
+
+  await flushAllTimers();
+
+  const fetchesBefore = env.serverMock.numOfStartedFetches;
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBe(fetchesBefore);
+});
+
+test('document store: focus with dynamic disable function', async () => {
+  let enabled = true;
+
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    revalidateOnWindowFocus: () => enabled,
+  });
+
+  renderHook(() => env.apiStore.useDocument().data?.value);
+
+  await flushAllTimers();
+
+  // Disable and focus — should not trigger fetch
+  enabled = false;
+
+  const fetchesBeforeDisabled = env.serverMock.numOfStartedFetches;
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBe(fetchesBeforeDisabled);
+
+  // Re-enable and focus — should trigger fetch
+  enabled = true;
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBeGreaterThan(
+    fetchesBeforeDisabled,
+  );
+});
+
+test('document store: realtime store does NOT trigger on focus even when option is set', async () => {
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
+    dynamicRealtimeThrottleMs: () => 300,
+    revalidateOnWindowFocus: true,
+  });
+
+  renderHook(() => env.apiStore.useDocument().data?.value);
+
+  await advanceTime(100);
+
+  const fetchesBefore = env.serverMock.numOfStartedFetches;
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBe(fetchesBefore);
+});
+
+test('document store: reset() cleans up and re-registers focus listener', async () => {
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    revalidateOnWindowFocus: true,
+  });
+
+  renderHook(() => env.apiStore.useDocument().data?.value);
+
+  await flushAllTimers();
+
+  act(() => {
+    env.apiStore.reset();
+  });
+
+  renderHook(() => env.apiStore.useDocument().data?.value);
+
+  await flushAllTimers();
+
+  const fetchesBefore = env.serverMock.numOfStartedFetches;
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBeGreaterThan(fetchesBefore);
+});
+
+// -- DocumentStore: backgroundCoalescingWindowMultiplier -----------------------
+
+test('document store: coalescing window is multiplied when window is not focused', async () => {
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    baseCoalescingWindowMs: 20,
+    backgroundCoalescingWindowMultiplier: 5,
+  });
+
+  renderHook(() => {
+    env.trackUIChanges(env.apiStore.useDocument().data?.value);
+  });
+
+  await flushAllTimers();
+
+  const initialFetches = env.serverMock.numOfStartedFetches;
+
+  env.simulateWindowBlur();
+
+  // Coalescing window should be 20 * 5 = 100ms
+  env.apiStore.invalidateData('highPriority');
+
+  // At 50ms, still within the multiplied coalescing window
+  await advanceTime(50);
+  expect(env.serverMock.numOfStartedFetches).toBe(initialFetches);
+
+  await advanceTime(20);
+  // trigger coalesced fetch
+  env.apiStore.invalidateData('highPriority');
+
+  // At 110ms, past the multiplied coalescing window
+  await advanceTime(60);
+  await flushAllTimers();
+
+  expect(env.serverMock.numOfStartedFetches).toBe(initialFetches + 1);
+
+  expect(env.timelineString).toMatchInlineSnapshot(`
+    "
+    time  | ui |
+    0     | 0  | ui-initialized
+    20ms  | 0  | 🔴 >fetch-started
+    820ms | 0  | 🔴 <fetch-finished (value: 0)
+    .     | 0  | window-blurred
+    920ms | 0  | 🟠 >fetch-started
+    1.72s | 0  | 🟠 <fetch-finished (value: 0)
+    "
+  `);
+});
+
+// -- DocumentStore: dynamicRealtimeThrottleMs windowIsNotFocused --------------
+
+test('document store: dynamicRealtimeThrottleMs receives correct windowIsNotFocused', async () => {
+  const receivedParams: Array<{
+    lastFetchDuration: number;
+    windowIsNotFocused: boolean;
+  }> = [];
+
+  const env = createDocumentStoreTestEnv(0, {
+    testScenario: 'loaded',
+    usesRealTimeUpdates: true,
+    dynamicRealtimeThrottleMs(params) {
+      receivedParams.push({ ...params });
+      return 300;
+    },
+  });
+
+  renderHook(() => env.apiStore.useDocument().data?.value);
+
+  // First RTU to establish timing (dynamicRealtimeThrottleMs needs lastFetchDuration > 0)
+  env.emulateExternalRTU(1);
+  await flushAllTimers();
+
+  // Second RTU in foreground
+  env.emulateExternalRTU(2);
+  await flushAllTimers();
+
+  expect(receivedParams.some((p) => p.windowIsNotFocused === false)).toBe(true);
+
+  // Go to background and trigger RTU
+  env.simulateWindowBlur();
+  env.emulateExternalRTU(3);
+  await flushAllTimers();
+
+  expect(receivedParams.some((p) => p.windowIsNotFocused === true)).toBe(true);
+});
+
+// -- CollectionStore: revalidateOnWindowFocus ----------------------------------
+
+test('collection store: focus triggers lowPriority invalidation for all items', async () => {
+  const env = createCollectionStoreTestEnv(
+    { '1': { name: 'Alice' }, '2': { name: 'Bob' } },
+    {
+      testScenario: 'loaded',
+      revalidateOnWindowFocus: true,
+    },
+  );
+
+  renderHook(() => env.apiStore.useItem('1'));
+  renderHook(() => env.apiStore.useItem('2'));
+
+  await flushAllTimers();
+
+  env.serverTable.fetchHistory.length = 0;
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverTable.fetchHistory).toMatchInlineSnapshot(`
+    - duration: 800
+      itemId: '1'
+      result: { name: 'Alice' }
+      startedAt: 820
+      type: 'fetch'
+    - duration: 800
+      itemId: '2'
+      result: { name: 'Bob' }
+      startedAt: 820
+      type: 'fetch'
+  `);
+});
+
+test('collection store: focus with dynamic disable function', async () => {
+  let enabled = true;
+
+  const env = createCollectionStoreTestEnv(
+    { '1': { name: 'Alice' }, '2': { name: 'Bob' } },
+    {
+      testScenario: 'loaded',
+      revalidateOnWindowFocus: () => enabled,
+    },
+  );
+
+  renderHook(() => env.apiStore.useItem('1'));
+  renderHook(() => env.apiStore.useItem('2'));
+
+  await flushAllTimers();
+
+  env.serverTable.fetchHistory.length = 0;
+
+  enabled = false;
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverTable.fetchHistory).toHaveLength(0);
+
+  enabled = true;
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  const fetchedItemIds: string[] = [];
+  for (const entry of env.serverTable.fetchHistory) {
+    if (entry.type === 'fetch') {
+      fetchedItemIds.push(entry.itemId);
+    }
+  }
+
+  expect(fetchedItemIds).toMatchInlineSnapshot(`
+    ['1', '2']
+  `);
+});
+
+// -- ListQueryStore: revalidateOnWindowFocus -----------------------------------
+
+test('list query store: focus triggers lowPriority invalidation for queries and items', async () => {
+  const initialData = {
+    users: [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ],
+  };
+
+  const env = createListQueryStoreTestEnv(initialData, {
+    testScenario: { loaded: { tables: ['users'] } },
+    revalidateOnWindowFocus: true,
+  });
+
+  renderHook(() => env.apiStore.useListQuery({ tableId: 'users' }));
+
+  renderHook(() => env.apiStore.useItem('users||1'));
+  renderHook(() => env.apiStore.useItem('users||2'));
+
+  await flushAllTimers();
+
+  env.serverTable.fetchHistory.length = 0;
+
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  const listFetch = env.serverTable.fetchHistory.find(
+    (entry) => entry.type === 'list',
+  );
+
+  expect(listFetch).toMatchInlineSnapshot(`
+    duration: 800
+    limit: 50
+    offset: 0
+    results:
+      - data: { id: 1, name: 'Alice' }
+        itemId: 'users||1'
+      - data: { id: 2, name: 'Bob' }
+        itemId: 'users||2'
+    startedAt: 820
+    type: 'list'
+  `);
+
+  const fetchedItemIds: string[] = [];
+  for (const entry of env.serverTable.fetchHistory) {
+    if (entry.type === 'fetch') {
+      fetchedItemIds.push(entry.itemId);
+    }
+  }
+
+  expect(fetchedItemIds).toMatchInlineSnapshot(`
+    ['users||1', 'users||2']
+  `);
+});
+
+test('list query store: focus with dynamic disable function', async () => {
+  let enabled = true;
+
+  const initialData = {
+    users: [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ],
+  };
+
+  const env = createListQueryStoreTestEnv(initialData, {
+    testScenario: { loaded: { tables: ['users'] } },
+    revalidateOnWindowFocus: () => enabled,
+  });
+
+  renderHook(() => env.apiStore.useListQuery({ tableId: 'users' }));
+
+  renderHook(() => env.apiStore.useItem('users||1'));
+  renderHook(() => env.apiStore.useItem('users||2'));
+
+  await flushAllTimers();
+
+  env.serverTable.fetchHistory.length = 0;
+
+  enabled = false;
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  expect(env.serverTable.fetchHistory).toHaveLength(0);
+
+  enabled = true;
+  env.simulateWindowFocus();
+  await flushAllTimers();
+
+  const hasListFetch = env.serverTable.fetchHistory.some(
+    (entry) => entry.type === 'list',
+  );
+  expect(hasListFetch).toBe(true);
+
+  const fetchedItemIds: string[] = [];
+  for (const entry of env.serverTable.fetchHistory) {
+    if (entry.type === 'fetch') {
+      fetchedItemIds.push(entry.itemId);
+    }
+  }
+
+  expect(fetchedItemIds).toMatchInlineSnapshot(`
+    ['users||1', 'users||2']
+  `);
+});

--- a/tests/utils/genericTestUtils.ts
+++ b/tests/utils/genericTestUtils.ts
@@ -30,3 +30,23 @@ export async function advanceTime(ms: number) {
     await vi.advanceTimersByTimeAsync(ms);
   });
 }
+
+export function simulateWindowBlur() {
+  Object.defineProperty(document, 'hidden', {
+    value: true,
+    writable: true,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+  window.dispatchEvent(new Event('blur'));
+}
+
+export function simulateWindowFocus() {
+  Object.defineProperty(document, 'hidden', {
+    value: false,
+    writable: true,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+  window.dispatchEvent(new Event('focus'));
+}


### PR DESCRIPTION
## Summary

Add optional revalidate-on-focus behavior for Document/Collection/List stores and make coalescing/throttling window-aware. This reduces background network pressure and enables stores to revalidate when the tab regains focus while preserving realtime behavior.
### Changes

- Add revalidateOnWindowFocus option to document, collection and list query stores (boolean or function) to trigger low-priority invalidation on window focus for non-realtime stores
- Introduce backgroundCoalescingWindowMultiplier and plumb getCoalescingWindowMultiplier into RequestScheduler to multiply coalescing windows when tab is unfocused
- Pass window focus state into dynamicRealtimeThrottleMs (now receives { lastFetchDuration, windowIsNotFocused }) so throttle decisions can account for background/foreground
- Use @ls-stack/browser-utils/window (isWindowFocused, onWindowFocus) and wire focus listeners; ensure listeners are cleaned up and re-registered on reset
- Update RequestScheduler to compute effective coalescing window using the multiplier
- Add/adjust tests and test helpers: new window-focus.test, simulateWindowFocus/Blur helpers, and multiple test updates to assert fetch history and throttle behavior
- Update mocks and server test utilities to expose fetchHistory and to support focus simulation
- Add dependency @ls-stack/browser-utils and update lockfile

### Testing Notes

Run the test suite (Vitest) — the new window-focus.test covers the main scenarios. Key verifications: 1) When revalidateOnWindowFocus is true (or returns true), a non-realtime store triggers a lowPriority invalidation/fetch on window focus. 2) Realtime stores ignore revalidateOnWindowFocus. 3) backgroundCoalescingWindowMultiplier multiplies the coalescing window while document.hidden=true (simulateWindowBlur) so coalesced fetches are delayed accordingly. 4) dynamicRealtimeThrottleMs receives windowIsNotFocused in its params for both foreground and background RTU cases. 5) reset() cleans up and re-registers focus listeners. Use the provided simulateWindowFocus()/simulateWindowBlur() helpers in tests or manually dispatch visibilitychange/focus events to reproduce. Also validate that focus listener cleanup works (no duplicate fetches) and that function-valued revalidateOnWindowFocus toggles behavior as expected.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
