### PR TITLE
Add partial refetch loading-state tracking

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,9 +87,7 @@ Passing an empty string `''` as payload returns an immediate error state with `{
 ### With selector
 
 ```tsx
-const itemName = store.useItem('item-1', {
-  selector: (data) => data?.name,
-});
+const itemName = store.useItem('item-1', { selector: (data) => data?.name });
 ```
 
 ### List Query Store specific options
@@ -117,10 +115,7 @@ Fetches and subscribes to a paginated list query.
 
 ```tsx
 const { items, status, hasMore, isLoading, isLoadingMore } = store.useListQuery(
-  {
-    projectId: 'proj-1',
-    status: 'active',
-  },
+  { projectId: 'proj-1', status: 'active' },
 );
 ```
 
@@ -152,6 +147,7 @@ store.useListQuery(filter, { loadSize: 20 }); // override defaultQuerySize
 
 - `items` - Array of items (or selected items)
 - `status` - `'idle'` | `'loading'` | `'success'` | `'error'` | `'refetching'` | `'loadingMore'`
+- `loadingFields` - Requested partial-resource fields still pending while cached data remains visible
 - `hasMore` - Whether more items are available for pagination
 - `isLoading` - Shorthand for `status === 'loading'`
 - `isLoadingMore` - Shorthand for `status === 'loadingMore'`

--- a/docs/partial-resources.md
+++ b/docs/partial-resources.md
@@ -32,10 +32,7 @@ const userStore = createListQueryStore<User, UserFilter, string, true>({
 
   partialResources: {
     // Merge newly fetched fields with previously loaded ones
-    mergeItems: (prev, fetched) => ({
-      ...(prev ?? {}),
-      ...fetched,
-    }),
+    mergeItems: (prev, fetched) => ({ ...(prev ?? {}), ...fetched }),
 
     // Select only the requested fields from a full item
     selectFields: (fields, item) => {
@@ -66,9 +63,7 @@ When partial resources is enabled, the `fields` option becomes **required** in h
 ```tsx
 // Fetch only name and email
 function UserCard({ userId }: { userId: string }) {
-  const { data } = userStore.useItem(userId, {
-    fields: ['name', 'email'],
-  });
+  const { data } = userStore.useItem(userId, { fields: ['name', 'email'] });
 
   return (
     <div>
@@ -127,6 +122,8 @@ When a hook requests fields that are partially loaded:
 - During the field fetch, the hook returns `null` data to prevent displaying stale partial data
 - Once the missing fields are loaded and merged, the complete data is returned
 
+If you enable `showPartialAsRefetching`, the hook exposes `loadingFields` with the requested fields that are still pending. When cached partial data already exists, TSDF keeps it visible during the follow-up fetch.
+
 ## Fields in Scheduling and Fetching
 
 Fields propagate through the scheduling and fetching APIs:
@@ -138,9 +135,7 @@ store.scheduleItemFetch('highPriority', 'user-1', {
 });
 
 // Await a fetch for specific fields
-const result = await store.awaitItemFetch('user-1', {
-  fields: ['name'],
-});
+const result = await store.awaitItemFetch('user-1', { fields: ['name'] });
 
 // Schedule a list query fetch
 store.scheduleListQueryFetch('highPriority', filter, undefined, {

--- a/src/listQueryStore/types.ts
+++ b/src/listQueryStore/types.ts
@@ -52,6 +52,8 @@ export type TSFDUseListQueryReturn<
   fields: HasPartialResources extends true
     ? FieldsInput
     : FieldsInput | undefined;
+  /** Requested partial-resource fields that are still pending. */
+  loadingFields?: string[];
   error: StoreError | null;
   queryKey: string;
   hasMore: boolean;
@@ -68,6 +70,8 @@ export type TSFDUseListItemReturn<
   data: Selected;
   status: QueryStatus | 'idle' | 'deleted';
   payload: ItemPayload | null;
+  /** Requested partial-resource fields that are still pending. */
+  loadingFields?: string[];
   error: StoreError | null;
   isLoading: boolean;
   itemStateKey: string;

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -152,7 +152,9 @@ export function useMultipleItems<
           const rawItemState = state.items[itemKey];
           const hasCachedDataInState =
             rawItemState !== null && rawItemState !== undefined;
+          const loadedFields = state.itemLoadedFields[itemKey] ?? [];
           let itemState = rawItemState;
+          let loadingFields: string[] | undefined;
 
           // Apply field selection for partial resources
           if (
@@ -199,11 +201,23 @@ export function useMultipleItems<
               };
             }
 
+            const pendingLoadingFields =
+              partialResources &&
+              showPartialAsRefetching &&
+              Array.isArray(fields) &&
+              fields.length > 0 &&
+              !returnIdleStatus
+                ? fields
+                : undefined;
+
             return {
               itemStateKey: itemKey,
               status: returnIdleStatus ? 'idle' : 'loading',
               error: null,
               isLoading: !returnIdleStatus,
+              ...(pendingLoadingFields
+                ? { loadingFields: pendingLoadingFields }
+                : {}),
               payload,
               data,
               queryMetadata: __LEGIT_CAST__<
@@ -224,7 +238,6 @@ export function useMultipleItems<
             fields.length > 0 &&
             (status === 'success' || status === 'refetching')
           ) {
-            const loadedFields = state.itemLoadedFields[itemKey] ?? [];
             const missingFields = fields.filter(
               (f) => !loadedFields.includes(f),
             );
@@ -240,6 +253,24 @@ export function useMultipleItems<
                 hasCachedDataInState && showPartialAsRefetching
                   ? 'refetching'
                   : 'loading';
+            }
+          }
+
+          if (partialResources && showPartialAsRefetching) {
+            if (Array.isArray(fields) && fields.length > 0) {
+              const pendingRequestedFields = fields.filter(
+                (field) => !loadedFields.includes(field),
+              );
+
+              if (pendingRequestedFields.length > 0) {
+                loadingFields = pendingRequestedFields;
+              }
+            } else if (
+              fields === '*' &&
+              itemFieldInvalidationFields &&
+              itemFieldInvalidationFields.length > 0
+            ) {
+              loadingFields = itemFieldInvalidationFields;
             }
           }
 
@@ -267,6 +298,7 @@ export function useMultipleItems<
             status,
             error: itemQuery.error,
             isLoading: status === 'loading',
+            ...(loadingFields ? { loadingFields } : {}),
             data: shouldHideDataWhileLoading
               ? selector
                 ? selector(null, itemQuery.payload)

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -242,8 +242,18 @@ export function useMultipleListQueries<
           QueryMetadata
         > => {
           const query = state.queries[queryKey];
+          let loadingFields: string[] | undefined;
 
           if (!query) {
+            const pendingLoadingFields =
+              partialResources &&
+              showPartialAsRefetching &&
+              Array.isArray(fields) &&
+              fields.length > 0 &&
+              !returnIdleStatus
+                ? fields
+                : undefined;
+
             return {
               queryKey,
               status: returnIdleStatus ? 'idle' : 'loading',
@@ -252,6 +262,9 @@ export function useMultipleListQueries<
               hasMore: false,
               payload: omitPayload ? undefined : payload,
               fields,
+              ...(pendingLoadingFields
+                ? { loadingFields: pendingLoadingFields }
+                : {}),
               isLoading: !returnIdleStatus,
               isLoadingMore: false,
               queryMetadata: __LEGIT_CAST__<
@@ -330,6 +343,37 @@ export function useMultipleListQueries<
             }
           }
 
+          if (partialResources && showPartialAsRefetching) {
+            if (Array.isArray(fields) && fields.length > 0) {
+              const pendingRequestedFields = fields.filter((field) =>
+                status === 'loading' && query.items.length === 0
+                  ? true
+                  : query.items.some((itemKey) => {
+                      const loadedFields =
+                        state.itemLoadedFields[itemKey] ?? [];
+                      return !loadedFields.includes(field);
+                    }),
+              );
+
+              if (pendingRequestedFields.length > 0) {
+                loadingFields = pendingRequestedFields;
+              }
+            } else if (fields === '*') {
+              const pendingInvalidationFields = Array.from(
+                new Set(
+                  query.items.flatMap(
+                    (itemKey) =>
+                      state.itemFieldInvalidationFields[itemKey] ?? [],
+                  ),
+                ),
+              ).sort();
+
+              if (pendingInvalidationFields.length > 0) {
+                loadingFields = pendingInvalidationFields;
+              }
+            }
+          }
+
           if (!returnRefetchingStatus && status === 'refetching') {
             status = 'success';
           }
@@ -345,6 +389,7 @@ export function useMultipleListQueries<
               : getQueryItems(state, query, fields),
             error: query.error,
             hasMore: query.hasMore,
+            ...(loadingFields ? { loadingFields } : {}),
             isLoading: status === 'loading',
             payload: omitPayload ? undefined : query.payload,
             fields,

--- a/tests/list-query-features/list-query-partial-resources-show-partial-status.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-show-partial-status.test.ts
@@ -146,6 +146,57 @@ test('useItem: option can expose refetching while cache exists but requested fie
   `);
 });
 
+test('useItem: loadingFields exposes which requested fields are still pending', async () => {
+  const env = createListQueryStoreTestEnv(initialServerData, {
+    partialResources: partialResourcesConfig,
+  });
+  const renders = createLoggerStore();
+
+  const { rerender } = renderHook(
+    ({ fields }: { fields: string[] }) => {
+      const result = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        showPartialAsRefetching: true,
+        fields,
+      });
+
+      renders.add({
+        status: result.status,
+        data: result.data,
+        loadingFields: result.loadingFields ?? null,
+        fields,
+      });
+    },
+    { initialProps: { fields: ['id'] } },
+  );
+
+  await flushAllTimers();
+
+  renders.addMark('Expand fields');
+  act(() => {
+    rerender({ fields: ['id', 'name'] });
+  });
+
+  await flushAllTimers();
+
+  expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+    "
+    -> status: loading ⋅ data: null ⋅ loadingFields: [id] ⋅ fields: [id]
+    -> status: success ⋅ data: {id:1} ⋅ loadingFields: null ⋅ fields: [id]
+
+    >>> Expand fields
+
+    -> status: refetching ⋅ data: {id:1} ⋅ loadingFields: [name] ⋅ fields: [id, name]
+    ┌─
+    ⋅ status: success
+    ⋅ data: {id:1, name:User 1}
+    ⋅ loadingFields: null
+    ⋅ fields: [id, name]
+    └─
+    "
+  `);
+});
+
 test('useItem: cache miss still reports loading with showPartialAsRefetching enabled', async () => {
   const env = createListQueryStoreTestEnv(initialServerData, {
     partialResources: partialResourcesConfig,
@@ -160,7 +211,11 @@ test('useItem: cache miss still reports loading with showPartialAsRefetching ena
   );
   await advanceTime(0);
 
-  expect(hook.result.current).toMatchObject({ status: 'loading', data: null });
+  expect(hook.result.current).toMatchObject({
+    status: 'loading',
+    data: null,
+    loadingFields: ['id', 'name'],
+  });
 
   hook.unmount();
   await flushAllTimers();
@@ -284,6 +339,94 @@ test('useListQuery: raw and masked hooks expose refetching vs success with showP
     ┌─
     ⋅ rawStatus: success
     ⋅ maskedStatus: success
+    ⋅ rawFirstItem: {id:1, name:User 1}
+    ⋅ maskedFirstItem: {id:1, name:User 1}
+    ⋅ fields: [id, name]
+    └─
+    "
+  `);
+});
+
+test('useListQuery: loadingFields exposes pending fields even when refetching is masked', async () => {
+  const env = createListQueryStoreTestEnv(initialServerData, {
+    partialResources: partialResourcesConfig,
+  });
+  const renders = createLoggerStore();
+
+  const { rerender } = renderHook(
+    ({ fields }: { fields: string[] }) => {
+      const rawResult = env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { returnRefetchingStatus: true, showPartialAsRefetching: true, fields },
+      );
+      const maskedResult = env.apiStore.useListQuery(
+        { tableId: 'users' },
+        {
+          returnRefetchingStatus: false,
+          showPartialAsRefetching: true,
+          fields,
+        },
+      );
+
+      renders.add({
+        rawStatus: rawResult.status,
+        maskedStatus: maskedResult.status,
+        rawLoadingFields: rawResult.loadingFields ?? null,
+        maskedLoadingFields: maskedResult.loadingFields ?? null,
+        rawFirstItem: rawResult.items[0] ?? null,
+        maskedFirstItem: maskedResult.items[0] ?? null,
+        fields,
+      });
+    },
+    { initialProps: { fields: ['id'] } },
+  );
+
+  await flushAllTimers();
+
+  renders.addMark('Expand fields');
+  act(() => {
+    rerender({ fields: ['id', 'name'] });
+  });
+
+  await flushAllTimers();
+
+  expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+    "
+    ┌─
+    ⋅ rawStatus: loading
+    ⋅ maskedStatus: loading
+    ⋅ rawLoadingFields: [id]
+    ⋅ maskedLoadingFields: [id]
+    ⋅ rawFirstItem: null
+    ⋅ maskedFirstItem: null
+    ⋅ fields: [id]
+    └─
+    ┌─
+    ⋅ rawStatus: success
+    ⋅ maskedStatus: success
+    ⋅ rawLoadingFields: null
+    ⋅ maskedLoadingFields: null
+    ⋅ rawFirstItem: {id:1}
+    ⋅ maskedFirstItem: {id:1}
+    ⋅ fields: [id]
+    └─
+
+    >>> Expand fields
+
+    ┌─
+    ⋅ rawStatus: refetching
+    ⋅ maskedStatus: success
+    ⋅ rawLoadingFields: [name]
+    ⋅ maskedLoadingFields: [name]
+    ⋅ rawFirstItem: {id:1}
+    ⋅ maskedFirstItem: {id:1}
+    ⋅ fields: [id, name]
+    └─
+    ┌─
+    ⋅ rawStatus: success
+    ⋅ maskedStatus: success
+    ⋅ rawLoadingFields: null
+    ⋅ maskedLoadingFields: null
     ⋅ rawFirstItem: {id:1, name:User 1}
     ⋅ maskedFirstItem: {id:1, name:User 1}
     ⋅ fields: [id, name]


### PR DESCRIPTION
## Summary
- document the new partial refetch loading states for `showPartialAsRefetching` and update relevant docs and tooling metadata
- align tooling configs, skills, and docs with the recent branching structure and coding standards
- refresh snapshots and source files to expose loading-state details while refetching partial resources

## Testing
- Not run (not requested)