### PR TITLE
Adjust cache limits and expose cleanup hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,7 @@ When fixing a bug:
 2. confirm that the test fails before applying the fix, to ensure the test is valid
 3. check the root cause of the issue and apply the fix, don't apply a superficial fix that only makes the test pass without addressing the underlying problem.
 4. apply the fix and confirm that the test passes after the fix is applied
+
+## Useful patterns
+
+- For unsafe data parsing, use `runcheck` lib

--- a/src/cacheLimits/lruCacheRuntime.ts
+++ b/src/cacheLimits/lruCacheRuntime.ts
@@ -1,0 +1,66 @@
+export type LruCacheRuntime = {
+  touch(keys: string[], isPresent: (key: string) => boolean): boolean;
+  registerActive(keys: string[]): () => void;
+  isActive(key: string): boolean;
+  getLastUsed(key: string): number;
+  clear(key: string): void;
+  clearAll(): void;
+};
+
+export function createLruCacheRuntime(): LruCacheRuntime {
+  const lastUsed = new Map<string, number>();
+  const activeRefs = new Map<string, number>();
+  let clock = 0;
+
+  return {
+    touch(keys, isPresent) {
+      let someKeyWasTouched = false;
+
+      for (const key of keys) {
+        if (!isPresent(key)) continue;
+
+        lastUsed.set(key, ++clock);
+        someKeyWasTouched = true;
+      }
+
+      return someKeyWasTouched;
+    },
+
+    registerActive(keys) {
+      if (keys.length === 0) return () => {};
+
+      for (const key of keys) {
+        activeRefs.set(key, (activeRefs.get(key) ?? 0) + 1);
+      }
+
+      return () => {
+        for (const key of keys) {
+          const nextCount = (activeRefs.get(key) ?? 0) - 1;
+          if (nextCount > 0) {
+            activeRefs.set(key, nextCount);
+          } else {
+            activeRefs.delete(key);
+          }
+        }
+      };
+    },
+
+    isActive(key) {
+      return activeRefs.has(key);
+    },
+
+    getLastUsed(key) {
+      return lastUsed.get(key) ?? 0;
+    },
+
+    clear(key) {
+      lastUsed.delete(key);
+      activeRefs.delete(key);
+    },
+
+    clearAll() {
+      lastUsed.clear();
+      activeRefs.clear();
+    },
+  };
+}

--- a/src/cacheLimits/lruCacheRuntime.ts
+++ b/src/cacheLimits/lruCacheRuntime.ts
@@ -55,12 +55,10 @@ export function createLruCacheRuntime(): LruCacheRuntime {
 
     clear(key) {
       lastUsed.delete(key);
-      activeRefs.delete(key);
     },
 
     clearAll() {
       lastUsed.clear();
-      activeRefs.clear();
     },
   };
 }

--- a/src/cacheLimits/scheduleIdleThrottled.ts
+++ b/src/cacheLimits/scheduleIdleThrottled.ts
@@ -1,0 +1,62 @@
+import { scheduleIdleCleanup } from '../persistentStorage/scheduleIdleCleanup';
+
+export type IdleThrottledScheduler = { schedule(): void; cancel(): void };
+
+export function createIdleThrottledScheduler({
+  throttleMs,
+  run,
+}: {
+  throttleMs: number;
+  run: () => void;
+}): IdleThrottledScheduler {
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let cancelIdleRun: (() => void) | null = null;
+  let isScheduled = false;
+  let lastRunAt = 0;
+  let scheduleId = 0;
+
+  function schedule(): void {
+    if (isScheduled) return;
+
+    isScheduled = true;
+    const currentScheduleId = ++scheduleId;
+    const delay = Math.max(0, lastRunAt + throttleMs - Date.now());
+
+    function queueIdleRun(): void {
+      cancelIdleRun = scheduleIdleCleanup(() => {
+        cancelIdleRun = null;
+        if (currentScheduleId !== scheduleId) return;
+
+        isScheduled = false;
+        lastRunAt = Date.now();
+        run();
+      });
+    }
+
+    if (delay > 0) {
+      pendingTimer = setTimeout(() => {
+        pendingTimer = null;
+        queueIdleRun();
+      }, delay);
+      return;
+    }
+
+    queueIdleRun();
+  }
+
+  function cancel(): void {
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    if (cancelIdleRun) {
+      cancelIdleRun();
+      cancelIdleRun = null;
+    }
+
+    scheduleId++;
+    isScheduled = false;
+  }
+
+  return { schedule, cancel };
+}

--- a/src/cacheLimits/useRegisterActiveKeys.ts
+++ b/src/cacheLimits/useRegisterActiveKeys.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+export function useRegisterActiveKeys(
+  keys: string[],
+  registerActiveKeys: (keys: string[]) => () => void,
+  touchKeys: (keys: string[]) => void,
+): void {
+  useEffect(() => {
+    if (keys.length === 0) return;
+
+    touchKeys(keys);
+    return registerActiveKeys(keys);
+  }, [keys, registerActiveKeys, touchKeys]);
+}

--- a/src/collectionStore/collectionCacheLimits.ts
+++ b/src/collectionStore/collectionCacheLimits.ts
@@ -1,0 +1,89 @@
+import { Store } from 't-state';
+import { LruCacheRuntime } from '../cacheLimits/lruCacheRuntime';
+import type { ValidPayload, ValidStoreState } from '../utils/storeShared';
+import type {
+  CollectionStateCleanup,
+  TSFDCollectionItem,
+  TSFDCollectionState,
+} from './collectionStore';
+
+export function createCollectionCacheLimits<
+  ItemState extends ValidStoreState,
+  ItemPayload extends ValidPayload,
+>({
+  store,
+  maxItems,
+  itemCacheRuntime,
+  isProtectedFromEviction,
+  cleanupItemResources,
+  onStateCleanup,
+}: {
+  store: Store<TSFDCollectionState<ItemState, ItemPayload>>;
+  maxItems: number | undefined;
+  itemCacheRuntime: Pick<LruCacheRuntime, 'getLastUsed'>;
+  isProtectedFromEviction: (
+    itemKey: string,
+    item: TSFDCollectionItem<ItemState, ItemPayload>,
+  ) => boolean;
+  cleanupItemResources: (itemKey: string, payload: ItemPayload) => void;
+  onStateCleanup:
+    | ((cleanup: CollectionStateCleanup<ItemPayload>) => void)
+    | undefined;
+}) {
+  let isEnforcingCacheLimits = false;
+
+  function enforceCacheLimits(): void {
+    if (maxItems === undefined || isEnforcingCacheLimits) return;
+
+    const cachedItems = Object.entries(store.state).flatMap(([itemKey, item]) =>
+      item !== null ? ([[itemKey, item]] as const) : [],
+    );
+
+    if (cachedItems.length <= maxItems) return;
+
+    const evictionCandidates = cachedItems
+      .filter(([itemKey, item]) => !isProtectedFromEviction(itemKey, item))
+      .sort(
+        ([itemKeyA], [itemKeyB]) =>
+          itemCacheRuntime.getLastUsed(itemKeyA) -
+          itemCacheRuntime.getLastUsed(itemKeyB),
+      );
+
+    let remainingItems = cachedItems.length;
+    const itemsToEvict: { itemKey: string; payload: ItemPayload }[] = [];
+
+    for (const [itemKey, item] of evictionCandidates) {
+      if (remainingItems <= maxItems) break;
+      itemsToEvict.push({ itemKey, payload: item.payload });
+      remainingItems--;
+    }
+
+    if (itemsToEvict.length === 0) return;
+
+    isEnforcingCacheLimits = true;
+    try {
+      store.produceState(
+        (draft) => {
+          for (const { itemKey } of itemsToEvict) {
+            delete draft[itemKey];
+          }
+        },
+        { action: 'evict-collection-items' },
+      );
+    } finally {
+      isEnforcingCacheLimits = false;
+    }
+
+    for (const { itemKey, payload } of itemsToEvict) {
+      cleanupItemResources(itemKey, payload);
+    }
+
+    onStateCleanup?.({
+      reason: 'cacheLimitEviction',
+      itemKeys: itemsToEvict.map(({ itemKey }) => itemKey),
+      payloads: itemsToEvict.map(({ payload }) => payload),
+    });
+  }
+
+  return { enforceCacheLimits };
+}

--- a/src/collectionStore/collectionStore.ts
+++ b/src/collectionStore/collectionStore.ts
@@ -9,6 +9,8 @@ import { evtmitter } from 'evtmitter';
 import { klona } from 'klona/json';
 import { unknownToError, type Result } from 't-result';
 import { Store } from 't-state';
+import { createLruCacheRuntime } from '../cacheLimits/lruCacheRuntime';
+import { createIdleThrottledScheduler } from '../cacheLimits/scheduleIdleThrottled';
 import { useListItem as useListItemBase } from '../hooks/useListItem';
 import { useListItemIsDeleted as useListItemIsDeletedBase } from '../hooks/useListItemIsDeleted';
 import { useListItemIsLoading as useListItemIsLoadingBase } from '../hooks/useListItemIsLoading';
@@ -54,6 +56,7 @@ import {
   ValidStoreState,
   type StoreError,
 } from '../utils/storeShared';
+import { createCollectionCacheLimits } from './collectionCacheLimits';
 import { executeBatchFetch as executeBatchFetchBase } from './executeBatchFetch';
 import { useItem as useItemBase, UseItemOptions } from './useItem';
 import {
@@ -130,6 +133,12 @@ export type CollectionStoreStoreEvents<ItemPayload extends ValidPayload> = {
   mutationEnd: { mutationId: number; payload: ItemPayload; success: boolean };
 };
 
+export type CollectionStateCleanup<ItemPayload extends ValidPayload> = {
+  reason: 'cacheLimitEviction';
+  itemKeys: string[];
+  payloads: ItemPayload[];
+};
+
 export type CollectionBrowserTabsMessage<
   ItemState extends ValidStoreState,
   ItemPayload extends ValidPayload,
@@ -187,6 +196,10 @@ export type CollectionStoreOptions<
   getItemsBatchKey?: (payload: ItemPayload) => string | false;
   /** Max items per batch - triggers immediate fetch when reached */
   maxBatchSize?: number;
+  /** Maximum number of cached items kept in memory. Defaults to 5,000. Inactive items are evicted in LRU order, while mounted hook items stay protected. */
+  maxItems?: number;
+  /** Called when cache-limit eviction removes items from in-memory state. */
+  onStateCleanup?: (cleanup: CollectionStateCleanup<ItemPayload>) => void;
   getCollectionItemKey?: (params: ItemPayload) => ValidPayload | unknown[];
   errorNormalizer: (exception: Error) => StoreError;
   lowPriorityThrottleMs: number;
@@ -238,6 +251,8 @@ type CollectionStoreEvents = {
   invalidateData: { priority: FetchType; itemKey: string };
 };
 
+const CACHE_LIMIT_ENFORCEMENT_THROTTLE_MS = 60 * 60 * 1000;
+
 export function createCollectionStore<
   ItemState extends ValidStoreState,
   ItemPayload extends ValidPayload,
@@ -249,6 +264,8 @@ export function createCollectionStore<
   batchFetchFn,
   getItemsBatchKey,
   maxBatchSize,
+  maxItems = 5_000,
+  onStateCleanup,
   lowPriorityThrottleMs,
   baseCoalescingWindowMs,
   errorNormalizer,
@@ -270,6 +287,7 @@ export function createCollectionStore<
   let remoteApplyDepth = 0;
   let currentBroadcastConsistency: SnapshotConsistency = 'confirmed';
   const lastCollectionSyncVersions = new Map<string, BrowserTabsSyncVersion>();
+  const itemCacheRuntime = createLruCacheRuntime();
 
   let initialData:
     | CollectionInitialStateItem<ItemPayload, ItemState>[]
@@ -333,6 +351,38 @@ export function createCollectionStore<
     return getCompositeKey(
       filterCollectionItemObjKey ? filterCollectionItemObjKey(params) : params,
     );
+  }
+
+  function touchItems(itemKeys: string[]): void {
+    itemCacheRuntime.touch(itemKeys, (itemKey) => {
+      return store.state[itemKey] !== undefined;
+    });
+  }
+
+  function registerActiveItems(itemKeys: string[]): () => void {
+    if (itemKeys.length === 0) return () => {};
+
+    const unregister = itemCacheRuntime.registerActive(itemKeys);
+
+    return () => {
+      unregister();
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
+    };
+  }
+
+  function shouldScheduleCacheLimitEnforcement(): boolean {
+    let cachedItemCount = 0;
+
+    for (const item of Object.values(store.state)) {
+      if (item !== null) {
+        cachedItemCount++;
+        if (cachedItemCount > maxItems) return true;
+      }
+    }
+
+    return false;
   }
 
   const getWindowIsFocused = testOptions?.getWindowIsFocused ?? isWindowFocused;
@@ -645,6 +695,12 @@ export function createCollectionStore<
       }
 
       lastCollectionSyncVersions.set(message.itemKey, candidateVersion);
+      if (snapshotItem !== null) {
+        touchItems([message.itemKey]);
+        if (shouldScheduleCacheLimitEnforcement()) {
+          scheduleCacheLimitEnforcement();
+        }
+      }
       return;
     }
 
@@ -671,6 +727,11 @@ export function createCollectionStore<
 
     if (message.item === null && schedulerPayload) {
       cleanupItemResources(message.itemKey, schedulerPayload);
+    } else if (message.item !== null) {
+      touchItems([message.itemKey]);
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
     }
 
     lastCollectionSyncVersions.set(message.itemKey, candidateVersion);
@@ -773,6 +834,10 @@ export function createCollectionStore<
       ({ requestId }) => results.get(requestId) === true,
     );
     if (successfulRequests.length > 0) {
+      touchItems(successfulRequests.map(({ requestId }) => requestId));
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
       for (const { requestId } of successfulRequests) {
         publishItemSnapshot(requestId, 'confirmed');
       }
@@ -801,6 +866,8 @@ export function createCollectionStore<
 
   function cleanupItemResources(itemKey: string, payload: ItemPayload): void {
     invalidationWasTriggered.delete(itemKey);
+    itemCacheRuntime.clear(itemKey);
+    lastCollectionSyncVersions.delete(itemKey);
 
     const itemScheduler = perItemSchedulers.get(itemKey);
     if (itemScheduler) {
@@ -809,6 +876,23 @@ export function createCollectionStore<
     }
 
     maybeDisposeBatchScheduler(payload);
+  }
+
+  function isProtectedFromEviction(
+    itemKey: string,
+    item: CollectionItem,
+  ): boolean {
+    if (itemCacheRuntime.isActive(itemKey)) return true;
+    const scheduler = getScheduler(itemKey, item.payload);
+    if (
+      item.status === 'loading' ||
+      item.status === 'refetching' ||
+      scheduler.getFetchIsInProgress()
+    ) {
+      return true;
+    }
+
+    return scheduler.isMutationInProgress(itemKey);
   }
 
   type FilterItemsFn = (params: ItemPayload, data: ItemState | null) => boolean;
@@ -1020,6 +1104,15 @@ export function createCollectionStore<
     const results = await persistence.preloadItems(
       payloads.map((payload) => getItemKey(payload)),
     );
+    const preloadedItemKeys = payloads.flatMap((payload, index) =>
+      results[index] ? [getItemKey(payload)] : [],
+    );
+    if (preloadedItemKeys.length > 0) {
+      touchItems(preloadedItemKeys);
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
+    }
     return payloads.map((payload, index) => ({
       payload,
       preloaded: results[index] ?? false,
@@ -1045,6 +1138,8 @@ export function createCollectionStore<
       events,
       getItemKey,
       getItemState,
+      registerActiveItems,
+      touchItems,
       persistence
         ? (payloads) =>
             persistence.maybeHydrateItems(
@@ -1112,6 +1207,10 @@ export function createCollectionStore<
       itemKey,
       0,
     );
+    touchItems([itemKey]);
+    if (shouldScheduleCacheLimitEnforcement()) {
+      scheduleCacheLimitEnforcement();
+    }
     publishItemSnapshot(itemKey);
   }
 
@@ -1178,6 +1277,10 @@ export function createCollectionStore<
     });
 
     if (updatedItemKeys.size > 0) {
+      touchItems([...updatedItemKeys]);
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
       for (const itemKey of updatedItemKeys) {
         const payload = store.state[itemKey]?.payload;
         if (payload) {
@@ -1269,7 +1372,31 @@ export function createCollectionStore<
   });
 
   // Attach persistent storage after store creation
+  const { enforceCacheLimits } = createCollectionCacheLimits({
+    store,
+    maxItems,
+    itemCacheRuntime,
+    isProtectedFromEviction,
+    cleanupItemResources,
+    onStateCleanup,
+  });
+
+  const cacheLimitEnforcementScheduler = createIdleThrottledScheduler({
+    throttleMs: CACHE_LIMIT_ENFORCEMENT_THROTTLE_MS,
+    run: enforceCacheLimits,
+  });
+
+  function scheduleCacheLimitEnforcement(): void {
+    cacheLimitEnforcementScheduler.schedule();
+  }
+
   persistence?.attach(store);
+  if (store.isInitialized) {
+    touchItems(Object.keys(store.state));
+    if (shouldScheduleCacheLimitEnforcement()) {
+      scheduleCacheLimitEnforcement();
+    }
+  }
 
   /**
    * Signals that the real-time transport (e.g. WebSocket) has reconnected after
@@ -1300,6 +1427,8 @@ export function createCollectionStore<
 
     invalidationWasTriggered.clear();
     lastCollectionSyncVersions.clear();
+    itemCacheRuntime.clearAll();
+    cacheLimitEnforcementScheduler.cancel();
     browserTabsPriority.reset();
 
     persistence?.dispose();

--- a/src/collectionStore/collectionStore.ts
+++ b/src/collectionStore/collectionStore.ts
@@ -867,7 +867,6 @@ export function createCollectionStore<
   function cleanupItemResources(itemKey: string, payload: ItemPayload): void {
     invalidationWasTriggered.delete(itemKey);
     itemCacheRuntime.clear(itemKey);
-    lastCollectionSyncVersions.delete(itemKey);
 
     const itemScheduler = perItemSchedulers.get(itemKey);
     if (itemScheduler) {

--- a/src/collectionStore/useMultipleItems.ts
+++ b/src/collectionStore/useMultipleItems.ts
@@ -5,6 +5,7 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { type Emitter } from 'evtmitter';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { Store } from 't-state';
+import { useRegisterActiveKeys } from '../cacheLimits/useRegisterActiveKeys';
 import { IsOffScreenContext } from '../isOffScreenContext';
 import { FetchType } from '../requestScheduler';
 import { shouldScheduleAutomaticFetch } from '../utils/automaticFetchPolicy';
@@ -56,6 +57,8 @@ export function useMultipleItems<
   getItemState: (
     payload: ItemPayload,
   ) => TSFDCollectionItem<ItemState, ItemPayload> | null | undefined,
+  registerActiveItems: (itemKeys: string[]) => () => void,
+  touchItems: (itemKeys: string[]) => void,
   preloadItems: ((payloads: ItemPayload[]) => Promise<boolean[]>) | undefined,
   scheduleAutomaticFetch: (fetchType: FetchType, payload: ItemPayload) => void,
   invalidationWasTriggered: Set<string>,
@@ -117,6 +120,12 @@ export function useMultipleItems<
     globalDisableRefetchOnMount,
     isOffScreenFromContext,
   ]);
+
+  const activeItemKeys = useMemo(() => {
+    return queriesWithId.map(({ itemKey }) => itemKey);
+  }, [queriesWithId]);
+
+  useRegisterActiveKeys(activeItemKeys, registerActiveItems, touchItems);
 
   const resultSelector = useCallback(
     (state: CollectionState) => {

--- a/src/listQueryStore/createFetchApi.ts
+++ b/src/listQueryStore/createFetchApi.ts
@@ -587,6 +587,18 @@ export function createFetchApi<
     }
   }
 
+  function deleteQueryFetchResources(queryKeys: string[]): void {
+    for (const queryKey of queryKeys) {
+      queryInitialFetchStartTime.delete(queryKey);
+
+      const queryScheduler = querySchedulers.get(queryKey);
+      if (!queryScheduler) continue;
+
+      queryScheduler.reset();
+      querySchedulers.delete(queryKey);
+    }
+  }
+
   function getQueryState(params: QueryPayload): Query | undefined {
     const queryKey = getQueryKey(params);
     return store.state.queries[queryKey];
@@ -1102,6 +1114,7 @@ export function createFetchApi<
     getOrCreateItemScheduler,
     syncRemoteFetchStart,
     syncRemoteFetchSuccess,
+    deleteQueryFetchResources,
     deleteItemFetchResources,
     resetSchedulers,
   };

--- a/src/listQueryStore/listQueryCacheLimits.ts
+++ b/src/listQueryStore/listQueryCacheLimits.ts
@@ -247,7 +247,7 @@ export function createListQueryCacheLimits<
     if (liveItemCount <= maxItems) return;
 
     const currentQueryEntries = Object.entries(store.state.queries);
-    const referencedItemCounts = buildReferencedItemCounts(currentQueryEntries);
+    let referencedItemCounts = buildReferencedItemCounts(currentQueryEntries);
     const standaloneProtectedItemKeys =
       getStandaloneProtectedItemKeys(liveItems);
     const itemPressureQueryEvictions = currentQueryEntries
@@ -265,22 +265,26 @@ export function createListQueryCacheLimits<
         const query = store.state.queries[queryKey];
         if (!query) return [];
 
+        const nextReferencedItemCounts = new Map(referencedItemCounts);
+        let nextLiveItemCount = liveItemCount;
         let wouldFreeItems = false;
         for (const itemKey of query.items) {
-          const nextRefCount = (referencedItemCounts.get(itemKey) ?? 0) - 1;
+          const nextRefCount = (nextReferencedItemCounts.get(itemKey) ?? 0) - 1;
           if (nextRefCount > 0) {
-            referencedItemCounts.set(itemKey, nextRefCount);
+            nextReferencedItemCounts.set(itemKey, nextRefCount);
             continue;
           }
 
-          referencedItemCounts.delete(itemKey);
+          nextReferencedItemCounts.delete(itemKey);
           if (!standaloneProtectedItemKeys.has(itemKey)) {
-            liveItemCount--;
+            nextLiveItemCount--;
             wouldFreeItems = true;
           }
         }
 
         if (!wouldFreeItems) return [];
+        referencedItemCounts = nextReferencedItemCounts;
+        liveItemCount = nextLiveItemCount;
         return [queryKey];
       });
 

--- a/src/listQueryStore/listQueryCacheLimits.ts
+++ b/src/listQueryStore/listQueryCacheLimits.ts
@@ -1,0 +1,321 @@
+import { Store } from 't-state';
+import { LruCacheRuntime } from '../cacheLimits/lruCacheRuntime';
+import type { ValidPayload, ValidStoreState } from '../utils/storeShared';
+import type { ListQueryStateCleanup } from './listQueryStore';
+import type { TSDFItemQuery, TSFDListQuery, TSFDListQueryState } from './types';
+
+type LiveItemEntry<ItemPayload extends ValidPayload> = {
+  itemKey: string;
+  itemQuery: TSDFItemQuery<ItemPayload>;
+};
+
+export function createListQueryCacheLimits<
+  ItemState extends ValidStoreState,
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+>({
+  store,
+  maxItems,
+  maxQueries,
+  itemCacheRuntime,
+  queryCacheRuntime,
+  isQueryProtectedFromEviction,
+  isStandaloneItemProtectedFromEviction,
+  cleanupItemStateMetadata,
+  cleanupQueryStateMetadata,
+  deleteQueryFetchResources,
+  deleteItemFetchResources,
+  onStateCleanup,
+}: {
+  store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>;
+  maxItems: number | undefined;
+  maxQueries: number | undefined;
+  itemCacheRuntime: Pick<LruCacheRuntime, 'getLastUsed'>;
+  queryCacheRuntime: Pick<LruCacheRuntime, 'getLastUsed'>;
+  isQueryProtectedFromEviction: (
+    queryKey: string,
+    query: TSFDListQuery<QueryPayload>,
+  ) => boolean;
+  isStandaloneItemProtectedFromEviction: (
+    itemKey: string,
+    itemQuery: TSDFItemQuery<ItemPayload>,
+  ) => boolean;
+  cleanupItemStateMetadata: (itemKey: string) => void;
+  cleanupQueryStateMetadata: (queryKey: string) => void;
+  deleteQueryFetchResources: (queryKeys: string[]) => void;
+  deleteItemFetchResources: (
+    itemsToCleanup: { itemKey: string; payload: ItemPayload }[],
+  ) => void;
+  onStateCleanup:
+    | ((cleanup: ListQueryStateCleanup<QueryPayload, ItemPayload>) => void)
+    | undefined;
+}) {
+  let isEnforcingCacheLimits = false;
+
+  function getReferencedItemKeysFromQueries(
+    queryKeys: Iterable<string> = Object.keys(store.state.queries),
+  ): Set<string> {
+    const referencedItemKeys = new Set<string>();
+
+    for (const queryKey of queryKeys) {
+      const query = store.state.queries[queryKey];
+      if (!query) continue;
+
+      for (const itemKey of query.items) {
+        referencedItemKeys.add(itemKey);
+      }
+    }
+
+    return referencedItemKeys;
+  }
+
+  function getLiveItemEntries(): LiveItemEntry<ItemPayload>[] {
+    return Object.keys(store.state.items).flatMap((itemKey) => {
+      const item = store.state.items[itemKey];
+      const itemQuery = store.state.itemQueries[itemKey];
+
+      if (!item || !itemQuery) return [];
+
+      return [{ itemKey, itemQuery }];
+    });
+  }
+
+  function deleteQueriesFromState(queryKeys: string[]): void {
+    if (queryKeys.length === 0) return;
+    const queryPayloads = queryKeys.flatMap((queryKey) => {
+      const query = store.state.queries[queryKey];
+      return query ? [query.payload] : [];
+    });
+
+    isEnforcingCacheLimits = true;
+    try {
+      store.produceState(
+        (draft) => {
+          for (const queryKey of queryKeys) {
+            delete draft.queries[queryKey];
+          }
+        },
+        { action: 'evict-list-queries' },
+      );
+    } finally {
+      isEnforcingCacheLimits = false;
+    }
+
+    deleteQueryFetchResources(queryKeys);
+    for (const queryKey of queryKeys) {
+      cleanupQueryStateMetadata(queryKey);
+    }
+    onStateCleanup?.({
+      reason: 'cacheLimitEviction',
+      itemKeys: [],
+      itemPayloads: [],
+      queryKeys,
+      queryPayloads,
+    });
+  }
+
+  function deleteItemsFromState(itemKeys: string[]): void {
+    if (itemKeys.length === 0) return;
+
+    const itemsToCleanup = itemKeys.flatMap((itemKey) => {
+      const itemQuery = store.state.itemQueries[itemKey];
+      return itemQuery ? [{ itemKey, payload: itemQuery.payload }] : [];
+    });
+    const itemPayloads = itemsToCleanup.map(({ payload }) => payload);
+
+    isEnforcingCacheLimits = true;
+    try {
+      store.produceState(
+        (draft) => {
+          for (const itemKey of itemKeys) {
+            delete draft.items[itemKey];
+            delete draft.itemQueries[itemKey];
+            delete draft.itemLoadedFields[itemKey];
+            delete draft.itemFieldInvalidationFields[itemKey];
+          }
+        },
+        { action: 'evict-list-items' },
+      );
+    } finally {
+      isEnforcingCacheLimits = false;
+    }
+
+    deleteItemFetchResources(itemsToCleanup);
+    for (const itemKey of itemKeys) {
+      cleanupItemStateMetadata(itemKey);
+    }
+    onStateCleanup?.({
+      reason: 'cacheLimitEviction',
+      itemKeys,
+      itemPayloads,
+      queryKeys: [],
+      queryPayloads: [],
+    });
+  }
+
+  function collectEvictableOrphanItemKeys(
+    referencedItemKeys: Set<string>,
+  ): string[] {
+    return getLiveItemEntries()
+      .filter(({ itemKey, itemQuery }) => {
+        return (
+          !referencedItemKeys.has(itemKey) &&
+          !isStandaloneItemProtectedFromEviction(itemKey, itemQuery)
+        );
+      })
+      .map(({ itemKey }) => itemKey);
+  }
+
+  function garbageCollectOrphanItems(): void {
+    const referencedItemKeys = getReferencedItemKeysFromQueries();
+    const orphanItemKeys = collectEvictableOrphanItemKeys(referencedItemKeys);
+
+    if (orphanItemKeys.length > 0) {
+      deleteItemsFromState(orphanItemKeys);
+    }
+  }
+
+  function getStandaloneProtectedItemKeys(
+    liveItems: LiveItemEntry<ItemPayload>[],
+  ): Set<string> {
+    const protectedItemKeys = new Set<string>();
+
+    for (const { itemKey, itemQuery } of liveItems) {
+      if (isStandaloneItemProtectedFromEviction(itemKey, itemQuery)) {
+        protectedItemKeys.add(itemKey);
+      }
+    }
+
+    return protectedItemKeys;
+  }
+
+  function buildReferencedItemCounts(
+    queryEntries: [string, TSFDListQuery<QueryPayload>][],
+  ): Map<string, number> {
+    const referencedItemCounts = new Map<string, number>();
+
+    for (const [, query] of queryEntries) {
+      for (const itemKey of query.items) {
+        referencedItemCounts.set(
+          itemKey,
+          (referencedItemCounts.get(itemKey) ?? 0) + 1,
+        );
+      }
+    }
+
+    return referencedItemCounts;
+  }
+
+  function enforceCacheLimits(): void {
+    if (
+      isEnforcingCacheLimits ||
+      (maxQueries === undefined && maxItems === undefined)
+    ) {
+      return;
+    }
+
+    if (maxQueries !== undefined) {
+      const queryEntries = Object.entries(store.state.queries);
+      if (queryEntries.length > maxQueries) {
+        let remainingQueries = queryEntries.length;
+        const queryKeysToEvict = queryEntries
+          .filter(([queryKey, query]) => {
+            return !isQueryProtectedFromEviction(queryKey, query);
+          })
+          .sort(
+            ([queryKeyA], [queryKeyB]) =>
+              queryCacheRuntime.getLastUsed(queryKeyA) -
+              queryCacheRuntime.getLastUsed(queryKeyB),
+          )
+          .flatMap(([queryKey]) => {
+            if (remainingQueries <= maxQueries) return [];
+            remainingQueries--;
+            return [queryKey];
+          });
+
+        if (queryKeysToEvict.length > 0) {
+          deleteQueriesFromState(queryKeysToEvict);
+          garbageCollectOrphanItems();
+        }
+      }
+    }
+
+    if (maxItems === undefined) return;
+
+    let liveItems = getLiveItemEntries();
+    let liveItemCount = liveItems.length;
+    if (liveItemCount <= maxItems) return;
+
+    const currentQueryEntries = Object.entries(store.state.queries);
+    const referencedItemCounts = buildReferencedItemCounts(currentQueryEntries);
+    const standaloneProtectedItemKeys =
+      getStandaloneProtectedItemKeys(liveItems);
+    const itemPressureQueryEvictions = currentQueryEntries
+      .filter(([queryKey, query]) => {
+        return !isQueryProtectedFromEviction(queryKey, query);
+      })
+      .sort(
+        ([queryKeyA], [queryKeyB]) =>
+          queryCacheRuntime.getLastUsed(queryKeyA) -
+          queryCacheRuntime.getLastUsed(queryKeyB),
+      )
+      .flatMap(([queryKey]) => {
+        if (liveItemCount <= maxItems) return [];
+
+        const query = store.state.queries[queryKey];
+        if (!query) return [];
+
+        let wouldFreeItems = false;
+        for (const itemKey of query.items) {
+          const nextRefCount = (referencedItemCounts.get(itemKey) ?? 0) - 1;
+          if (nextRefCount > 0) {
+            referencedItemCounts.set(itemKey, nextRefCount);
+            continue;
+          }
+
+          referencedItemCounts.delete(itemKey);
+          if (!standaloneProtectedItemKeys.has(itemKey)) {
+            liveItemCount--;
+            wouldFreeItems = true;
+          }
+        }
+
+        if (!wouldFreeItems) return [];
+        return [queryKey];
+      });
+
+    if (itemPressureQueryEvictions.length > 0) {
+      deleteQueriesFromState(itemPressureQueryEvictions);
+      garbageCollectOrphanItems();
+    }
+
+    const referencedItemKeys = getReferencedItemKeysFromQueries();
+    liveItems = getLiveItemEntries();
+    liveItemCount = liveItems.length;
+    if (liveItemCount <= maxItems) return;
+
+    const standaloneItemKeysToEvict = liveItems
+      .filter(({ itemKey, itemQuery }) => {
+        return (
+          !referencedItemKeys.has(itemKey) &&
+          !isStandaloneItemProtectedFromEviction(itemKey, itemQuery)
+        );
+      })
+      .sort(
+        ({ itemKey: itemKeyA }, { itemKey: itemKeyB }) =>
+          itemCacheRuntime.getLastUsed(itemKeyA) -
+          itemCacheRuntime.getLastUsed(itemKeyB),
+      )
+      .flatMap(({ itemKey }) => {
+        if (liveItemCount <= maxItems) return [];
+        liveItemCount--;
+        return [itemKey];
+      });
+
+    if (standaloneItemKeysToEvict.length > 0) {
+      deleteItemsFromState(standaloneItemKeysToEvict);
+    }
+  }
+
+  return { enforceCacheLimits };
+}

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -1104,13 +1104,11 @@ export function createListQueryStore<
     itemPendingInvalidationFields.delete(itemKey);
     itemInvalidationWasTriggered.delete(itemKey);
     itemCacheRuntime.clear(itemKey);
-    lastItemSyncVersions.delete(itemKey);
   }
 
   function cleanupQueryStateMetadata(queryKey: string): void {
     queryInvalidationWasTriggered.delete(queryKey);
     queryCacheRuntime.clear(queryKey);
-    lastQuerySyncVersions.delete(queryKey);
   }
 
   function isQueryProtectedFromEviction(

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -5,6 +5,8 @@ import {
 import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { evtmitter } from 'evtmitter';
 import { Store } from 't-state';
+import { createLruCacheRuntime } from '../cacheLimits/lruCacheRuntime';
+import { createIdleThrottledScheduler } from '../cacheLimits/scheduleIdleThrottled';
 import { setupListQueryPersistence } from '../persistentStorage/listQueryStorePersistence';
 import type {
   ListQueryPersistentStorageConfig,
@@ -41,6 +43,7 @@ import {
   ValidStoreState,
 } from '../utils/storeShared';
 import { createFetchApi } from './createFetchApi';
+import { createListQueryCacheLimits } from './listQueryCacheLimits';
 import { createMutationApi } from './createMutationApi';
 import {
   type FetchListFnReturn,
@@ -99,6 +102,19 @@ export type ListQueryStore<
     TOffsetPagination
   >
 >;
+
+export type ListQueryStateCleanup<
+  QueryPayload extends ValidPayload,
+  ItemPayload extends ValidPayload,
+> = {
+  reason: 'cacheLimitEviction';
+  itemKeys: string[];
+  itemPayloads: ItemPayload[];
+  queryKeys: string[];
+  queryPayloads: QueryPayload[];
+};
+
+const CACHE_LIMIT_ENFORCEMENT_THROTTLE_MS = 60 * 60 * 1000;
 
 const noFetchItemFnError = 'No fetchItemFn was provided';
 const noPartialResourcesFieldsOptionError =
@@ -196,6 +212,14 @@ type ListQueryStoreOptionsBase<
   errorNormalizer: (exception: Error) => StoreError;
   defaultQuerySize?: number;
   maxItemBatchSize?: number;
+  /** Maximum number of cached items kept in memory. Defaults to 5,000. Item pressure may evict whole inactive queries to avoid leaving cached queries partially loaded. */
+  maxItems?: number;
+  /** Maximum number of cached queries kept in memory. Defaults to 1,000. Inactive queries are evicted in LRU order while mounted hook queries stay protected. */
+  maxQueries?: number;
+  /** Called when cache-limit eviction removes items or queries from in-memory state. */
+  onStateCleanup?: (
+    cleanup: ListQueryStateCleanup<QueryPayload, ItemPayload>,
+  ) => void;
   usesRealTimeUpdates?: boolean;
   '~test'?: {
     initialData?: ListQueryStoreInitialData<
@@ -306,6 +330,9 @@ export function createListQueryStore<
     errorNormalizer,
     defaultQuerySize = 50,
     maxItemBatchSize,
+    maxItems = 5_000,
+    maxQueries = 1_000,
+    onStateCleanup,
     usesRealTimeUpdates = false,
     '~test': testOptions,
     lowPriorityThrottleMs,
@@ -329,6 +356,8 @@ export function createListQueryStore<
   let currentBroadcastConsistency: SnapshotConsistency = 'confirmed';
   const lastQuerySyncVersions = new Map<string, BrowserTabsSyncVersion>();
   const lastItemSyncVersions = new Map<string, BrowserTabsSyncVersion>();
+  const itemCacheRuntime = createLruCacheRuntime();
+  const queryCacheRuntime = createLruCacheRuntime();
 
   type HasPR = [TPartialResources] extends [true] ? true : false;
   const offsetPagination: OffsetPaginationConfig | undefined =
@@ -552,6 +581,60 @@ export function createListQueryStore<
     );
   }
 
+  function touchQueries(queryKeys: string[]): void {
+    queryCacheRuntime.touch(queryKeys, (queryKey) => {
+      return store.state.queries[queryKey] !== undefined;
+    });
+  }
+
+  function touchItems(itemKeys: string[]): void {
+    itemCacheRuntime.touch(itemKeys, (itemKey) => {
+      return store.state.itemQueries[itemKey] !== undefined;
+    });
+  }
+
+  function registerActiveQueryRefs(queryKeys: string[]): () => void {
+    if (queryKeys.length === 0) return () => {};
+
+    const unregister = queryCacheRuntime.registerActive(queryKeys);
+
+    return () => {
+      unregister();
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
+    };
+  }
+
+  function registerActiveStandaloneItems(itemKeys: string[]): () => void {
+    if (itemKeys.length === 0) return () => {};
+
+    const unregister = itemCacheRuntime.registerActive(itemKeys);
+
+    return () => {
+      unregister();
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
+    };
+  }
+
+  function shouldScheduleCacheLimitEnforcement(): boolean {
+    if (Object.keys(store.state.queries).length > maxQueries) {
+      return true;
+    }
+
+    let itemCount = 0;
+    for (const itemQuery of Object.values(store.state.itemQueries)) {
+      if (itemQuery !== null) {
+        itemCount++;
+        if (itemCount > maxItems) return true;
+      }
+    }
+
+    return false;
+  }
+
   const getWindowIsFocused = testOptions?.getWindowIsFocused ?? isWindowFocused;
 
   function runWithoutBroadcast<T>(callback: () => T): T {
@@ -719,6 +802,20 @@ export function createListQueryStore<
     const results = await persistence.preloadQueries(
       payloads.map((queryPayload) => getQueryKey(queryPayload)),
     );
+    const preloadedQueryKeys = payloads.flatMap((queryPayload, index) =>
+      results[index] ? [getQueryKey(queryPayload)] : [],
+    );
+    if (preloadedQueryKeys.length > 0) {
+      touchQueries(preloadedQueryKeys);
+      touchItems(
+        preloadedQueryKeys.flatMap(
+          (queryKey) => store.state.queries[queryKey]?.items ?? [],
+        ),
+      );
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
+    }
     return payloads.map((queryPayload, index) => ({
       payload: queryPayload,
       preloaded: results[index] ?? false,
@@ -747,6 +844,15 @@ export function createListQueryStore<
     const results = await persistence.preloadItems(
       payloads.map((itemPayload) => getItemKey(itemPayload)),
     );
+    const preloadedItemKeys = payloads.flatMap((itemPayload, index) =>
+      results[index] ? [getItemKey(itemPayload)] : [],
+    );
+    if (preloadedItemKeys.length > 0) {
+      touchItems(preloadedItemKeys);
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
+      }
+    }
     return payloads.map((itemPayload, index) => ({
       payload: itemPayload,
       preloaded: results[index] ?? false,
@@ -769,6 +875,7 @@ export function createListQueryStore<
     getOrCreateItemScheduler,
     syncRemoteFetchStart,
     syncRemoteFetchSuccess,
+    deleteQueryFetchResources,
     deleteItemFetchResources,
     resetSchedulers,
   } = createFetchApi<ItemState, QueryPayload, ItemPayload>({
@@ -833,6 +940,17 @@ export function createListQueryStore<
       const successfulQueryKeys = requests
         .filter(({ requestId }) => results.get(requestId) === true)
         .map(({ requestId }) => requestId);
+      if (successfulQueryKeys.length > 0) {
+        touchQueries(successfulQueryKeys);
+        touchItems(
+          successfulQueryKeys.flatMap(
+            (queryKey) => store.state.queries[queryKey]?.items ?? [],
+          ),
+        );
+        if (shouldScheduleCacheLimitEnforcement()) {
+          scheduleCacheLimitEnforcement();
+        }
+      }
       const firstQueryKey = successfulQueryKeys[0];
 
       if (firstQueryKey) {
@@ -854,6 +972,12 @@ export function createListQueryStore<
       const successfulItems = requests
         .filter(({ requestId }) => results.get(requestId) === true)
         .map((request) => ({ itemKey: request.requestId }));
+      if (successfulItems.length > 0) {
+        touchItems(successfulItems.map(({ itemKey }) => itemKey));
+        if (shouldScheduleCacheLimitEnforcement()) {
+          scheduleCacheLimitEnforcement();
+        }
+      }
       const firstSuccessfulItem = successfulItems[0];
 
       if (firstSuccessfulItem) {
@@ -888,9 +1012,9 @@ export function createListQueryStore<
     invalidateQueryAndItems,
     invalidateItem,
     startItemMutation,
-    updateItemState,
-    addItemToState,
-    deleteItemState,
+    updateItemState: updateItemStateBase,
+    addItemToState: addItemToStateBase,
+    deleteItemState: deleteItemStateBase,
     resetInvalidationTracking,
     performMutation: performMutationBase,
   } = createMutationApi<ItemState, QueryPayload, ItemPayload>({
@@ -975,6 +1099,55 @@ export function createListQueryStore<
     }
   }
 
+  function cleanupItemStateMetadata(itemKey: string): void {
+    itemFieldInvalidationPriorities.delete(itemKey);
+    itemPendingInvalidationFields.delete(itemKey);
+    itemInvalidationWasTriggered.delete(itemKey);
+    itemCacheRuntime.clear(itemKey);
+    lastItemSyncVersions.delete(itemKey);
+  }
+
+  function cleanupQueryStateMetadata(queryKey: string): void {
+    queryInvalidationWasTriggered.delete(queryKey);
+    queryCacheRuntime.clear(queryKey);
+    lastQuerySyncVersions.delete(queryKey);
+  }
+
+  function isQueryProtectedFromEviction(
+    queryKey: string,
+    query: TSFDListQuery<QueryPayload>,
+  ): boolean {
+    if (queryCacheRuntime.isActive(queryKey)) return true;
+    const scheduler = getOrCreateQueryScheduler(queryKey);
+    if (
+      query.status === 'loading' ||
+      query.status === 'refetching' ||
+      query.status === 'loadingMore' ||
+      scheduler.getFetchIsInProgress()
+    ) {
+      return true;
+    }
+
+    return scheduler.isMutationInProgress(queryKey);
+  }
+
+  function isStandaloneItemProtectedFromEviction(
+    itemKey: string,
+    itemQuery: TSDFItemQuery<ItemPayload>,
+  ): boolean {
+    if (itemCacheRuntime.isActive(itemKey)) return true;
+    const scheduler = getOrCreateItemScheduler(itemKey, itemQuery.payload);
+    if (
+      itemQuery.status === 'loading' ||
+      itemQuery.status === 'refetching' ||
+      scheduler.getFetchIsInProgress()
+    ) {
+      return true;
+    }
+
+    return scheduler.isMutationInProgress(itemKey);
+  }
+
   function mergeIncomingItemSnapshot(
     currentItem: ItemState | null | undefined,
     incomingItem: ItemState | null,
@@ -1033,8 +1206,7 @@ export function createListQueryStore<
 
     itemInvalidationWasTriggered.delete(message.itemKey);
     if (message.item === null && message.itemQuery === null) {
-      itemFieldInvalidationPriorities.delete(message.itemKey);
-      itemPendingInvalidationFields.delete(message.itemKey);
+      cleanupItemStateMetadata(message.itemKey);
     }
     pruneItemInvalidationTracking();
     if (message.item === null && message.itemQuery === null) {
@@ -1042,6 +1214,11 @@ export function createListQueryStore<
         deleteItemFetchResources([
           { itemKey: message.itemKey, payload: payloadToCleanup },
         ]);
+      }
+    } else if (message.item !== null && message.itemQuery !== null) {
+      touchItems([message.itemKey]);
+      if (shouldScheduleCacheLimitEnforcement()) {
+        scheduleCacheLimitEnforcement();
       }
     }
   }
@@ -1100,6 +1277,11 @@ export function createListQueryStore<
         item.itemKey,
         toBrowserTabsSyncVersion(message, message.consistency),
       );
+    }
+    touchQueries([message.queryKey]);
+    touchItems(message.items.map(({ itemKey }) => itemKey));
+    if (shouldScheduleCacheLimitEnforcement()) {
+      scheduleCacheLimitEnforcement();
     }
   }
 
@@ -1277,6 +1459,8 @@ export function createListQueryStore<
         store,
         events,
         getQueryKey,
+        registerActiveQueryRefs,
+        touchQueries,
         getQueryState,
         persistence
           ? (payloads) =>
@@ -1339,6 +1523,8 @@ export function createListQueryStore<
       store,
       events,
       getItemKey,
+      registerActiveStandaloneItems,
+      touchItems,
       scheduleAutomaticItemFetch,
       persistence
         ? (payloads) =>
@@ -1389,6 +1575,8 @@ export function createListQueryStore<
       findItemFn,
       options,
       store,
+      registerActiveStandaloneItems,
+      touchItems,
     );
   }
 
@@ -1414,7 +1602,42 @@ export function createListQueryStore<
   });
 
   // Attach persistent storage after store creation
+  const { enforceCacheLimits } = createListQueryCacheLimits({
+    store,
+    maxItems,
+    maxQueries,
+    itemCacheRuntime,
+    queryCacheRuntime,
+    isQueryProtectedFromEviction,
+    isStandaloneItemProtectedFromEviction,
+    cleanupItemStateMetadata,
+    cleanupQueryStateMetadata,
+    deleteQueryFetchResources,
+    deleteItemFetchResources,
+    onStateCleanup,
+  });
+
+  const cacheLimitEnforcementScheduler = createIdleThrottledScheduler({
+    throttleMs: CACHE_LIMIT_ENFORCEMENT_THROTTLE_MS,
+    run: enforceCacheLimits,
+  });
+
+  function scheduleCacheLimitEnforcement(): void {
+    cacheLimitEnforcementScheduler.schedule();
+  }
+
   persistence?.attach(store);
+  if (store.isInitialized) {
+    touchQueries(Object.keys(store.state.queries));
+    touchItems(
+      Object.keys(store.state.itemQueries).filter((itemKey) => {
+        return store.state.itemQueries[itemKey] !== undefined;
+      }),
+    );
+    if (shouldScheduleCacheLimitEnforcement()) {
+      scheduleCacheLimitEnforcement();
+    }
+  }
 
   /**
    * Signals that the real-time transport (e.g. WebSocket) has reconnected after
@@ -1437,6 +1660,9 @@ export function createListQueryStore<
     resetInvalidationTracking();
     lastQuerySyncVersions.clear();
     lastItemSyncVersions.clear();
+    queryCacheRuntime.clearAll();
+    itemCacheRuntime.clearAll();
+    cacheLimitEnforcementScheduler.cancel();
     browserTabsPriority?.reset();
 
     persistence?.dispose();
@@ -1581,6 +1807,68 @@ export function createListQueryStore<
     const [options] = args;
     return awaitItemFetch(itemPayload, options);
   };
+
+  function getRelatedQueryKeysForItemEntries(
+    itemEntries: { payload: ItemPayload }[],
+  ): string[] {
+    return Array.from(
+      new Set(
+        itemEntries.flatMap(({ payload }) =>
+          getQueriesRelatedToItem(payload).map(({ key }) => key),
+        ),
+      ),
+    );
+  }
+
+  function touchUpdatedItemEntries(
+    itemEntries: { itemKey: string; payload: ItemPayload }[],
+  ): void {
+    touchItems(itemEntries.map(({ itemKey }) => itemKey));
+    touchQueries(getRelatedQueryKeysForItemEntries(itemEntries));
+    if (shouldScheduleCacheLimitEnforcement()) {
+      scheduleCacheLimitEnforcement();
+    }
+  }
+
+  function updateItemState(
+    itemIds: Parameters<typeof updateItemStateBase>[0],
+    produceNewData: Parameters<typeof updateItemStateBase>[1],
+    options?: Parameters<typeof updateItemStateBase>[2],
+  ): ReturnType<typeof updateItemStateBase> {
+    const wasUpdated = updateItemStateBase(itemIds, produceNewData, options);
+
+    if (!wasUpdated) return wasUpdated;
+
+    const itemEntries = getItemsKeyArray(itemIds);
+    touchUpdatedItemEntries(itemEntries);
+
+    return wasUpdated;
+  }
+
+  function addItemToState(
+    itemPayload: Parameters<typeof addItemToStateBase>[0],
+    data: Parameters<typeof addItemToStateBase>[1],
+    options?: Parameters<typeof addItemToStateBase>[2],
+  ): void {
+    addItemToStateBase(itemPayload, data, options);
+    touchUpdatedItemEntries([
+      { itemKey: getItemKey(itemPayload), payload: itemPayload },
+    ]);
+  }
+
+  function deleteItemState(
+    itemId: Parameters<typeof deleteItemStateBase>[0],
+  ): void {
+    const itemEntries = getItemsKeyArray(itemId);
+    const relatedQueryKeys = getRelatedQueryKeysForItemEntries(itemEntries);
+
+    deleteItemStateBase(itemId);
+
+    for (const { itemKey } of itemEntries) {
+      cleanupItemStateMetadata(itemKey);
+    }
+    touchQueries(relatedQueryKeys);
+  }
 
   return {
     store,

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -1833,11 +1833,11 @@ export function createListQueryStore<
     produceNewData: Parameters<typeof updateItemStateBase>[1],
     options?: Parameters<typeof updateItemStateBase>[2],
   ): ReturnType<typeof updateItemStateBase> {
+    const itemEntries = getItemsKeyArray(itemIds);
     const wasUpdated = updateItemStateBase(itemIds, produceNewData, options);
 
     if (!wasUpdated) return wasUpdated;
 
-    const itemEntries = getItemsKeyArray(itemIds);
     touchUpdatedItemEntries(itemEntries);
 
     return wasUpdated;

--- a/src/listQueryStore/useFindItem.ts
+++ b/src/listQueryStore/useFindItem.ts
@@ -1,6 +1,8 @@
+import { deepEqual } from '@ls-stack/utils/deepEqual';
 import { findAndMap } from '@ls-stack/utils/arrayUtils';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { Store } from 't-state';
+import { useRegisterActiveKeys } from '../cacheLimits/useRegisterActiveKeys';
 import { ValidPayload, ValidStoreState } from '../utils/storeShared';
 import type { TSFDListQueryState } from './types';
 
@@ -15,31 +17,45 @@ export function useFindItem<
     selector,
   }: { selector?: (data: ItemState, id: ItemPayload) => SelectedItem },
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
+  registerActiveItems: (itemKeys: string[]) => () => void,
+  touchItems: (itemKeys: string[]) => void,
 ): SelectedItem | null {
-  return store.useSelector((state) => {
-    const selectedItem = findAndMap(
-      Object.entries(state.items),
-      ([itemKey, item]) => {
-        if (!item) return false;
+  const selectedItem = store.useSelectorRC(
+    (state) => {
+      const matchedItem = findAndMap(
+        Object.entries(state.items),
+        ([itemKey, item]) => {
+          if (!item) return false;
 
-        const itemQuery = state.itemQueries[itemKey];
+          const itemQuery = state.itemQueries[itemKey];
 
-        if (!itemQuery) return false;
+          if (!itemQuery) return false;
 
-        if (findItemFn(item, itemQuery.payload)) {
-          return { item, itemQuery };
-        }
+          if (findItemFn(item, itemQuery.payload)) {
+            return { itemKey, item, itemQuery };
+          }
 
-        return false;
-      },
-    );
+          return false;
+        },
+      );
 
-    if (!selectedItem) return null;
+      if (!matchedItem) return null;
 
-    if (selector) {
-      return selector(selectedItem.item, selectedItem.itemQuery.payload);
-    }
+      return {
+        itemKey: matchedItem.itemKey,
+        value: selector
+          ? selector(matchedItem.item, matchedItem.itemQuery.payload)
+          : __LEGIT_CAST__<SelectedItem, ItemState>(matchedItem.item),
+      };
+    },
+    { equalityFn: deepEqual },
+  );
 
-    return __LEGIT_CAST__<SelectedItem, ItemState>(selectedItem.item);
-  });
+  useRegisterActiveKeys(
+    selectedItem?.itemKey ? [selectedItem.itemKey] : [],
+    registerActiveItems,
+    touchItems,
+  );
+
+  return selectedItem?.value ?? null;
 }

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -5,6 +5,7 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { type Emitter } from 'evtmitter';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { Store } from 't-state';
+import { useRegisterActiveKeys } from '../cacheLimits/useRegisterActiveKeys';
 import { IsOffScreenContext } from '../isOffScreenContext';
 import { FetchType, ScheduleFetchResults } from '../requestScheduler';
 import { shouldScheduleAutomaticFetch } from '../utils/automaticFetchPolicy';
@@ -68,6 +69,8 @@ export function useMultipleItems<
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
   events: Emitter<ListQueryStoreEvents>,
   getItemKey: (params: ItemPayload) => string,
+  registerActiveItems: (itemKeys: string[]) => () => void,
+  touchItems: (itemKeys: string[]) => void,
   scheduleAutomaticItemFetch: (
     fetchType: FetchType,
     payload: ItemPayload,
@@ -136,6 +139,12 @@ export function useMultipleItems<
     globalDisableRefetchOnMount,
     isOffScreenFromContext,
   ]);
+
+  const activeItemKeys = useMemo(() => {
+    return queriesWithId.map(({ itemKey }) => itemKey);
+  }, [queriesWithId]);
+
+  useRegisterActiveKeys(activeItemKeys, registerActiveItems, touchItems);
 
   const resultSelector = useCallback(
     (state: State) => {

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -6,6 +6,7 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { type Emitter } from 'evtmitter';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { Store } from 't-state';
+import { useRegisterActiveKeys } from '../cacheLimits/useRegisterActiveKeys';
 import { IsOffScreenContext } from '../isOffScreenContext';
 import { FetchType, ScheduleFetchResults } from '../requestScheduler';
 import { shouldScheduleAutomaticFetch } from '../utils/automaticFetchPolicy';
@@ -71,6 +72,8 @@ export function useMultipleListQueries<
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
   events: Emitter<ListQueryStoreEvents>,
   getQueryKey: (params: QueryPayload) => string,
+  registerActiveQueries: (queryKeys: string[]) => () => void,
+  touchQueries: (queryKeys: string[]) => void,
   getQueryState: (
     params: QueryPayload,
   ) => TSFDListQuery<QueryPayload> | undefined,
@@ -154,6 +157,10 @@ export function useMultipleListQueries<
     globalDisableRefetchOnMount,
     isOffScreenFromContext,
   ]);
+
+  const activeQueryKeys = useMemo(() => {
+    return queriesWithId.map(({ key }) => key);
+  }, [queriesWithId]);
 
   const getQueryItems = useCallback(
     (
@@ -523,6 +530,8 @@ export function useMultipleListQueries<
   });
 
   const ignoreQueriesInRefetchOnMount = useConst(() => new Set<string>());
+
+  useRegisterActiveKeys(activeQueryKeys, registerActiveQueries, touchQueries);
 
   useEffect(() => {
     const effectState = { cancelled: false };

--- a/src/persistentStorage/scheduleIdleCleanup.ts
+++ b/src/persistentStorage/scheduleIdleCleanup.ts
@@ -2,11 +2,15 @@
  * Schedules a fire-and-forget cleanup callback during idle time.
  * Uses `requestIdleCallback` when available, falls back to `setTimeout(fn, 2000)`.
  */
-export function scheduleIdleCleanup(callback: () => void): void {
+export function scheduleIdleCleanup(callback: () => void): () => void {
   // eslint-disable-next-line @ls-stack/improved-no-unnecessary-condition -- allow runtime existence check
   if (typeof requestIdleCallback === 'function') {
-    requestIdleCallback(() => callback(), { timeout: 3000 });
+    const idleCallbackId = requestIdleCallback(() => callback(), {
+      timeout: 3000,
+    });
+    return () => cancelIdleCallback(idleCallbackId);
   } else {
-    setTimeout(callback, 2000);
+    const timeoutId = setTimeout(callback, 2000);
+    return () => clearTimeout(timeoutId);
   }
 }

--- a/tests/basic-functionality/collection-store.test.ts
+++ b/tests/basic-functionality/collection-store.test.ts
@@ -3,7 +3,9 @@ import { createCollectionStore } from '../../src/collectionStore/collectionStore
 import { createCollectionStoreTestEnv } from '../mocks/collectionStoreTestEnv';
 import { DEFAULT_FETCH_DURATION_MS } from '../mocks/serverTableMock';
 import { normalizeError, TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
-import { flushAllTimers } from '../utils/genericTestUtils';
+import { advanceTime, flushAllTimers } from '../utils/genericTestUtils';
+
+const CACHE_LIMIT_ENFORCEMENT_THROTTLE_MS = 60 * 60 * 1000;
 
 type TodoItem = { title: string; completed: boolean };
 
@@ -197,6 +199,100 @@ test('initialization fetch', async () => {
       refetchOnMount: '❌'
       status: 'success'
       wasLoaded: '✅'
+  `);
+});
+
+test('maxItems evicts the least recently used inactive item from memory', async () => {
+  const env = createCollectionStoreTestEnv(
+    {
+      '1': { title: 'first', completed: false },
+      '2': { title: 'second', completed: false },
+      '3': { title: 'third', completed: false },
+    },
+    { maxItems: 2 },
+  );
+
+  env.scheduleFetch('highPriority', '1');
+  await flushAllTimers();
+  env.scheduleFetch('highPriority', '2');
+  await flushAllTimers();
+  env.scheduleFetch('highPriority', '3');
+  await flushAllTimers();
+
+  expect(env.apiStore.getItemState('1')).toBeUndefined();
+  expect(env.apiStore.getItemState('2')?.data?.value.title).toBe('second');
+  expect(env.apiStore.getItemState('3')?.data?.value.title).toBe('third');
+  expect(env.store.state['1']).toBeUndefined();
+  expect(Object.keys(env.store.state).sort()).toEqual(['"2', '"3']);
+});
+
+test('maxItems throttles repeated cache-limit evictions after the first overflow', async () => {
+  const env = createCollectionStoreTestEnv(
+    {
+      '1': { title: 'first', completed: false },
+      '2': { title: 'second', completed: false },
+      '3': { title: 'third', completed: false },
+    },
+    { maxItems: 1 },
+  );
+
+  env.apiStore.addItemToState('1', {
+    value: { title: 'first', completed: false },
+  });
+  await flushAllTimers();
+
+  env.apiStore.addItemToState('2', {
+    value: { title: 'second', completed: false },
+  });
+  await flushAllTimers();
+
+  expect(env.apiStore.getItemState('1')).toBeUndefined();
+  expect(env.apiStore.getItemState('2')?.data?.value.title).toBe('second');
+
+  env.apiStore.addItemToState('3', {
+    value: { title: 'third', completed: false },
+  });
+
+  await advanceTime(CACHE_LIMIT_ENFORCEMENT_THROTTLE_MS - 1);
+  expect(env.apiStore.getItemState('2')?.data?.value.title).toBe('second');
+  expect(env.apiStore.getItemState('3')?.data?.value.title).toBe('third');
+  expect(env.apiStore.getItemState('1')).toBeUndefined();
+  expect(env.apiStore.getItemState('2')?.data?.value.title).toBe('second');
+
+  await advanceTime(1);
+  await flushAllTimers();
+
+  expect(env.apiStore.getItemState('2')).toBeUndefined();
+  expect(env.apiStore.getItemState('3')?.data?.value.title).toBe('third');
+});
+
+test('onStateCleanup is called when cache-limit eviction removes items from memory', async () => {
+  const cleanupCalls: unknown[] = [];
+  const env = createCollectionStoreTestEnv(
+    {
+      '1': { title: 'first', completed: false },
+      '2': { title: 'second', completed: false },
+      '3': { title: 'third', completed: false },
+    },
+    {
+      maxItems: 2,
+      onStateCleanup: (cleanup) => {
+        cleanupCalls.push(cleanup);
+      },
+    },
+  );
+
+  env.scheduleFetch('highPriority', '1');
+  await flushAllTimers();
+  env.scheduleFetch('highPriority', '2');
+  await flushAllTimers();
+  env.scheduleFetch('highPriority', '3');
+  await flushAllTimers();
+
+  expect(cleanupCalls).toMatchInlineSnapshot(`
+    - itemKeys: ['"1']
+      payloads: ['1']
+      reason: 'cacheLimitEviction'
   `);
 });
 

--- a/tests/basic-functionality/list-query-state-manipulation.test.ts
+++ b/tests/basic-functionality/list-query-state-manipulation.test.ts
@@ -4,6 +4,7 @@ import {
   type Tables,
 } from '../mocks/listQueryStoreTestEnv';
 import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import { flushAllTimers } from '../utils/genericTestUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -86,6 +87,38 @@ describe('update state functions', () => {
         payload: 'users||4'
       - data: { id: 5, name: 'modified' }
         payload: 'users||5'
+    `);
+  });
+
+  test('predicate updates keep touched items fresh for cache eviction', async () => {
+    const env = createListQueryStoreTestEnv(
+      { users: range(1, 3).map((id) => ({ id, name: `User ${id}` })) },
+      { maxItems: 2 },
+    );
+
+    env.scheduleItemFetch('highPriority', 'users||1');
+    await flushAllTimers();
+    env.scheduleItemFetch('highPriority', 'users||2');
+    await flushAllTimers();
+
+    env.apiStore.updateItemState(
+      (_, state) => state.name === 'User 1',
+      (data) => {
+        data.name = 'Updated User 1';
+      },
+    );
+
+    env.scheduleItemFetch('highPriority', 'users||3');
+    await flushAllTimers();
+
+    expect(env.apiStore.getItemState('users||1')).toMatchInlineSnapshot(`
+      id: 1
+      name: 'Updated User 1'
+    `);
+    expect(env.apiStore.getItemState('users||2')).toBeUndefined();
+    expect(env.apiStore.getItemState('users||3')).toMatchInlineSnapshot(`
+      id: 3
+      name: 'User 3'
     `);
   });
 

--- a/tests/basic-functionality/list-query-store.test.ts
+++ b/tests/basic-functionality/list-query-store.test.ts
@@ -478,6 +478,64 @@ describe('fetch query', () => {
     ).toBe(true);
   });
 
+  test('maxItems ignores skipped overlapping queries when estimating item pressure', async () => {
+    const env = createListQueryStoreTestEnv(
+      {
+        users: range(1, 3).map((id) => ({
+          id,
+          age: id * 10,
+          name: `User ${id}`,
+        })),
+      },
+      { maxItems: 2 },
+    );
+
+    env.scheduleFetch('highPriority', {
+      tableId: 'users',
+      filters: [{ op: 'gt', field: 'id', value: 1 }],
+    });
+    await flushAllTimers();
+    env.scheduleFetch('highPriority', {
+      tableId: 'users',
+      filters: [{ op: 'gt', field: 'age', value: 10 }],
+    });
+    await flushAllTimers();
+    env.scheduleFetch('highPriority', {
+      tableId: 'users',
+      filters: [{ op: 'eq', field: 'id', value: 1 }],
+    });
+    await flushAllTimers();
+
+    expect(
+      env.apiStore.getQueryState({
+        tableId: 'users',
+        filters: [{ op: 'gt', field: 'age', value: 10 }],
+      })?.items,
+    ).toHaveLength(2);
+    expect(
+      env.apiStore.getQueryState({
+        tableId: 'users',
+        filters: [{ op: 'gt', field: 'id', value: 1 }],
+      })?.items,
+    ).toHaveLength(2);
+    expect(
+      env.apiStore.getQueryState({
+        tableId: 'users',
+        filters: [{ op: 'eq', field: 'id', value: 1 }],
+      }),
+    ).toBeUndefined();
+    expect(Object.keys(env.store.state.items)).toHaveLength(2);
+    expect(env.apiStore.getItemState('users||1')).toBeUndefined();
+    expect(env.apiStore.getItemState('users||2')).toMatchObject({
+      id: 2,
+      name: 'User 2',
+    });
+    expect(env.apiStore.getItemState('users||3')).toMatchObject({
+      id: 3,
+      name: 'User 3',
+    });
+  });
+
   test('onStateCleanup is called when cache-limit eviction removes queries and orphan items', async () => {
     const cleanupCalls: unknown[] = [];
     const env = createListQueryStoreTestEnv(

--- a/tests/basic-functionality/list-query-store.test.ts
+++ b/tests/basic-functionality/list-query-store.test.ts
@@ -1,3 +1,4 @@
+import { renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import {
   createListQueryStoreTestEnv,
@@ -423,6 +424,93 @@ describe('fetch query', () => {
     await flushAllTimers();
 
     expect(env.serverTable.numOfFinishedFetches).toBe(6);
+  });
+
+  test('maxQueries evicts the least recently used inactive query from memory', async () => {
+    const env = createListQueryStoreTestEnv(
+      {
+        users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+        orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+      },
+      { maxQueries: 1 },
+    );
+
+    env.scheduleFetch('highPriority', { tableId: 'users' });
+    await flushAllTimers();
+    env.scheduleFetch('highPriority', { tableId: 'orders' });
+    await flushAllTimers();
+
+    expect(env.apiStore.getQueryState({ tableId: 'users' })).toBeUndefined();
+    expect(env.apiStore.getItemState('users||1')).toBeUndefined();
+
+    const hook = renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { disableRefetchOnMount: true, returnIdleStatus: true },
+      ),
+    );
+
+    expect(hook.result.current.status).toBe('idle');
+    expect(hook.result.current.items).toEqual([]);
+  });
+
+  test('maxItems evicts whole inactive queries instead of leaving partial cached queries', async () => {
+    const env = createListQueryStoreTestEnv(
+      {
+        users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+        orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+      },
+      { maxItems: 3 },
+    );
+
+    env.scheduleFetch('highPriority', { tableId: 'users' });
+    await flushAllTimers();
+    env.scheduleFetch('highPriority', { tableId: 'orders' });
+    await flushAllTimers();
+
+    expect(env.apiStore.getQueryState({ tableId: 'users' })).toBeUndefined();
+    expect(env.apiStore.getItemState('users||1')).toBeUndefined();
+
+    const remainingQuery = env.apiStore.getQueryState({ tableId: 'orders' });
+    expect(remainingQuery?.items).toHaveLength(3);
+    expect(
+      remainingQuery?.items.every((itemKey) => env.store.state.items[itemKey]),
+    ).toBe(true);
+  });
+
+  test('onStateCleanup is called when cache-limit eviction removes queries and orphan items', async () => {
+    const cleanupCalls: unknown[] = [];
+    const env = createListQueryStoreTestEnv(
+      {
+        users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+        orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+      },
+      {
+        maxItems: 3,
+        onStateCleanup: (cleanup) => {
+          cleanupCalls.push(cleanup);
+        },
+      },
+    );
+
+    env.scheduleFetch('highPriority', { tableId: 'users' });
+    await flushAllTimers();
+    env.scheduleFetch('highPriority', { tableId: 'orders' });
+    await flushAllTimers();
+
+    expect(cleanupCalls).toMatchInlineSnapshot(`
+      - itemKeys: []
+        itemPayloads: []
+        queryKeys: ['{tableId:"users"}']
+        queryPayloads:
+          - tableId: 'users'
+        reason: 'cacheLimitEviction'
+      - itemKeys: ['"users||1', '"users||2', '"users||3']
+        itemPayloads: ['users||1', 'users||2', 'users||3']
+        queryKeys: []
+        queryPayloads: []
+        reason: 'cacheLimitEviction'
+    `);
   });
 });
 

--- a/tests/browser-tabs/browser-tabs-state-methods.test.tsx
+++ b/tests/browser-tabs/browser-tabs-state-methods.test.tsx
@@ -1,6 +1,9 @@
 import { act } from 'react';
+import { rc_object, rc_parse, rc_string } from 'runcheck';
 import { expect, test } from 'vitest';
 import {
+  type BrowserTabsTransportAuditEntry,
+  createInspectableInMemoryBrowserTabsTransportFactory,
   createInMemoryBrowserTabsTransportFactory,
   getNextStoreId,
 } from '../mocks/browserTabsTestUtils';
@@ -21,6 +24,42 @@ import {
 } from './browser-tabs-test-helpers';
 
 setupBrowserTabsTestLifecycle();
+
+const collectionSnapshotWithNameSchema = rc_object({
+  kind: rc_string,
+  item: rc_object({
+    data: rc_object({ value: rc_object({ name: rc_string }) }),
+  }),
+});
+
+const listItemSnapshotWithNameSchema = rc_object({
+  kind: rc_string,
+  item: rc_object({ name: rc_string }),
+});
+
+function isCollectionSnapshotWithName(
+  entry: BrowserTabsTransportAuditEntry,
+  expectedName: string,
+): boolean {
+  const result = rc_parse(entry.message, collectionSnapshotWithNameSchema);
+  return (
+    result.ok &&
+    result.value.kind === 'collection-item-snapshot' &&
+    result.value.item.data.value.name === expectedName
+  );
+}
+
+function isListItemSnapshotWithName(
+  entry: BrowserTabsTransportAuditEntry,
+  expectedName: string,
+): boolean {
+  const result = rc_parse(entry.message, listItemSnapshotWithNameSchema);
+  return (
+    result.ok &&
+    result.value.kind === 'list-item-snapshot' &&
+    result.value.item.name === expectedName
+  );
+}
 
 test('document updateState changes are applied to background tabs', async () => {
   const transportFactory = createInMemoryBrowserTabsTransportFactory();
@@ -297,6 +336,85 @@ test('local collection eviction does not broadcast deletion-like snapshots to ba
   expect(envB.apiStore.getItemState('item2')?.data).toEqual({
     value: { name: 'Item 2' },
   });
+});
+
+test('collection delete tombstones still reject delayed older snapshots', async () => {
+  const transport = createInspectableInMemoryBrowserTabsTransportFactory();
+  const id = getNextStoreId('collection-delete-stale-snapshot');
+  const sharedServerTableState = createSharedServerTableState(
+    createCollectionItems(),
+  );
+
+  const envA = createCollectionStoreTestEnv(createCollectionItems(), {
+    id,
+    sharedServerTableState,
+    browserTabsTransportFactory: transport.transportFactory,
+    testScenario: 'loaded',
+  });
+  const envB = createCollectionStoreTestEnv(createCollectionItems(), {
+    id,
+    sharedServerTableState,
+    browserTabsTransportFactory: transport.transportFactory,
+    testScenario: 'loaded',
+  });
+
+  envB.apiStore.updateItemState('item1', (draft) => {
+    draft.value.name = 'Older remote value';
+  });
+  await advanceTime(0);
+
+  const oldSnapshot = transport
+    .getMessages()
+    .find((entry) => isCollectionSnapshotWithName(entry, 'Older remote value'));
+
+  expect(oldSnapshot).toBeDefined();
+
+  envA.apiStore.deleteItemState('item1');
+  await advanceTime(0);
+
+  transport.replayMessage(oldSnapshot!);
+  await advanceTime(0);
+
+  expect(envA.apiStore.getItemState('item1')).toBeNull();
+});
+
+test('list-item delete tombstones still reject delayed older snapshots', async () => {
+  const transport = createInspectableInMemoryBrowserTabsTransportFactory();
+  const id = getNextStoreId('list-item-delete-stale-snapshot');
+  const sharedServerTableState =
+    createSharedListQueryServerTableState(createUsersTable());
+
+  const envA = createListQueryStoreTestEnv(createUsersTable(), {
+    id,
+    sharedServerTableState,
+    browserTabsTransportFactory: transport.transportFactory,
+    testScenario: { loaded: { tables: ['users'] } },
+  });
+  const envB = createListQueryStoreTestEnv(createUsersTable(), {
+    id,
+    sharedServerTableState,
+    browserTabsTransportFactory: transport.transportFactory,
+    testScenario: { loaded: { tables: ['users'] } },
+  });
+
+  envB.apiStore.updateItemState('users||1', (draft) => {
+    draft.name = 'Older remote value';
+  });
+  await advanceTime(0);
+
+  const oldSnapshot = transport
+    .getMessages()
+    .find((entry) => isListItemSnapshotWithName(entry, 'Older remote value'));
+
+  expect(oldSnapshot).toBeDefined();
+
+  envA.apiStore.deleteItemState('users||1');
+  await advanceTime(0);
+
+  transport.replayMessage(oldSnapshot!);
+  await advanceTime(0);
+
+  expect(envA.apiStore.getItemState('users||1')).toBeNull();
 });
 
 test('document state updates do not sync to tabs without an active session key', async () => {

--- a/tests/browser-tabs/browser-tabs-state-methods.test.tsx
+++ b/tests/browser-tabs/browser-tabs-state-methods.test.tsx
@@ -258,6 +258,47 @@ test('list query state changes emitted during an in-flight mutation sync immedia
   await mutationPromise;
 });
 
+test('local collection eviction does not broadcast deletion-like snapshots to background tabs', async () => {
+  const transportFactory = createInMemoryBrowserTabsTransportFactory();
+  const id = getNextStoreId('collection-local-eviction');
+  const sharedServerTableState = createSharedServerTableState({
+    item1: { name: 'Item 1' },
+    item2: { name: 'Item 2' },
+  });
+
+  const envA = createCollectionStoreTestEnv(
+    { item1: { name: 'Item 1' }, item2: { name: 'Item 2' } },
+    {
+      id,
+      maxItems: 1,
+      sharedServerTableState,
+      browserTabsTransportFactory: transportFactory,
+      testScenario: { loadedWithStaleData: { item1: { name: 'Item 1' } } },
+    },
+  );
+  const envB = createCollectionStoreTestEnv(
+    { item1: { name: 'Item 1' }, item2: { name: 'Item 2' } },
+    {
+      id,
+      sharedServerTableState,
+      browserTabsTransportFactory: transportFactory,
+      testScenario: { loadedWithStaleData: { item1: { name: 'Item 1' } } },
+    },
+  );
+
+  envA.scheduleFetch('highPriority', 'item2');
+  await flushAllTimers();
+  await advanceTime(0);
+
+  expect(envA.apiStore.getItemState('item1')).toBeUndefined();
+  expect(envB.apiStore.getItemState('item1')?.data).toEqual({
+    value: { name: 'Item 1' },
+  });
+  expect(envB.apiStore.getItemState('item2')?.data).toEqual({
+    value: { name: 'Item 2' },
+  });
+});
+
 test('document state updates do not sync to tabs without an active session key', async () => {
   const transportFactory = createInMemoryBrowserTabsTransportFactory();
   const id = getNextStoreId('document-state-no-session');

--- a/tests/hooks/collection-hooks-2.test.tsx
+++ b/tests/hooks/collection-hooks-2.test.tsx
@@ -253,6 +253,41 @@ test('maxItems keeps active hook items and allows protected overflow', async () 
   expect(env.apiStore.getItemState('3')).toBeUndefined();
 });
 
+test('maxItems keeps a mounted item protected after delete and refetch', async () => {
+  const env = createCollectionStoreTestEnv<Todo>(
+    {
+      '1': { title: 'one', completed: false },
+      '2': { title: 'two', completed: false },
+    },
+    { maxItems: 1 },
+  );
+
+  env.scheduleFetch('highPriority', '1');
+  await flushAllTimers();
+
+  renderHook(() =>
+    env.apiStore.useItem('1', {
+      disableRefetchOnMount: true,
+      returnRefetchingStatus: true,
+    }),
+  );
+
+  await flushAllTimers();
+
+  act(() => {
+    env.apiStore.deleteItemState('1');
+  });
+  await flushAllTimers();
+
+  env.scheduleFetch('highPriority', '1');
+  await flushAllTimers();
+  env.scheduleFetch('highPriority', '2');
+  await flushAllTimers();
+
+  expect(env.apiStore.getItemState('1')?.data?.value.title).toBe('one');
+  expect(env.apiStore.getItemState('2')).toBeUndefined();
+});
+
 test('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
   const env = createCollectionStoreTestEnv<Todo>(
     { '1': defaultTodo, '2': defaultTodo },

--- a/tests/hooks/collection-hooks-2.test.tsx
+++ b/tests/hooks/collection-hooks-2.test.tsx
@@ -220,6 +220,39 @@ test('disable then enable isOffScreen', async () => {
   expect(env.serverTable.numOfFinishedFetches).toBe(1);
 });
 
+test('maxItems keeps active hook items and allows protected overflow', async () => {
+  const env = createCollectionStoreTestEnv<Todo>(
+    {
+      '1': { title: 'one', completed: false },
+      '2': { title: 'two', completed: false },
+      '3': { title: 'three', completed: false },
+    },
+    { maxItems: 1 },
+  );
+
+  env.scheduleFetch('highPriority', '1');
+  env.scheduleFetch('highPriority', '2');
+  await flushAllTimers();
+
+  const queries = [{ payload: '1' }, { payload: '2' }];
+  renderHook(() =>
+    env.apiStore.useMultipleItems(queries, {
+      disableRefetchOnMount: true,
+      returnRefetchingStatus: true,
+    }),
+  );
+
+  await flushAllTimers();
+
+  env.scheduleFetch('highPriority', '3');
+  await flushAllTimers();
+
+  expect(Object.keys(env.store.state).sort()).toEqual(['"1', '"2']);
+  expect(env.apiStore.getItemState('1')?.data?.value.title).toBe('one');
+  expect(env.apiStore.getItemState('2')?.data?.value.title).toBe('two');
+  expect(env.apiStore.getItemState('3')).toBeUndefined();
+});
+
 test('useMultipleItems should not trigger a mount refetch when some option changes', async () => {
   const env = createCollectionStoreTestEnv<Todo>(
     { '1': defaultTodo, '2': defaultTodo },

--- a/tests/hooks/list-query-hooks-3.test.tsx
+++ b/tests/hooks/list-query-hooks-3.test.tsx
@@ -1012,3 +1012,100 @@ test('medium priority on loaded list query applies delay', async () => {
     "
   `);
 });
+
+test('maxItems keeps active list-query hooks and their items in memory', async () => {
+  const env = createListQueryStoreTestEnv(
+    {
+      users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+      orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+    },
+    { maxItems: 1 },
+  );
+
+  env.scheduleFetch('highPriority', { tableId: 'users' });
+  await flushAllTimers();
+
+  const usersQuery = { tableId: 'users' } as const;
+  renderHook(() =>
+    env.apiStore.useListQuery(usersQuery, {
+      disableRefetchOnMount: true,
+      returnRefetchingStatus: true,
+    }),
+  );
+
+  await flushAllTimers();
+
+  env.scheduleFetch('highPriority', { tableId: 'orders' });
+  await flushAllTimers();
+
+  expect(env.apiStore.getQueryState({ tableId: 'users' })?.items).toHaveLength(
+    3,
+  );
+  expect(env.apiStore.getQueryState({ tableId: 'orders' })).toBeUndefined();
+  expect(env.apiStore.getItemState('users||1')).toMatchObject({
+    id: 1,
+    name: 'User 1',
+  });
+});
+
+test('maxItems keeps active standalone useItem entries when their source query is evicted', async () => {
+  const env = createListQueryStoreTestEnv(
+    {
+      users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+      orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+    },
+    { maxItems: 1 },
+  );
+
+  env.scheduleFetch('highPriority', { tableId: 'users' });
+  await flushAllTimers();
+
+  const hook = renderHook(() => env.apiStore.useItem('users||1'));
+  await flushAllTimers();
+
+  env.scheduleFetch('highPriority', { tableId: 'orders' });
+  await flushAllTimers();
+
+  expect(hook.result.current.data).toMatchObject({ id: 1, name: 'User 1' });
+  expect(env.apiStore.getQueryState({ tableId: 'users' })).toBeUndefined();
+  expect(env.apiStore.getItemState('users||1')).toMatchObject({
+    id: 1,
+    name: 'User 1',
+  });
+  expect(env.apiStore.getItemState('users||2')).toBeUndefined();
+});
+
+test('maxItems keeps the item matched by useFindItem when inactive queries are evicted', async () => {
+  const env = createListQueryStoreTestEnv(
+    {
+      users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+      orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+    },
+    { maxItems: 1 },
+  );
+
+  const hook = renderHook(
+    ({ keepUsersQuery }: { keepUsersQuery: boolean }) => {
+      env.apiStore.useListQuery(keepUsersQuery ? { tableId: 'users' } : false, {
+        returnRefetchingStatus: true,
+      });
+
+      return env.apiStore.useFindItem((item) => item.name === 'User 1');
+    },
+    { initialProps: { keepUsersQuery: true } },
+  );
+  await flushAllTimers();
+
+  hook.rerender({ keepUsersQuery: false });
+  await flushAllTimers();
+
+  env.scheduleFetch('highPriority', { tableId: 'orders' });
+  await flushAllTimers();
+
+  expect(hook.result.current).toMatchObject({ id: 1, name: 'User 1' });
+  expect(env.apiStore.getItemState('users||1')).toMatchObject({
+    id: 1,
+    name: 'User 1',
+  });
+  expect(env.apiStore.getItemState('users||2')).toBeUndefined();
+});

--- a/tests/hooks/list-query-hooks-3.test.tsx
+++ b/tests/hooks/list-query-hooks-3.test.tsx
@@ -1075,6 +1075,41 @@ test('maxItems keeps active standalone useItem entries when their source query i
   expect(env.apiStore.getItemState('users||2')).toBeUndefined();
 });
 
+test('maxItems keeps a mounted list item protected after delete and refetch', async () => {
+  const env = createListQueryStoreTestEnv(
+    { users: range(1, 2).map((id) => ({ id, name: `User ${id}` })) },
+    { maxItems: 1 },
+  );
+
+  env.scheduleItemFetch('highPriority', 'users||1');
+  await flushAllTimers();
+
+  renderHook(() =>
+    env.apiStore.useItem('users||1', {
+      disableRefetchOnMount: true,
+      returnRefetchingStatus: true,
+    }),
+  );
+
+  await flushAllTimers();
+
+  act(() => {
+    env.apiStore.deleteItemState('users||1');
+  });
+  await flushAllTimers();
+
+  env.scheduleItemFetch('highPriority', 'users||1');
+  await flushAllTimers();
+  env.scheduleItemFetch('highPriority', 'users||2');
+  await flushAllTimers();
+
+  expect(env.apiStore.getItemState('users||1')).toMatchObject({
+    id: 1,
+    name: 'User 1',
+  });
+  expect(env.apiStore.getItemState('users||2')).toBeUndefined();
+});
+
 test('maxItems keeps the item matched by useFindItem when inactive queries are evicted', async () => {
   const env = createListQueryStoreTestEnv(
     {

--- a/tests/mocks/browserTabsTestUtils.ts
+++ b/tests/mocks/browserTabsTestUtils.ts
@@ -65,6 +65,16 @@ function createInMemoryBrowserTabsTransportFactoryBase() {
 
       return auditLog.filter((entry) => entry.channelName === channelName);
     },
+    replayMessage(entry: BrowserTabsTransportAuditEntry): void {
+      const listenersForChannel = listenersByChannel.get(entry.channelName);
+      if (!listenersForChannel) return;
+
+      for (const listener of listenersForChannel) {
+        setTimeout(() => {
+          listener(klona(entry.message));
+        }, 0);
+      }
+    },
   };
 }
 

--- a/tests/mocks/collectionStoreTestEnv.ts
+++ b/tests/mocks/collectionStoreTestEnv.ts
@@ -3,6 +3,7 @@ import {
   createCollectionStore,
   type CollectionBrowserTabsMessage,
   type CollectionInitialStateItem,
+  type CollectionStoreOptions,
 } from '../../src/collectionStore/collectionStore';
 import type { FetchType } from '../../src/requestScheduler';
 import type { BrowserTabsLeadershipTimings } from '../../src/utils/browserTabsLeadership';
@@ -66,8 +67,13 @@ export type CollectionStoreTestEnvOptions<D extends Record<string, unknown>> = {
   useBatchFetch?: boolean;
   /** Max items per batch (only used when useBatchFetch is true) */
   maxBatchSize?: number;
+  maxItems?: number;
   /** Optional function to group batch fetches by key */
   getItemsBatchKey?: (payload: string) => string | false;
+  onStateCleanup?: CollectionStoreOptions<
+    CollectionTestItem<D>,
+    string
+  >['onStateCleanup'];
   testScenario?: CollectionStoreTestScenario<D>;
   usesRealTimeUpdates?: boolean;
   blockWindowClose?: BlockWindowCloseHandler;
@@ -95,7 +101,9 @@ export function createCollectionStoreTestEnv<D extends Record<string, unknown>>(
     mediumPriorityDelayMs,
     useBatchFetch,
     maxBatchSize,
+    maxItems,
     getItemsBatchKey,
+    onStateCleanup,
     testScenario,
     usesRealTimeUpdates,
     blockWindowClose,
@@ -181,6 +189,8 @@ export function createCollectionStoreTestEnv<D extends Record<string, unknown>>(
     lowPriorityThrottleMs,
     baseCoalescingWindowMs,
     maxBatchSize: useBatchFetch ? maxBatchSize : undefined,
+    maxItems,
+    onStateCleanup,
     getItemsBatchKey: useBatchFetch ? getItemsBatchKey : undefined,
     fetchFn: async (payload, signal) => {
       const value = await serverTable.fetch(payload, signal);

--- a/tests/mocks/listQueryStoreTestEnv.ts
+++ b/tests/mocks/listQueryStoreTestEnv.ts
@@ -116,6 +116,9 @@ export function createListQueryStoreTestEnv<
     usesRealTimeUpdates,
     useBatchFetch,
     maxItemBatchSize,
+    maxItems,
+    maxQueries,
+    onStateCleanup,
     getItemsBatchKey,
     disableFetchItemFn,
     optimisticListUpdates,
@@ -152,6 +155,15 @@ export function createListQueryStoreTestEnv<
     useBatchFetch?: boolean;
     /** Max items per batch (only used when useBatchFetch is true) */
     maxItemBatchSize?: number;
+    maxItems?: number;
+    maxQueries?: number;
+    onStateCleanup?: ListQueryStoreOptions<
+      TRow,
+      ListQueryParams,
+      ListQueryItemPayload,
+      TPartialResources,
+      TOffsetPagination
+    >['onStateCleanup'];
     /** Optional function to group batch fetches by key */
     getItemsBatchKey?: (payload: string) => string | false;
     disableFetchItemFn?: boolean;
@@ -282,6 +294,9 @@ export function createListQueryStoreTestEnv<
     defaultQuerySize,
     usesRealTimeUpdates,
     maxItemBatchSize: useBatchFetch ? maxItemBatchSize : undefined,
+    maxItems,
+    maxQueries,
+    onStateCleanup,
     batchFetchItemFn: useBatchFetch ? batchFetchItemFn : undefined,
     getItemsBatchKey: useBatchFetch ? getItemsBatchKey : undefined,
     blockWindowClose: blockWindowClose ?? null,


### PR DESCRIPTION
Summary
- Tighten the default cache limits so list queries, collections, and individual queries stay within the new max counts and drive the LRU runtime helpers accordingly
- Add an `onStateCleanup` callback that lets consumers react whenever the stores evict items from state, helping clients stay in sync with the LRU pruning
Testing
- Not run (not requested)