### PR TITLE
Add debouncePayload option to store hooks to debounce fetches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Do not manually wire up fetch functions, error normalizers, or event handlers â€
   - `advanceTime(ms)`: wraps `vi.advanceTimersByTimeAsync(ms)` in `act()` â€” use instead of calling `vi.advanceTimersByTimeAsync()` directly
   - `range(start, end)`: creates an array of numbers from start to end (inclusive)
   - `pick(obj, keys)`: picks specific keys from an object
+- Add comments to explain the purpose of different phases of the test, especially when using `expect` statements, to make it easier for future readers to understand the intent of the test
 
 ## General Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ When adding a new feature, or adjust a existing one:
 - add jsdoc comments to the public API available to library users
   - when adding jsdoc to function arguments prefer adding them to the types/interfaces instead of the implementation, to ensure they are visible in IDEs when users hover the relevant types
 - if adding new public exports, update the relevant barrel file (`src/main.ts`)
+- if the feature requires changes to the documentation, update the relevant docs files in `docs/` and public api jsdoc comments in `src/`
 
 ## Bug fix instructions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,11 @@ TSDF provides three store types for different data patterns:
 | [Offset Pagination](./offset-pagination.md)             | List Query             | Offset/limit-based pagination with chunked invalidation              |
 | [Shared Types](./shared-types.md)                       | All                    | Common types (`StoreError`, `FetchType`, `IsOffScreenContext`, etc.) |
 
+Notable additions:
+
+- Hook payload debouncing is documented in [React Hooks](./hooks.md#debouncepayload)
+- The exported `PayloadDebounce` type is documented in [Shared Types](./shared-types.md#payloaddebounce)
+
 ## Quick Start
 
 ```tsx

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,6 +24,62 @@ These options are available across all data hooks:
 | `returnRefetchingStatus`   | `false`                                                   | When `false`, maps `refetching` status to `success` so the UI doesn't flicker during background refetches                                                   |
 | `ensureIsLoaded`           | `false`                                                   | Forces a high-priority fetch on mount and overrides status to `loading` until data is loaded. Useful for components that must show fresh data               |
 
+## `debouncePayload`
+
+Payload-based hooks support `debouncePayload` to debounce automatic fetches
+caused by rapid payload changes.
+
+This applies to:
+
+- `useItem`
+- `useListQuery`
+- `useMultipleItems`
+- `useMultipleListQueries`
+
+Behavior:
+
+- The hook still reads from state using the latest payload immediately
+- Only the automatic fetch side is delayed
+- Cached data for the latest payload is still returned right away when present
+- Intermediate payloads are skipped if they are replaced before the debounce
+  window ends
+- `useItem` and `useListQuery` throw if `debouncePayload` is combined with
+  `ensureIsLoaded`
+
+### Basic trailing debounce
+
+```tsx
+const result = store.useListQuery(filter, { debouncePayload: { ms: 200 } });
+```
+
+This waits `200ms` after the last payload change before fetching.
+
+### `leading`
+
+```tsx
+const result = store.useItem(itemId, {
+  debouncePayload: { ms: 300, leading: true },
+});
+```
+
+With `leading: true`:
+
+- The first payload in a burst may fetch immediately
+- Later payload changes inside the same burst stay debounced
+- When the debounce window ends, TSDF fetches the latest payload
+
+### `maxWait`
+
+```tsx
+const result = store.useListQuery(filter, {
+  debouncePayload: { ms: 300, maxWait: 1000 },
+});
+```
+
+`maxWait` limits how long a burst may stay deferred. Even if payload changes
+keep happening inside the debounce window, TSDF fetches the latest payload once
+`maxWait` is reached.
+
 ## useDocument
 
 **Store**: [Document Store](./document-store.md)
@@ -90,6 +146,19 @@ Passing an empty string `''` as payload returns an immediate error state with `{
 const itemName = store.useItem('item-1', { selector: (data) => data?.name });
 ```
 
+### Debouncing payload changes
+
+```tsx
+const item = store.useItem(selectedItemId, {
+  debouncePayload: { ms: 250, leading: true, maxWait: 1000 },
+});
+```
+
+This is useful when `selectedItemId` changes rapidly, such as typeahead-driven
+selection or fast keyboard navigation.
+
+`ensureIsLoaded` cannot be combined with `debouncePayload` on single hooks.
+
 ### List Query Store specific options
 
 - `loadFromStateOnly` - Don't fetch; return a cache-miss error (`{ code: 460, id: 'cache-miss' }`) if the item isn't already in the store
@@ -143,6 +212,20 @@ const result = store.useListQuery(filter, {
 store.useListQuery(filter, { loadSize: 20 }); // override defaultQuerySize
 ```
 
+### Debouncing query changes
+
+```tsx
+const result = store.useListQuery(
+  { search, status: 'open' },
+  { debouncePayload: { ms: 300, maxWait: 1200 } },
+);
+```
+
+`ensureIsLoaded` cannot be combined with `debouncePayload` on `useListQuery`.
+
+This is useful for search forms and filter panels where the query payload
+changes on every keystroke.
+
 ### Return value
 
 - `items` - Array of items (or selected items)
@@ -172,6 +255,15 @@ const items = store.useMultipleItems([
 
 Per-item options override the global options passed to the hook.
 
+You can debounce automatic fetches for rapid item-array changes:
+
+```tsx
+const items = store.useMultipleItems(
+  selectedIds.map((payload) => ({ payload })),
+  { debouncePayload: { ms: 150 } },
+);
+```
+
 ## useMultipleListQueries
 
 **Store**: [List Query Store](./list-query-store.md)
@@ -184,6 +276,14 @@ const queries = store.useMultipleListQueries([
   { payload: { projectId: 'proj-2' }, loadSize: 10 },
 ]);
 // queries[0].items, queries[1].items, etc.
+```
+
+You can debounce automatic fetches for rapid query-array changes:
+
+```tsx
+const queries = store.useMultipleListQueries(queryInputs, {
+  debouncePayload: { ms: 200, maxWait: 1000 },
+});
 ```
 
 ## useFindItem

--- a/docs/shared-types.md
+++ b/docs/shared-types.md
@@ -43,6 +43,50 @@ Payloads that identify items or queries must be one of:
 
 Payloads are converted to composite keys internally for state storage. Object payloads are serialized deterministically (key order doesn't matter).
 
+## PayloadDebounce
+
+Configuration for debouncing automatic fetches triggered by rapid payload
+changes in payload-based hooks.
+
+Supported by:
+
+- `useItem`
+- `useListQuery`
+- `useMultipleItems`
+- `useMultipleListQueries`
+
+Shape:
+
+```ts
+type PayloadDebounce = { ms: number; maxWait?: number; leading?: boolean };
+```
+
+Fields:
+
+- `ms` — debounce window in milliseconds
+- `maxWait` — optional upper bound for how long a burst may stay deferred
+- `leading` — allows the first payload in a burst to fetch immediately
+
+Important behavior:
+
+- The hook still reads from state using the latest payload immediately
+- Only the automatic fetch side is delayed
+- If cached data already exists for the latest payload, the hook can still
+  return it immediately while the fetch is deferred
+- `useItem` and `useListQuery` do not support combining `debouncePayload` with
+  `ensureIsLoaded`
+
+Example:
+
+```tsx
+const result = store.useListQuery(
+  { search, status: 'active' },
+  { debouncePayload: { ms: 300, leading: true, maxWait: 1200 } },
+);
+```
+
+See [React Hooks](./hooks.md#debouncepayload) for usage patterns.
+
 ## IsOffScreenContext
 
 A React context that disables all TSDF hooks in a subtree when set to `true`. Useful for tabs, modals, or off-screen content that shouldn't trigger fetches.

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
   "dependencies": {
     "@evtmitter/react": "^0.1.0",
     "@ls-stack/browser-utils": "^0.3.0",
-    "@ls-stack/react-utils": "^0.9.0",
-    "@ls-stack/utils": "^3.73.0",
+    "@ls-stack/react-utils": "^0.12.1",
+    "@ls-stack/utils": "^3.73.1",
     "evtmitter": "^1.0.2",
     "immer": "^11.1.3",
     "klona": "^2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@ls-stack/react-utils':
-        specifier: ^0.9.0
-        version: 0.9.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^0.12.1
+        version: 0.12.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@ls-stack/utils':
-        specifier: ^3.73.0
-        version: 3.73.0
+        specifier: ^3.73.1
+        version: 3.73.1
       evtmitter:
         specifier: ^1.0.2
         version: 1.0.2
@@ -453,8 +453,8 @@ packages:
       eslint: ^9.33.0
       typescript: ^5.9.2
 
-  '@ls-stack/react-utils@0.9.0':
-    resolution: {integrity: sha512-wy4SUO1PgQJVnb8u8NA4Gkg+uliCn+FVydWcTEVlXXHK3gsWS3hqP6cwlssc2UeXCAcecgqHZg4bgwtsGOgKFg==}
+  '@ls-stack/react-utils@0.12.1':
+    resolution: {integrity: sha512-KO0gLgDHpc88tS6pHe8Jiz5ws83r3O61TboVa29sGUWycijeLSKGDhQuR5VJfutLS8gUt7+F0OGUQ67LHeIYxA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18.0.0||^19.0.0'
@@ -463,12 +463,8 @@ packages:
     resolution: {integrity: sha512-07hSR0SSooobOov4lakqFkzL01dMWPZ3az1TUp2uq5z1LFVRQ7m2vDgdca3EPLmPTPyrlC96dRG91H0SqJENzg==}
     engines: {node: '>=20.0.0'}
 
-  '@ls-stack/utils@3.65.0':
-    resolution: {integrity: sha512-dOMK9LNuPmLRkraaRORBQqTq/JWGXyKHOKva25NhzWJgjOSZwPm/r8Ty8zd/bLCjaIO6aBUNl7zqJ6JTM6YaCQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@ls-stack/utils@3.73.0':
-    resolution: {integrity: sha512-pGLqb+fq1k0NrDGdrgMXx78iDLmVbainVCmusGWzY3t8SM1Lt7SMX+26rLv8IFnKOoEKLvesoha6WkuhYoRNCQ==}
+  '@ls-stack/utils@3.73.1':
+    resolution: {integrity: sha512-DxtUXHMWXbzbk7iVSNkPaOJ53NTFT3X5zZ3AgXijj0FWl9a11+avC9SlZ7O14rnujeZOsCSExeFYa+jVWQN4PQ==}
     engines: {node: '>=20.0.0'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2343,11 +2339,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ls-stack/react-utils@0.9.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@ls-stack/react-utils@0.12.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@evtmitter/react': 0.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@ls-stack/browser-utils': 0.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@ls-stack/utils': 3.65.0
+      '@ls-stack/utils': 3.73.1
       evtmitter: 1.0.2
       react: 19.2.3
       t-result: 0.6.1
@@ -2362,12 +2358,7 @@ snapshots:
       - react
       - react-dom
 
-  '@ls-stack/utils@3.65.0':
-    dependencies:
-      evtmitter: 1.0.2
-      t-result: 0.6.1
-
-  '@ls-stack/utils@3.73.0':
+  '@ls-stack/utils@3.73.1':
     dependencies:
       '@leeoniya/ufuzzy': 1.0.19
       evtmitter: 1.0.2

--- a/src/collectionStore/useItem.ts
+++ b/src/collectionStore/useItem.ts
@@ -2,6 +2,7 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { useMemo } from 'react';
 import { Store, useSubscribeToStore } from 't-state';
 import { FetchType } from '../requestScheduler';
+import { assertNoEnsureIsLoadedWithDebouncePayload } from '../utils/payloadDebounce';
 import {
   ValidPayload,
   ValidStoreState,
@@ -18,7 +19,14 @@ import { UseMultipleItemsOptions } from './useMultipleItems';
 export type UseItemOptions<
   ItemState extends ValidStoreState,
   Selected,
-> = UseMultipleItemsOptions<ItemState, Selected> & { ensureIsLoaded?: boolean };
+> = UseMultipleItemsOptions<ItemState, Selected> & {
+  /**
+   * Forces a high-priority fetch on mount and keeps the hook in `loading`
+   * until the current payload finishes loading. Cannot be combined with
+   * `debouncePayload`.
+   */
+  ensureIsLoaded?: boolean;
+};
 
 export function useItem<
   ItemState extends ValidStoreState,
@@ -35,6 +43,7 @@ export function useItem<
     disableRefetchOnMount,
     returnIdleStatus,
     isOffScreen,
+    debouncePayload,
   }: UseItemOptions<ItemState, Selected>,
   store: Store<TSFDCollectionState<ItemState, ItemPayload>>,
   scheduleFetch: (fetchType: FetchType, payload: ItemPayload) => void,
@@ -44,15 +53,22 @@ export function useItem<
   ) => readonly TSFDUseCollectionItemReturn<S, ItemPayload, undefined>[],
 ): TSFDUseCollectionItemReturn<Selected, ItemPayload> {
   const isInvalidPayload = payload === '';
+  const hasPayload =
+    payload !== false &&
+    payload !== null &&
+    payload !== undefined &&
+    payload !== '';
+
+  assertNoEnsureIsLoadedWithDebouncePayload(
+    'useItem',
+    ensureIsLoaded,
+    debouncePayload,
+  );
 
   const query = useMemo(
-    () =>
-      payload === false ||
-      payload === null ||
-      payload === undefined ||
-      payload === ''
-        ? []
-        : [
+    (): CollectionUseMultipleItemsQuery<ItemPayload, undefined>[] =>
+      hasPayload
+        ? [
             {
               payload,
               omitPayload,
@@ -62,19 +78,21 @@ export function useItem<
               returnIdleStatus,
               isOffScreen,
             },
-          ],
+          ]
+        : [],
     [
       disableRefetches,
       disableRefetchOnMount,
+      hasPayload,
       isOffScreen,
       omitPayload,
+      payload,
       returnIdleStatus,
       returnRefetchingStatus,
-      payload,
     ],
   );
 
-  const item = useMultipleItems(query, { selector });
+  const item = useMultipleItems(query, { selector, debouncePayload });
 
   const result = useMemo(
     (): TSFDUseCollectionItemReturn<Selected, ItemPayload> =>
@@ -102,21 +120,31 @@ export function useItem<
             isLoading: false,
             queryMetadata: undefined,
           }),
-    [item, selector, isInvalidPayload],
+    [isInvalidPayload, item, selector],
   );
+
+  const fetchQuery = hasPayload ? query[0] : undefined;
+  const isPayloadReadyForFetch = hasPayload;
 
   const [useModifyResult, emitIsLoadedEvt] = useEnsureIsLoaded(
     ensureIsLoaded,
-    !!payload,
+    hasPayload && isPayloadReadyForFetch,
     () => {
-      if (payload) {
-        scheduleFetch('highPriority', payload);
+      if (fetchQuery && isPayloadReadyForFetch) {
+        scheduleFetch('highPriority', fetchQuery.payload);
       }
     },
   );
 
   useSubscribeToStore(store, ({ observe }) => {
-    if (!ensureIsLoaded) return;
+    if (
+      !ensureIsLoaded ||
+      !hasPayload ||
+      !isPayloadReadyForFetch ||
+      !result.itemStateKey
+    ) {
+      return;
+    }
 
     observe
       .ifSelector((state) => state[result.itemStateKey]?.status)

--- a/src/collectionStore/useMultipleItems.ts
+++ b/src/collectionStore/useMultipleItems.ts
@@ -1,5 +1,6 @@
 import { useOnEvtmitterEvent } from '@evtmitter/react';
 import { useConst } from '@ls-stack/react-utils/useConst';
+import { useDebouncedValue } from '@ls-stack/react-utils/useDebouncedValue';
 import { deepEqual } from '@ls-stack/utils/deepEqual';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { type Emitter } from 'evtmitter';
@@ -9,7 +10,15 @@ import { useRegisterActiveKeys } from '../cacheLimits/useRegisterActiveKeys';
 import { IsOffScreenContext } from '../isOffScreenContext';
 import { FetchType } from '../requestScheduler';
 import { shouldScheduleAutomaticFetch } from '../utils/automaticFetchPolicy';
-import { ValidPayload, ValidStoreState } from '../utils/storeShared';
+import {
+  getPayloadDebounceOptions,
+  shouldDebouncePayload,
+} from '../utils/payloadDebounce';
+import {
+  type PayloadDebounce,
+  ValidPayload,
+  ValidStoreState,
+} from '../utils/storeShared';
 import type {
   CollectionUseMultipleItemsQuery,
   TSFDCollectionItem,
@@ -33,6 +42,12 @@ export type UseMultipleItemsOptions<
   disableRefetches?: boolean;
   disableRefetchOnMount?: boolean;
   isOffScreen?: boolean;
+  /**
+   * Debounces automatic fetches caused by payload changes, while selection
+   * still reads from the latest payload. Supports trailing debounce via `ms`,
+   * optional `leading`, and optional `maxWait`.
+   */
+  debouncePayload?: PayloadDebounce;
 };
 
 export function useMultipleItems<
@@ -50,6 +65,7 @@ export function useMultipleItems<
     disableRefetches: allItemsDisableRefetches,
     disableRefetchOnMount: allItemsDisableRefetchOnMount,
     isOffScreen: allItemsIsOffScreen,
+    debouncePayload,
   }: UseMultipleItemsOptions<ItemState, Selected>,
   store: Store<TSFDCollectionState<ItemState, ItemPayload>>,
   events: Emitter<CollectionStoreEvents>,
@@ -126,6 +142,16 @@ export function useMultipleItems<
   }, [queriesWithId]);
 
   useRegisterActiveKeys(activeItemKeys, registerActiveItems, touchItems);
+
+  const shouldDebounceFetchQueries = shouldDebouncePayload(debouncePayload);
+  const [debouncedFetchQueriesWithId] = useDebouncedValue(
+    queriesWithId,
+    shouldDebounceFetchQueries ? (debouncePayload?.ms ?? 0) : 0,
+    getPayloadDebounceOptions(debouncePayload),
+  );
+  const fetchQueriesWithId = shouldDebounceFetchQueries
+    ? debouncedFetchQueriesWithId
+    : queriesWithId;
 
   const resultSelector = useCallback(
     (state: CollectionState) => {
@@ -211,7 +237,7 @@ export function useMultipleItems<
       payload,
       isOffScreen,
       disableRefetches,
-    } of queriesWithId) {
+    } of fetchQueriesWithId) {
       if (isOffScreen) continue;
 
       if (itemKey !== event.itemKey) continue;
@@ -238,8 +264,8 @@ export function useMultipleItems<
     const effectState = { cancelled: false };
 
     void (async () => {
-      if (preloadItems && queriesWithId.length > 0) {
-        await preloadItems(queriesWithId.map(({ payload }) => payload));
+      if (preloadItems && fetchQueriesWithId.length > 0) {
+        await preloadItems(fetchQueriesWithId.map(({ payload }) => payload));
         if (effectState.cancelled) return;
       }
 
@@ -251,7 +277,7 @@ export function useMultipleItems<
         isOffScreen,
         disableRefetches,
         disableRefetchOnMount,
-      } of queriesWithId) {
+      } of fetchQueriesWithId) {
         removedQueries.delete(itemId);
 
         if (isOffScreen) continue;
@@ -299,9 +325,9 @@ export function useMultipleItems<
     };
   }, [
     getItemState,
+    fetchQueriesWithId,
     ignoreItemsInRefetchOnMount,
     preloadItems,
-    queriesWithId,
     scheduleAutomaticFetch,
   ]);
 

--- a/src/listQueryStore/useItem.ts
+++ b/src/listQueryStore/useItem.ts
@@ -2,6 +2,7 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { useMemo } from 'react';
 import { Store, useSubscribeToStore } from 't-state';
 import { FetchType, ScheduleFetchResults } from '../requestScheduler';
+import { assertNoEnsureIsLoadedWithDebouncePayload } from '../utils/payloadDebounce';
 import {
   ValidPayload,
   ValidStoreState,
@@ -20,6 +21,11 @@ export type UseItemOptions<
   ItemState extends ValidStoreState,
   Selected,
 > = UseMultipleItemsOptions<ItemState, Selected> & {
+  /**
+   * Forces a high-priority fetch on mount and keeps the hook in `loading`
+   * until the current payload finishes loading. Cannot be combined with
+   * `debouncePayload`.
+   */
   ensureIsLoaded?: boolean;
   fields?: FieldsInput;
   /**
@@ -47,6 +53,7 @@ export function useItem<
     showPartialAsRefetching,
     isOffScreen,
     fields,
+    debouncePayload,
   }: UseItemOptions<ItemState, Selected>,
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
   scheduleItemFetch: (
@@ -60,15 +67,22 @@ export function useItem<
   ) => readonly TSFDUseListItemReturn<S, ItemPayload, undefined>[],
 ): TSFDUseListItemReturn<Selected, ItemPayload> {
   const isInvalidPayload = itemPayload === '';
+  const hasPayload =
+    itemPayload !== false &&
+    itemPayload !== null &&
+    itemPayload !== undefined &&
+    itemPayload !== '';
+
+  assertNoEnsureIsLoadedWithDebouncePayload(
+    'useItem',
+    ensureIsLoaded,
+    debouncePayload,
+  );
 
   const query = useMemo(
     (): ListQueryUseMultipleItemsQuery<ItemPayload, undefined>[] =>
-      itemPayload === false ||
-      itemPayload === null ||
-      itemPayload === undefined ||
-      itemPayload === ''
-        ? []
-        : [
+      hasPayload
+        ? [
             {
               payload: itemPayload,
               fields,
@@ -79,12 +93,14 @@ export function useItem<
               returnRefetchingStatus,
               showPartialAsRefetching,
             },
-          ],
+          ]
+        : [],
     [
       itemPayload,
       fields,
       disableRefetches,
       disableRefetchOnMount,
+      hasPayload,
       isOffScreen,
       returnIdleStatus,
       returnRefetchingStatus,
@@ -95,6 +111,7 @@ export function useItem<
   const queryResult = useMultipleItems<Selected>(query, {
     selector,
     loadFromStateOnly,
+    debouncePayload,
   });
 
   const result = useMemo(
@@ -123,21 +140,33 @@ export function useItem<
             itemStateKey: '',
             queryMetadata: undefined,
           }),
-    [itemPayload, queryResult, selector, isInvalidPayload],
+    [isInvalidPayload, itemPayload, queryResult, selector],
   );
+
+  const fetchQuery = hasPayload ? query[0] : undefined;
+  const isPayloadReadyForFetch = hasPayload;
 
   const [useModifyResult, emitIsLoadedEvt] = useEnsureIsLoaded(
     ensureIsLoaded,
-    !!itemPayload,
+    hasPayload && isPayloadReadyForFetch,
     () => {
-      if (itemPayload) {
-        scheduleItemFetch('highPriority', itemPayload, { fields });
+      if (fetchQuery && isPayloadReadyForFetch) {
+        scheduleItemFetch('highPriority', fetchQuery.payload, {
+          fields: fetchQuery.fields,
+        });
       }
     },
   );
 
   useSubscribeToStore(store, ({ observe }) => {
-    if (!ensureIsLoaded || !result.itemStateKey) return;
+    if (
+      !ensureIsLoaded ||
+      !hasPayload ||
+      !isPayloadReadyForFetch ||
+      !result.itemStateKey
+    ) {
+      return;
+    }
 
     observe
       .ifSelector((state) => state.itemQueries[result.itemStateKey]?.status)

--- a/src/listQueryStore/useListQuery.ts
+++ b/src/listQueryStore/useListQuery.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Store, useSubscribeToStore } from 't-state';
 import { FetchType, ScheduleFetchResults } from '../requestScheduler';
+import { assertNoEnsureIsLoadedWithDebouncePayload } from '../utils/payloadDebounce';
 import {
   ValidPayload,
   ValidStoreState,
@@ -20,6 +21,11 @@ export type UseListQueryOptions<
   ItemPayload extends ValidPayload,
   SelectedItem,
 > = UseMultipleListQueriesOptions<ItemState, ItemPayload, SelectedItem> & {
+  /**
+   * Forces a high-priority fetch on mount and keeps the hook in `loading`
+   * until the current payload finishes loading. Cannot be combined with
+   * `debouncePayload`.
+   */
   ensureIsLoaded?: boolean;
   fields?: FieldsInput;
   /**
@@ -48,6 +54,7 @@ export function useListQuery<
     isOffScreen,
     ensureIsLoaded,
     fields,
+    debouncePayload,
   }: UseListQueryOptions<ItemState, ItemPayload, SelectedItem>,
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
   getQueryKey: (params: QueryPayload) => string,
@@ -63,15 +70,22 @@ export function useListQuery<
   ) => readonly TSFDUseListQueryReturn<S, QueryPayload, undefined>[],
 ): TSFDUseListQueryReturn<SelectedItem, QueryPayload> {
   const isInvalidPayload = payload === '';
+  const hasPayload =
+    payload !== false &&
+    payload !== null &&
+    payload !== undefined &&
+    payload !== '';
+
+  assertNoEnsureIsLoadedWithDebouncePayload(
+    'useListQuery',
+    ensureIsLoaded,
+    debouncePayload,
+  );
 
   const query = useMemo(
     (): ListQueryUseMultipleListQueriesQuery<QueryPayload, undefined>[] =>
-      payload === false ||
-      payload === null ||
-      payload === undefined ||
-      payload === ''
-        ? []
-        : [
+      hasPayload
+        ? [
             {
               payload,
               fields,
@@ -84,11 +98,13 @@ export function useListQuery<
               isOffScreen,
               loadSize,
             },
-          ],
+          ]
+        : [],
     [
       disableRefetches,
       disableRefetchOnMount,
       fields,
+      hasPayload,
       isOffScreen,
       loadSize,
       omitPayload,
@@ -99,7 +115,10 @@ export function useListQuery<
     ],
   );
 
-  const queryResult = useMultipleListQueries(query, { itemSelector });
+  const queryResult = useMultipleListQueries(query, {
+    itemSelector,
+    debouncePayload,
+  });
 
   const result = useMemo(
     (): TSFDUseListQueryReturn<SelectedItem, QueryPayload> =>
@@ -129,23 +148,37 @@ export function useListQuery<
             isLoadingMore: false,
             queryMetadata: undefined,
           }),
-    [queryResult, fields, isInvalidPayload],
+    [fields, isInvalidPayload, queryResult],
   );
 
-  const queryKey = payload ? getQueryKey(payload) : '';
+  const queryKey = hasPayload ? getQueryKey(payload) : '';
+  const fetchQuery = hasPayload ? query[0] : undefined;
+  const isPayloadReadyForFetch = hasPayload;
 
   const [useModifyResult, emitIsLoadedEvt] = useEnsureIsLoaded(
     ensureIsLoaded,
-    !!payload,
+    hasPayload && isPayloadReadyForFetch,
     () => {
-      if (payload) {
-        scheduleListQueryFetch('highPriority', payload, undefined, { fields });
+      if (fetchQuery && isPayloadReadyForFetch) {
+        scheduleListQueryFetch(
+          'highPriority',
+          fetchQuery.payload,
+          fetchQuery.loadSize,
+          { fields: fetchQuery.fields },
+        );
       }
     },
   );
 
   useSubscribeToStore(store, ({ observe }) => {
-    if (!ensureIsLoaded || !queryKey) return;
+    if (
+      !ensureIsLoaded ||
+      !hasPayload ||
+      !isPayloadReadyForFetch ||
+      !queryKey
+    ) {
+      return;
+    }
 
     observe
       .ifSelector((state) => state.queries[queryKey]?.status)

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -1,5 +1,6 @@
 import { useOnEvtmitterEvent } from '@evtmitter/react';
 import { useConst } from '@ls-stack/react-utils/useConst';
+import { useDebouncedValue } from '@ls-stack/react-utils/useDebouncedValue';
 import { deepEqual } from '@ls-stack/utils/deepEqual';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { type Emitter } from 'evtmitter';
@@ -10,7 +11,12 @@ import { IsOffScreenContext } from '../isOffScreenContext';
 import { FetchType, ScheduleFetchResults } from '../requestScheduler';
 import { shouldScheduleAutomaticFetch } from '../utils/automaticFetchPolicy';
 import {
+  getPayloadDebounceOptions,
+  shouldDebouncePayload,
+} from '../utils/payloadDebounce';
+import {
   fetchTypePriority,
+  type PayloadDebounce,
   ValidPayload,
   ValidStoreState,
 } from '../utils/storeShared';
@@ -46,6 +52,12 @@ export type UseMultipleItemsOptions<
   disableRefetches?: boolean;
   disableRefetchOnMount?: boolean;
   isOffScreen?: boolean;
+  /**
+   * Debounces automatic fetches caused by payload changes, while selection
+   * still reads from the latest payload. Supports trailing debounce via `ms`,
+   * optional `leading`, and optional `maxWait`.
+   */
+  debouncePayload?: PayloadDebounce;
 };
 
 export function useMultipleItems<
@@ -65,6 +77,7 @@ export function useMultipleItems<
     disableRefetches: allItemsDisableRefetches,
     disableRefetchOnMount: allItemsDisableRefetchOnMount,
     isOffScreen: allItemsIsOffScreen,
+    debouncePayload,
   }: UseMultipleItemsOptions<ItemState, Selected>,
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
   events: Emitter<ListQueryStoreEvents>,
@@ -145,6 +158,16 @@ export function useMultipleItems<
   }, [queriesWithId]);
 
   useRegisterActiveKeys(activeItemKeys, registerActiveItems, touchItems);
+
+  const shouldDebounceFetchQueries = shouldDebouncePayload(debouncePayload);
+  const [debouncedFetchQueriesWithId] = useDebouncedValue(
+    queriesWithId,
+    shouldDebounceFetchQueries ? (debouncePayload?.ms ?? 0) : 0,
+    getPayloadDebounceOptions(debouncePayload),
+  );
+  const fetchQueriesWithId = shouldDebounceFetchQueries
+    ? debouncedFetchQueriesWithId
+    : queriesWithId;
 
   const resultSelector = useCallback(
     (state: State) => {
@@ -364,7 +387,7 @@ export function useMultipleItems<
   useOnEvtmitterEvent(events, 'invalidateItem', ({ payload: event }) => {
     if (loadFromStateOnly || !fetchItemFn) return;
 
-    const matchingQueries = queriesWithId.filter(
+    const matchingQueries = fetchQueriesWithId.filter(
       ({ itemKey, isOffScreen }) => !isOffScreen && itemKey === event.itemKey,
     );
 
@@ -416,8 +439,8 @@ export function useMultipleItems<
     const effectState = { cancelled: false };
 
     void (async () => {
-      if (preloadItems && queriesWithId.length > 0) {
-        await preloadItems(queriesWithId.map(({ payload }) => payload));
+      if (preloadItems && fetchQueriesWithId.length > 0) {
+        await preloadItems(fetchQueriesWithId.map(({ payload }) => payload));
         if (effectState.cancelled) return;
       }
 
@@ -432,7 +455,7 @@ export function useMultipleItems<
         isOffScreen,
         disableRefetches,
         disableRefetchOnMount,
-      } of queriesWithId) {
+      } of fetchQueriesWithId) {
         removedItems.delete(itemKey);
 
         if (isOffScreen) continue;
@@ -531,7 +554,7 @@ export function useMultipleItems<
     ignoreItemsInRefetchOnMount,
     loadFromStateOnly,
     preloadItems,
-    queriesWithId,
+    fetchQueriesWithId,
     scheduleAutomaticItemFetch,
     autoFetchSignals,
     fetchItemFn,

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -1,5 +1,6 @@
 import { useOnEvtmitterEvent } from '@evtmitter/react';
 import { useConst } from '@ls-stack/react-utils/useConst';
+import { useDebouncedValue } from '@ls-stack/react-utils/useDebouncedValue';
 import { filterAndMap } from '@ls-stack/utils/arrayUtils';
 import { deepEqual } from '@ls-stack/utils/deepEqual';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
@@ -11,7 +12,12 @@ import { IsOffScreenContext } from '../isOffScreenContext';
 import { FetchType, ScheduleFetchResults } from '../requestScheduler';
 import { shouldScheduleAutomaticFetch } from '../utils/automaticFetchPolicy';
 import {
+  getPayloadDebounceOptions,
+  shouldDebouncePayload,
+} from '../utils/payloadDebounce';
+import {
   fetchTypePriority,
+  type PayloadDebounce,
   ValidPayload,
   ValidStoreState,
 } from '../utils/storeShared';
@@ -48,6 +54,12 @@ export type UseMultipleListQueriesOptions<
   disableRefetchOnMount?: boolean;
   isOffScreen?: boolean;
   loadSize?: number;
+  /**
+   * Debounces automatic fetches caused by payload changes, while selection
+   * still reads from the latest payload. Supports trailing debounce via `ms`,
+   * optional `leading`, and optional `maxWait`.
+   */
+  debouncePayload?: PayloadDebounce;
 };
 
 export function useMultipleListQueries<
@@ -68,6 +80,7 @@ export function useMultipleListQueries<
     disableRefetchOnMount: allItemsDisableRefetchOnMount,
     isOffScreen: allItemsIsOffScreen,
     loadSize: allItemsLoadSize,
+    debouncePayload,
   }: UseMultipleListQueriesOptions<ItemState, ItemPayload, SelectedItem>,
   store: Store<TSFDListQueryState<ItemState, QueryPayload, ItemPayload>>,
   events: Emitter<ListQueryStoreEvents>,
@@ -161,6 +174,16 @@ export function useMultipleListQueries<
   const activeQueryKeys = useMemo(() => {
     return queriesWithId.map(({ key }) => key);
   }, [queriesWithId]);
+
+  const shouldDebounceFetchQueries = shouldDebouncePayload(debouncePayload);
+  const [debouncedFetchQueriesWithId] = useDebouncedValue(
+    queriesWithId,
+    shouldDebounceFetchQueries ? (debouncePayload?.ms ?? 0) : 0,
+    getPayloadDebounceOptions(debouncePayload),
+  );
+  const fetchQueriesWithId = shouldDebounceFetchQueries
+    ? debouncedFetchQueriesWithId
+    : queriesWithId;
 
   const getQueryItems = useCallback(
     (
@@ -506,7 +529,7 @@ export function useMultipleListQueries<
       fields,
       isOffScreen,
       disableRefetches,
-    } of queriesWithId) {
+    } of fetchQueriesWithId) {
       if (isOffScreen) continue;
 
       if (key !== event.queryKey) continue;
@@ -537,8 +560,8 @@ export function useMultipleListQueries<
     const effectState = { cancelled: false };
 
     void (async () => {
-      if (preloadQueries && queriesWithId.length > 0) {
-        await preloadQueries(queriesWithId.map(({ payload }) => payload));
+      if (preloadQueries && fetchQueriesWithId.length > 0) {
+        await preloadQueries(fetchQueriesWithId.map(({ payload }) => payload));
         if (effectState.cancelled) return;
       }
 
@@ -552,7 +575,7 @@ export function useMultipleListQueries<
         loadSize,
         disableRefetches,
         disableRefetchOnMount,
-      } of queriesWithId) {
+      } of fetchQueriesWithId) {
         removedQueries.delete(queryId);
 
         if (isOffScreen) continue;
@@ -681,7 +704,7 @@ export function useMultipleListQueries<
     getQueryState,
     ignoreQueriesInRefetchOnMount,
     preloadQueries,
-    queriesWithId,
+    fetchQueriesWithId,
     store,
     scheduleAutomaticListQueryFetch,
     partialResources,

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ export type {
 
 // Shared types
 export type {
+  PayloadDebounce,
   StoreError,
   TSDFStatus,
   ValidPayload,

--- a/src/utils/payloadDebounce.ts
+++ b/src/utils/payloadDebounce.ts
@@ -1,0 +1,37 @@
+import type { DebounceOptions } from '@ls-stack/utils/debounce';
+import type { PayloadDebounce } from './storeShared';
+
+export function shouldDebouncePayload(
+  debouncePayload: PayloadDebounce | undefined,
+) {
+  return !!debouncePayload && debouncePayload.ms > 0;
+}
+
+export function getPayloadDebounceOptions(
+  debouncePayload: PayloadDebounce | undefined,
+): DebounceOptions | undefined {
+  if (!debouncePayload) return undefined;
+  const { leading, maxWait } = debouncePayload;
+
+  if (leading === undefined && maxWait === undefined) {
+    return undefined;
+  }
+
+  return { leading, maxWait, trailing: true };
+}
+
+export function assertNoEnsureIsLoadedWithDebouncePayload(
+  hookName: string,
+  ensureIsLoaded: boolean | undefined,
+  debouncePayload: PayloadDebounce | undefined,
+) {
+  if (
+    !import.meta.env.PROD &&
+    ensureIsLoaded &&
+    shouldDebouncePayload(debouncePayload)
+  ) {
+    throw new Error(
+      `${hookName} does not support using ensureIsLoaded together with debouncePayload.`,
+    );
+  }
+}

--- a/src/utils/storeShared.ts
+++ b/src/utils/storeShared.ts
@@ -6,6 +6,28 @@ export type ValidPayload = number | string | Record<string, unknown>;
 
 export type ValidStoreState = Record<string, unknown> | unknown[];
 
+/**
+ * Debounce settings for payload-driven automatic fetches in store hooks.
+ *
+ * The hook still reads data from state using the latest payload immediately.
+ * Only the automatic fetch side is delayed. Single hooks do not support
+ * combining this with `ensureIsLoaded`.
+ */
+export type PayloadDebounce = {
+  /** Debounce window in milliseconds before the latest payload is fetched. */
+  ms: number;
+  /**
+   * Maximum time a burst may stay deferred before the latest payload is
+   * fetched, even if changes keep happening within the debounce window.
+   */
+  maxWait?: number;
+  /**
+   * When true, the first payload in a burst may fetch immediately, and later
+   * changes within the same burst stay debounced until the wait window ends.
+   */
+  leading?: boolean;
+};
+
 export const invalidPayloadError = {
   code: 461,
   id: 'invalid-payload',

--- a/tests/hooks/collection-hooks.test.tsx
+++ b/tests/hooks/collection-hooks.test.tsx
@@ -876,6 +876,25 @@ describe('useItem isolated tests', () => {
       "
     `);
   });
+
+  test('throws when ensureIsLoaded is combined with debouncePayload', () => {
+    const env = createCollectionStoreTestEnv<Todo>({ '1': defaultTodo });
+
+    expect(() =>
+      renderHook(() =>
+        env.apiStore.useItem('1', {
+          ensureIsLoaded: true,
+          debouncePayload: { ms: 100 },
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `
+      Error#:
+        message: 'useItem does not support using ensureIsLoaded together with debouncePayload.'
+        name: 'Error'
+      `,
+    );
+  });
 });
 
 test('RTU update works', async () => {

--- a/tests/hooks/debounce-payload-hooks.test.tsx
+++ b/tests/hooks/debounce-payload-hooks.test.tsx
@@ -52,332 +52,406 @@ afterAll(() => {
 
 type Todo = { title: string; completed: boolean };
 
-// describe('collection hook payload debounce', () => {
-//   test('debouncePayload delays rapid payload changes while selection follows the latest payload', async () => {
-//     const env = createCollectionStoreTestEnv<Todo>(
-//       {
-//         '1': { title: 'one', completed: false },
-//         '2': { title: 'two', completed: true },
-//         '3': { title: 'three', completed: false },
-//       },
-//       {
-//         testScenario: {
-//           loadedWithStaleData: {
-//             '1': { title: 'one', completed: false },
-//             '2': { title: 'two', completed: true },
-//           },
-//         },
-//       },
-//     );
-
-//     const renders = createLoggerStore({
-//       filterKeys: ['status', 'payload', 'data'],
-//     });
-
-//     const { rerender } = renderHook(
-//       ({ payload }: { payload: string | false }) => {
-//         const result = env.apiStore.useItem(payload, {
-//           debouncePayload: { ms: 100 },
-//         });
-
-//         renders.add({
-//           status: result.status,
-//           payload: result.payload,
-//           data: result.data?.value ?? null,
-//         });
-//       },
-//       { initialProps: { payload: false } },
-//     );
-
-//     renders.reset();
-
-//     act(() => {
-//       rerender({ payload: '1' });
-//     });
-//     await advanceTime(50);
-
-//     act(() => {
-//       rerender({ payload: '2' });
-//     });
-//     await advanceTime(50);
-
-//     act(() => {
-//       rerender({ payload: '3' });
-//     });
-
-//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
-//       "
-//       -> status: success ⋅ payload: 1 ⋅ data: {title:one, completed:❌}
-//       -> status: success ⋅ payload: 2 ⋅ data: {title:two, completed:✅}
-//       -> status: loading ⋅ payload: 3 ⋅ data: null
-//       "
-//     `);
-
-//     expect(
-//       env.serverTable.getRequestHistory('item', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`[]`);
-
-//     await advanceTime(99);
-
-//     expect(
-//       env.serverTable.getRequestHistory('item', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`[]`);
-
-//     await advanceTime(1);
-//     await flushAllTimers();
-//     await flushAllTimers();
-
-//     expect(
-//       env.serverTable.getRequestHistory('item', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`
-//       - _type: 'item'
-//         payload: { itemId: '3' }
-//     `);
-//   });
-// });
-
-// type FetchQueryParams = { tableId: string };
-
-// describe('list query hook payload debounce', () => {
-//   test('debouncePayload delays rapid query payload changes while selection follows the latest payload', async () => {
-//     const env = createListQueryStoreTestEnv(initialServerData, {
-//       testScenario: { loaded: { tables: ['users', 'products'] } },
-//     });
-//     const listQueryStore = env.apiStore;
-
-//     const renders = createLoggerStore();
-
-//     const { rerender } = renderHook(
-//       ({ payload }: { payload: FetchQueryParams | false }) => {
-//         const queryResult = listQueryStore.useListQuery(payload, {
-//           debouncePayload: { ms: 100 },
-//           itemSelector: (data) => data.name,
-//         });
-
-//         renders.add(pick(queryResult, ['status', 'payload', 'items']));
-//       },
-//       { initialProps: { payload: false } },
-//     );
-
-//     renders.reset();
-
-//     act(() => {
-//       rerender({ payload: { tableId: 'users' } });
-//     });
-//     await advanceTime(50);
-
-//     act(() => {
-//       rerender({ payload: { tableId: 'products' } });
-//     });
-//     await advanceTime(50);
-
-//     act(() => {
-//       rerender({ payload: { tableId: 'orders' } });
-//     });
-
-//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
-//       "
-//       -> status: success ⋅ payload: {tableId:users} ⋅ items: [User 1, …(4 more)]
-//       -> status: success ⋅ payload: {tableId:products} ⋅ items: [Product 1, …(49 more)]
-//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
-//       "
-//     `);
-
-//     expect(
-//       env.serverTable.getRequestHistory('list', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`[]`);
-
-//     await advanceTime(99);
-
-//     expect(
-//       env.serverTable.getRequestHistory('list', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`[]`);
-
-//     await flushAllTimers();
-//     await flushAllTimers();
-
-//     expect(
-//       env.serverTable.getRequestHistory('list', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`
-//       - _type: 'list'
-//         payload:
-//           fields: '*'
-//           pos: { limit: 50, offset: 0 }
-//         returned_items: 50
-//     `);
-//   });
-
-//   test('debouncePayload maxWait flushes the latest query after repeated payload changes', async () => {
-//     const env = createListQueryStoreTestEnv(initialServerData, {
-//       testScenario: { loaded: { tables: ['users', 'products'] } },
-//     });
-//     const listQueryStore = env.apiStore;
-
-//     const renders = createLoggerStore();
-
-//     const { rerender } = renderHook(
-//       ({ payload }: { payload: FetchQueryParams }) => {
-//         const queryResult = listQueryStore.useListQuery(payload, {
-//           debouncePayload: { ms: 300, maxWait: 500 },
-//           itemSelector: (data) => data.name,
-//         });
-
-//         renders.add(pick(queryResult, ['status', 'payload', 'items']));
-//       },
-//       { initialProps: { payload: { tableId: 'orders' } } },
-//     );
-
-//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
-//       "
-//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
-//       "
-//     `);
-
-//     rerender({ payload: { tableId: 'users' } });
-//     await advanceTime(200);
-
-//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
-//       "
-//       ⋅⋅⋅
-//       -> status: success ⋅ payload: {tableId:users} ⋅ items: [User 1, …(4 more)]
-//       "
-//     `);
-
-//     rerender({ payload: { tableId: 'orders' } });
-//     await advanceTime(299);
-
-//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
-//       "
-//       ⋅⋅⋅
-//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
-//       "
-//     `);
-
-//     expect(env.serverTable.numOfStartedFetches).toBe(1);
-
-//     await advanceTime(1);
-//     await advanceTime(11);
-
-//     expect(env.serverTable.numOfStartedFetches).toBe(1);
-
-//     await flushAllTimers();
-
-//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
-//       "
-//       ⋅⋅⋅
-//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
-//       -> status: success ⋅ payload: {tableId:orders} ⋅ items: [Order 1, …(49 more)]
-//       "
-//     `);
-//   });
-
-//   test('debouncePayload delays rapid item payload changes while selection follows the latest payload', async () => {
-//     const env = createListQueryStoreTestEnv(initialServerData, {
-//       testScenario: { loaded: { items: ['users||1', 'products||1'] } },
-//     });
-//     const listQueryStore = env.apiStore;
-
-//     const renders = createLoggerStore();
-
-//     const { rerender } = renderHook(
-//       ({ payload }: { payload: string | false }) => {
-//         const queryResult = listQueryStore.useItem(payload, {
-//           debouncePayload: { ms: 100 },
-//         });
-
-//         renders.add(pick(queryResult, ['status', 'payload', 'data']));
-//       },
-//       { initialProps: { payload: false } },
-//     );
-
-//     renders.reset();
-
-//     rerender({ payload: 'users||1' });
-//     await advanceTime(50);
-
-//     rerender({ payload: 'products||1' });
-//     await advanceTime(50);
-
-//     rerender({ payload: 'orders||1' });
-
-//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
-//       "
-//       -> status: success ⋅ payload: users||1 ⋅ data: {id:1, name:User 1}
-//       -> status: success ⋅ payload: products||1 ⋅ data: {id:1, name:Product 1}
-//       -> status: loading ⋅ payload: orders||1 ⋅ data: null
-//       "
-//     `);
-
-//     expect(
-//       env.serverTable.getRequestHistory('item', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`[]`);
-
-//     await advanceTime(99);
-
-//     expect(
-//       env.serverTable.getRequestHistory('item', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`[]`);
-
-//     await flushAllTimers();
-//     await flushAllTimers();
-
-//     expect(
-//       env.serverTable.getRequestHistory('item', { includeTime: false }),
-//     ).toMatchInlineSnapshot(`
-//       - _type: 'item'
-//         payload: { itemId: 'orders||1' }
-//     `);
-//   });
-
-//   test('debouncePayload leading fetches immediately and debounces later payload changes', async () => {
-//     const env = createListQueryStoreTestEnv(initialServerData);
-//     const listQueryStore = env.apiStore;
-
-//     env.serverTable.setItem('users||100', { id: 100, name: 'User 100' });
-//     env.serverTable.setItem('users||101', { id: 101, name: 'User 101' });
-
-//     const renders = createLoggerStore();
-
-//     const { rerender } = renderHook(
-//       ({ payload }: { payload: string }) => {
-//         const selectionResult = listQueryStore.useItem(payload, {
-//           debouncePayload: { ms: 300, leading: true },
-//           selector: (data) => data?.name ?? null,
-//         });
-
-//         renders.add(
-//           pick(selectionResult, ['status', 'payload', 'isLoading', 'data']),
-//         );
-//       },
-//       { initialProps: { payload: 'users||100' } },
-//     );
-
-//     await advanceTime(11);
-
-//     expect(env.serverTable.numOfStartedFetches).toBe(1);
-
-//     rerender({ payload: 'users||101' });
-
-//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
-//       "
-//       -> status: loading ⋅ payload: users||100 ⋅ isLoading: ✅ ⋅ data: null
-//       -> status: loading ⋅ payload: users||101 ⋅ isLoading: ✅ ⋅ data: null
-//       "
-//     `);
-
-//     await advanceTime(299);
-//     await advanceTime(11);
-
-//     expect(env.serverTable.numOfStartedFetches).toBe(2);
-
-//     await flushAllTimers();
-
-//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
-//       "
-//       ⋅⋅⋅
-//       -> status: loading ⋅ payload: users||101 ⋅ isLoading: ✅ ⋅ data: null
-//       -> status: success ⋅ payload: users||101 ⋅ isLoading: ❌ ⋅ data: User 101
-//       "
-//     `);
-//   });
-// });
+describe('collection hook payload debounce', () => {
+  test('debouncePayload delays rapid payload changes while selection follows the latest payload', async () => {
+    const env = createCollectionStoreTestEnv<Todo>(
+      {
+        '1': { title: 'one', completed: false },
+        '2': { title: 'two', completed: true },
+        '3': { title: 'three', completed: false },
+      },
+      {
+        testScenario: {
+          loadedWithStaleData: {
+            '1': { title: 'one', completed: false },
+            '2': { title: 'two', completed: true },
+          },
+        },
+      },
+    );
+
+    const renders = createLoggerStore({
+      filterKeys: ['status', 'payload', 'data'],
+    });
+
+    const { rerender } = renderHook(
+      ({ payload }: { payload: string | false }) => {
+        const result = env.apiStore.useItem(payload, {
+          debouncePayload: { ms: 100 },
+        });
+
+        renders.add({
+          status: result.status,
+          payload: result.payload,
+          data: result.data?.value ?? null,
+        });
+      },
+      { initialProps: { payload: false } },
+    );
+
+    renders.reset();
+
+    act(() => {
+      rerender({ payload: '1' });
+    });
+    await advanceTime(50);
+
+    act(() => {
+      rerender({ payload: '2' });
+    });
+    await advanceTime(50);
+
+    act(() => {
+      rerender({ payload: '3' });
+    });
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ payload: 1 ⋅ data: {title:one, completed:❌}
+      -> status: success ⋅ payload: 2 ⋅ data: {title:two, completed:✅}
+      -> status: loading ⋅ payload: 3 ⋅ data: null
+      "
+    `);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await advanceTime(99);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await advanceTime(1);
+    await flushAllTimers();
+    await flushAllTimers();
+
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload: { itemId: '3' }
+      `);
+  });
+
+  test('debouncePayload delays fetches while switching between unloaded item payloads', async () => {
+    const env = createCollectionStoreTestEnv<Todo>({
+      '1': { title: 'one', completed: false },
+      '2': { title: 'two', completed: true },
+    });
+
+    const renders = createLoggerStore({
+      filterKeys: ['status', 'payload', 'data'],
+    });
+
+    const { rerender } = renderHook(
+      ({ payload }: { payload: string | false }) => {
+        const result = env.apiStore.useItem(payload, {
+          debouncePayload: { ms: 100 },
+        });
+
+        renders.add({
+          status: result.status,
+          payload: result.payload,
+          data: result.data?.value ?? null,
+        });
+      },
+      { initialProps: { payload: false } },
+    );
+
+    renders.reset();
+
+    act(() => {
+      rerender({ payload: '1' });
+    });
+    await advanceTime(50);
+
+    act(() => {
+      rerender({ payload: '2' });
+    });
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ payload: 1 ⋅ data: null
+      -> status: loading ⋅ payload: 2 ⋅ data: null
+      "
+    `);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await advanceTime(99);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await advanceTime(1);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await flushAllTimers();
+    await flushAllTimers();
+
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+      - _type: 'item'
+        payload: { itemId: '2' }
+    `);
+
+    expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+      "
+      ⋅⋅⋅
+      -> status: loading ⋅ payload: 2 ⋅ data: null
+      -> status: success ⋅ payload: 2 ⋅ data: {title:two, completed:✅}
+      "
+    `);
+  });
+});
+
+type FetchQueryParams = { tableId: string };
+
+describe('list query hook payload debounce', () => {
+  test('debouncePayload delays rapid query payload changes while selection follows the latest payload', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      testScenario: { loaded: { tables: ['users', 'products'] } },
+    });
+    const listQueryStore = env.apiStore;
+
+    const renders = createLoggerStore();
+
+    const { rerender } = renderHook(
+      ({ payload }: { payload: FetchQueryParams | false }) => {
+        const queryResult = listQueryStore.useListQuery(payload, {
+          debouncePayload: { ms: 100 },
+          itemSelector: (data) => data.name,
+        });
+
+        renders.add(pick(queryResult, ['status', 'payload', 'items']));
+      },
+      { initialProps: { payload: false } },
+    );
+
+    renders.reset();
+
+    act(() => {
+      rerender({ payload: { tableId: 'users' } });
+    });
+    await advanceTime(50);
+
+    act(() => {
+      rerender({ payload: { tableId: 'products' } });
+    });
+    await advanceTime(50);
+
+    act(() => {
+      rerender({ payload: { tableId: 'orders' } });
+    });
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ payload: {tableId:users} ⋅ items: [User 1, …(4 more)]
+      -> status: success ⋅ payload: {tableId:products} ⋅ items: [Product 1, …(49 more)]
+      -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+      "
+    `);
+
+    expect(
+      env.serverTable.getRequestHistory('list', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await advanceTime(99);
+
+    expect(
+      env.serverTable.getRequestHistory('list', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await flushAllTimers();
+    await flushAllTimers();
+
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: '*'
+            pos: { limit: 50, offset: 0 }
+          returned_items: 50
+      `);
+  });
+
+  test('debouncePayload maxWait flushes the latest query after repeated payload changes', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      testScenario: { loaded: { tables: ['users', 'products'] } },
+    });
+    const listQueryStore = env.apiStore;
+
+    const renders = createLoggerStore();
+
+    const { rerender } = renderHook(
+      ({ payload }: { payload: FetchQueryParams }) => {
+        const queryResult = listQueryStore.useListQuery(payload, {
+          debouncePayload: { ms: 300, maxWait: 500 },
+          itemSelector: (data) => data.name,
+        });
+
+        renders.add(pick(queryResult, ['status', 'payload', 'items']));
+      },
+      { initialProps: { payload: { tableId: 'orders' } } },
+    );
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+      "
+    `);
+
+    rerender({ payload: { tableId: 'users' } });
+    await advanceTime(200);
+
+    expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+      "
+      ⋅⋅⋅
+      -> status: success ⋅ payload: {tableId:users} ⋅ items: [User 1, …(4 more)]
+      "
+    `);
+
+    rerender({ payload: { tableId: 'orders' } });
+    await advanceTime(299);
+
+    expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+      "
+      ⋅⋅⋅
+      -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+      "
+    `);
+
+    expect(env.serverTable.numOfStartedFetches).toBe(1);
+
+    await advanceTime(1);
+    await advanceTime(11);
+
+    expect(env.serverTable.numOfStartedFetches).toBe(1);
+
+    await flushAllTimers();
+
+    expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+      "
+      ⋅⋅⋅
+      -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+      -> status: success ⋅ payload: {tableId:orders} ⋅ items: [Order 1, …(49 more)]
+      "
+    `);
+  });
+
+  test('debouncePayload delays rapid item payload changes while selection follows the latest payload', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      testScenario: { loaded: { items: ['users||1', 'products||1'] } },
+    });
+    const listQueryStore = env.apiStore;
+
+    const renders = createLoggerStore();
+
+    const { rerender } = renderHook(
+      ({ payload }: { payload: string | false }) => {
+        const queryResult = listQueryStore.useItem(payload, {
+          debouncePayload: { ms: 100 },
+        });
+
+        renders.add(pick(queryResult, ['status', 'payload', 'data']));
+      },
+      { initialProps: { payload: false } },
+    );
+
+    renders.reset();
+
+    rerender({ payload: 'users||1' });
+    await advanceTime(50);
+
+    rerender({ payload: 'products||1' });
+    await advanceTime(50);
+
+    rerender({ payload: 'orders||1' });
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ payload: users||1 ⋅ data: {id:1, name:User 1}
+      -> status: success ⋅ payload: products||1 ⋅ data: {id:1, name:Product 1}
+      -> status: loading ⋅ payload: orders||1 ⋅ data: null
+      "
+    `);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await advanceTime(99);
+
+    expect(
+      env.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`[]`);
+
+    await flushAllTimers();
+    await flushAllTimers();
+
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload: { itemId: 'orders||1' }
+      `);
+  });
+
+  test('debouncePayload leading fetches immediately and debounces later payload changes', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData);
+    const listQueryStore = env.apiStore;
+
+    env.serverTable.setItem('users||100', { id: 100, name: 'User 100' });
+    env.serverTable.setItem('users||101', { id: 101, name: 'User 101' });
+
+    const renders = createLoggerStore();
+
+    const { rerender } = renderHook(
+      ({ payload }: { payload: string }) => {
+        const selectionResult = listQueryStore.useItem(payload, {
+          debouncePayload: { ms: 300, leading: true },
+          selector: (data) => data?.name ?? null,
+        });
+
+        renders.add(
+          pick(selectionResult, ['status', 'payload', 'isLoading', 'data']),
+        );
+      },
+      { initialProps: { payload: 'users||100' } },
+    );
+
+    await advanceTime(11);
+
+    expect(env.serverTable.numOfStartedFetches).toBe(1);
+
+    rerender({ payload: 'users||101' });
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ payload: users||100 ⋅ isLoading: ✅ ⋅ data: null
+      -> status: loading ⋅ payload: users||101 ⋅ isLoading: ✅ ⋅ data: null
+      "
+    `);
+
+    await advanceTime(299);
+    await advanceTime(11);
+
+    expect(env.serverTable.numOfStartedFetches).toBe(2);
+
+    await flushAllTimers();
+
+    expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+      "
+      ⋅⋅⋅
+      -> status: loading ⋅ payload: users||101 ⋅ isLoading: ✅ ⋅ data: null
+      -> status: success ⋅ payload: users||101 ⋅ isLoading: ❌ ⋅ data: User 101
+      "
+    `);
+  });
+});

--- a/tests/hooks/debounce-payload-hooks.test.tsx
+++ b/tests/hooks/debounce-payload-hooks.test.tsx
@@ -1,0 +1,383 @@
+import { createLoggerStore } from '@ls-stack/utils/testUtils';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import '@testing-library/react/dont-cleanup-after-each';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import { createCollectionStoreTestEnv } from '../mocks/collectionStoreTestEnv';
+import { ignoreNotWrappedInActErrors } from '../mocks/ignoreNotWrappedInActErrors';
+import {
+  createListQueryStoreTestEnv,
+  type Tables,
+} from '../mocks/listQueryStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import {
+  advanceTime,
+  flushAllTimers,
+  pick,
+  range,
+} from '../utils/genericTestUtils';
+
+const initialServerData: Tables = {
+  users: range(1, 5).map((id) => ({ id, name: `User ${id}` })),
+  products: range(1, 50).map((id) => ({ id, name: `Product ${id}` })),
+  orders: range(1, 50).map((id) => ({ id, name: `Order ${id}` })),
+};
+
+const restoreConsoleError = ignoreNotWrappedInActErrors();
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+beforeEach(() => {
+  vi.setSystemTime(TEST_INITIAL_TIME);
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+});
+
+afterAll(() => {
+  restoreConsoleError();
+  cleanup();
+});
+
+type Todo = { title: string; completed: boolean };
+
+// describe('collection hook payload debounce', () => {
+//   test('debouncePayload delays rapid payload changes while selection follows the latest payload', async () => {
+//     const env = createCollectionStoreTestEnv<Todo>(
+//       {
+//         '1': { title: 'one', completed: false },
+//         '2': { title: 'two', completed: true },
+//         '3': { title: 'three', completed: false },
+//       },
+//       {
+//         testScenario: {
+//           loadedWithStaleData: {
+//             '1': { title: 'one', completed: false },
+//             '2': { title: 'two', completed: true },
+//           },
+//         },
+//       },
+//     );
+
+//     const renders = createLoggerStore({
+//       filterKeys: ['status', 'payload', 'data'],
+//     });
+
+//     const { rerender } = renderHook(
+//       ({ payload }: { payload: string | false }) => {
+//         const result = env.apiStore.useItem(payload, {
+//           debouncePayload: { ms: 100 },
+//         });
+
+//         renders.add({
+//           status: result.status,
+//           payload: result.payload,
+//           data: result.data?.value ?? null,
+//         });
+//       },
+//       { initialProps: { payload: false } },
+//     );
+
+//     renders.reset();
+
+//     act(() => {
+//       rerender({ payload: '1' });
+//     });
+//     await advanceTime(50);
+
+//     act(() => {
+//       rerender({ payload: '2' });
+//     });
+//     await advanceTime(50);
+
+//     act(() => {
+//       rerender({ payload: '3' });
+//     });
+
+//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+//       "
+//       -> status: success ⋅ payload: 1 ⋅ data: {title:one, completed:❌}
+//       -> status: success ⋅ payload: 2 ⋅ data: {title:two, completed:✅}
+//       -> status: loading ⋅ payload: 3 ⋅ data: null
+//       "
+//     `);
+
+//     expect(
+//       env.serverTable.getRequestHistory('item', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`[]`);
+
+//     await advanceTime(99);
+
+//     expect(
+//       env.serverTable.getRequestHistory('item', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`[]`);
+
+//     await advanceTime(1);
+//     await flushAllTimers();
+//     await flushAllTimers();
+
+//     expect(
+//       env.serverTable.getRequestHistory('item', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`
+//       - _type: 'item'
+//         payload: { itemId: '3' }
+//     `);
+//   });
+// });
+
+// type FetchQueryParams = { tableId: string };
+
+// describe('list query hook payload debounce', () => {
+//   test('debouncePayload delays rapid query payload changes while selection follows the latest payload', async () => {
+//     const env = createListQueryStoreTestEnv(initialServerData, {
+//       testScenario: { loaded: { tables: ['users', 'products'] } },
+//     });
+//     const listQueryStore = env.apiStore;
+
+//     const renders = createLoggerStore();
+
+//     const { rerender } = renderHook(
+//       ({ payload }: { payload: FetchQueryParams | false }) => {
+//         const queryResult = listQueryStore.useListQuery(payload, {
+//           debouncePayload: { ms: 100 },
+//           itemSelector: (data) => data.name,
+//         });
+
+//         renders.add(pick(queryResult, ['status', 'payload', 'items']));
+//       },
+//       { initialProps: { payload: false } },
+//     );
+
+//     renders.reset();
+
+//     act(() => {
+//       rerender({ payload: { tableId: 'users' } });
+//     });
+//     await advanceTime(50);
+
+//     act(() => {
+//       rerender({ payload: { tableId: 'products' } });
+//     });
+//     await advanceTime(50);
+
+//     act(() => {
+//       rerender({ payload: { tableId: 'orders' } });
+//     });
+
+//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+//       "
+//       -> status: success ⋅ payload: {tableId:users} ⋅ items: [User 1, …(4 more)]
+//       -> status: success ⋅ payload: {tableId:products} ⋅ items: [Product 1, …(49 more)]
+//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+//       "
+//     `);
+
+//     expect(
+//       env.serverTable.getRequestHistory('list', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`[]`);
+
+//     await advanceTime(99);
+
+//     expect(
+//       env.serverTable.getRequestHistory('list', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`[]`);
+
+//     await flushAllTimers();
+//     await flushAllTimers();
+
+//     expect(
+//       env.serverTable.getRequestHistory('list', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`
+//       - _type: 'list'
+//         payload:
+//           fields: '*'
+//           pos: { limit: 50, offset: 0 }
+//         returned_items: 50
+//     `);
+//   });
+
+//   test('debouncePayload maxWait flushes the latest query after repeated payload changes', async () => {
+//     const env = createListQueryStoreTestEnv(initialServerData, {
+//       testScenario: { loaded: { tables: ['users', 'products'] } },
+//     });
+//     const listQueryStore = env.apiStore;
+
+//     const renders = createLoggerStore();
+
+//     const { rerender } = renderHook(
+//       ({ payload }: { payload: FetchQueryParams }) => {
+//         const queryResult = listQueryStore.useListQuery(payload, {
+//           debouncePayload: { ms: 300, maxWait: 500 },
+//           itemSelector: (data) => data.name,
+//         });
+
+//         renders.add(pick(queryResult, ['status', 'payload', 'items']));
+//       },
+//       { initialProps: { payload: { tableId: 'orders' } } },
+//     );
+
+//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+//       "
+//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+//       "
+//     `);
+
+//     rerender({ payload: { tableId: 'users' } });
+//     await advanceTime(200);
+
+//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+//       "
+//       ⋅⋅⋅
+//       -> status: success ⋅ payload: {tableId:users} ⋅ items: [User 1, …(4 more)]
+//       "
+//     `);
+
+//     rerender({ payload: { tableId: 'orders' } });
+//     await advanceTime(299);
+
+//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+//       "
+//       ⋅⋅⋅
+//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+//       "
+//     `);
+
+//     expect(env.serverTable.numOfStartedFetches).toBe(1);
+
+//     await advanceTime(1);
+//     await advanceTime(11);
+
+//     expect(env.serverTable.numOfStartedFetches).toBe(1);
+
+//     await flushAllTimers();
+
+//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+//       "
+//       ⋅⋅⋅
+//       -> status: loading ⋅ payload: {tableId:orders} ⋅ items: []
+//       -> status: success ⋅ payload: {tableId:orders} ⋅ items: [Order 1, …(49 more)]
+//       "
+//     `);
+//   });
+
+//   test('debouncePayload delays rapid item payload changes while selection follows the latest payload', async () => {
+//     const env = createListQueryStoreTestEnv(initialServerData, {
+//       testScenario: { loaded: { items: ['users||1', 'products||1'] } },
+//     });
+//     const listQueryStore = env.apiStore;
+
+//     const renders = createLoggerStore();
+
+//     const { rerender } = renderHook(
+//       ({ payload }: { payload: string | false }) => {
+//         const queryResult = listQueryStore.useItem(payload, {
+//           debouncePayload: { ms: 100 },
+//         });
+
+//         renders.add(pick(queryResult, ['status', 'payload', 'data']));
+//       },
+//       { initialProps: { payload: false } },
+//     );
+
+//     renders.reset();
+
+//     rerender({ payload: 'users||1' });
+//     await advanceTime(50);
+
+//     rerender({ payload: 'products||1' });
+//     await advanceTime(50);
+
+//     rerender({ payload: 'orders||1' });
+
+//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+//       "
+//       -> status: success ⋅ payload: users||1 ⋅ data: {id:1, name:User 1}
+//       -> status: success ⋅ payload: products||1 ⋅ data: {id:1, name:Product 1}
+//       -> status: loading ⋅ payload: orders||1 ⋅ data: null
+//       "
+//     `);
+
+//     expect(
+//       env.serverTable.getRequestHistory('item', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`[]`);
+
+//     await advanceTime(99);
+
+//     expect(
+//       env.serverTable.getRequestHistory('item', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`[]`);
+
+//     await flushAllTimers();
+//     await flushAllTimers();
+
+//     expect(
+//       env.serverTable.getRequestHistory('item', { includeTime: false }),
+//     ).toMatchInlineSnapshot(`
+//       - _type: 'item'
+//         payload: { itemId: 'orders||1' }
+//     `);
+//   });
+
+//   test('debouncePayload leading fetches immediately and debounces later payload changes', async () => {
+//     const env = createListQueryStoreTestEnv(initialServerData);
+//     const listQueryStore = env.apiStore;
+
+//     env.serverTable.setItem('users||100', { id: 100, name: 'User 100' });
+//     env.serverTable.setItem('users||101', { id: 101, name: 'User 101' });
+
+//     const renders = createLoggerStore();
+
+//     const { rerender } = renderHook(
+//       ({ payload }: { payload: string }) => {
+//         const selectionResult = listQueryStore.useItem(payload, {
+//           debouncePayload: { ms: 300, leading: true },
+//           selector: (data) => data?.name ?? null,
+//         });
+
+//         renders.add(
+//           pick(selectionResult, ['status', 'payload', 'isLoading', 'data']),
+//         );
+//       },
+//       { initialProps: { payload: 'users||100' } },
+//     );
+
+//     await advanceTime(11);
+
+//     expect(env.serverTable.numOfStartedFetches).toBe(1);
+
+//     rerender({ payload: 'users||101' });
+
+//     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+//       "
+//       -> status: loading ⋅ payload: users||100 ⋅ isLoading: ✅ ⋅ data: null
+//       -> status: loading ⋅ payload: users||101 ⋅ isLoading: ✅ ⋅ data: null
+//       "
+//     `);
+
+//     await advanceTime(299);
+//     await advanceTime(11);
+
+//     expect(env.serverTable.numOfStartedFetches).toBe(2);
+
+//     await flushAllTimers();
+
+//     expect(renders.snapshotFromLast).toMatchInlineSnapshot(`
+//       "
+//       ⋅⋅⋅
+//       -> status: loading ⋅ payload: users||101 ⋅ isLoading: ✅ ⋅ data: null
+//       -> status: success ⋅ payload: users||101 ⋅ isLoading: ❌ ⋅ data: User 101
+//       "
+//     `);
+//   });
+// });

--- a/tests/hooks/list-query-hooks.test.tsx
+++ b/tests/hooks/list-query-hooks.test.tsx
@@ -81,6 +81,7 @@ describe('useMultipleItemsQuery invalidation tests', () => {
       productsRender.add(pick(products, ['status', 'payload', 'items']));
     });
 
+    await advanceTime(1);
     await flushAllTimers();
 
     expect(env.serverTable.numOfFinishedFetches).toBe(2);
@@ -716,6 +717,30 @@ describe('useQuery', () => {
     `);
   });
 
+  test('throws when ensureIsLoaded is combined with debouncePayload', () => {
+    const env = createListQueryStoreTestEnv(initialServerData);
+    const listQueryStore = env.apiStore;
+
+    expect(() =>
+      renderHook(() =>
+        listQueryStore.useListQuery(
+          { tableId: 'users' },
+          {
+            ensureIsLoaded: true,
+            debouncePayload: { ms: 100 },
+            itemSelector: (data) => data.name,
+          },
+        ),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `
+      Error#:
+        message: 'useListQuery does not support using ensureIsLoaded together with debouncePayload.'
+        name: 'Error'
+      `,
+    );
+  });
+
   test('disableRefetchOnMount', async () => {
     const env = createListQueryStoreTestEnv(initialServerData, {
       testScenario: { loaded: { tables: ['users'] } },
@@ -932,6 +957,26 @@ describe('useItem', () => {
       -> status: success ⋅ payload: users||1 ⋅ isLoading: ❌ ⋅ data: User 1
       "
     `);
+  });
+
+  test('throws when ensureIsLoaded is combined with debouncePayload', () => {
+    const env = createListQueryStoreTestEnv(initialServerData);
+    const listQueryStore = env.apiStore;
+
+    expect(() =>
+      renderHook(() =>
+        listQueryStore.useItem('users||1', {
+          ensureIsLoaded: true,
+          debouncePayload: { ms: 100 },
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `
+      Error#:
+        message: 'useItem does not support using ensureIsLoaded together with debouncePayload.'
+        name: 'Error'
+      `,
+    );
   });
 
   test('disableRefetchOnMount', async () => {

--- a/tests/mocks/ignoreNotWrappedInActErrors.ts
+++ b/tests/mocks/ignoreNotWrappedInActErrors.ts
@@ -1,0 +1,22 @@
+const notWrappedInActMessage = 'was not wrapped in act';
+
+export function ignoreNotWrappedInActErrors() {
+  const originalConsoleError = console.error;
+
+  console.error = (...args) => {
+    if (
+      args.length > 0 &&
+      typeof args[0] === 'string' &&
+      args[0].includes(notWrappedInActMessage)
+    ) {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- testing utility only
+    originalConsoleError(...args);
+  };
+
+  return () => {
+    console.error = originalConsoleError;
+  };
+}


### PR DESCRIPTION
## Summary

Introduce a PayloadDebounce option for payload-driven hooks to debounce automatic fetches caused by rapid payload changes. Adds utility functions, integrates debouncing into selection hooks while preserving immediate state reads, updates docs/tests, and enforces that ensureIsLoaded cannot be combined with debouncePayload for single-item hooks.
### Changes

- Add PayloadDebounce type to shared store types and re-export it from main API.
- Implement payload debounce utilities (shouldDebouncePayload, getPayloadDebounceOptions, assertNoEnsureIsLoadedWithDebouncePayload).
- Integrate debouncePayload into useMultipleItems / useMultipleListQueries via useDebouncedValue and wire through useItem/useListQuery so selection reads latest payload immediately while fetches are debounced.
- Prevent combining ensureIsLoaded with debouncePayload on single-item hooks by asserting and throwing in development.
- Add comprehensive docs describing debouncePayload behavior, options (ms, leading, maxWait), and usage examples in docs/hooks.md and docs/shared-types.md; update docs README.
- Add tests covering trailing debounce, leading, maxWait behavior, selection vs. fetch timing, and ensureIsLoaded assertion; include a test helper to ignore certain console errors.
- Bump @ls-stack/react-utils and @ls-stack/utils dependency versions and update lockfile.

### Testing Notes

Run the test suite (vitest) to verify new debounce tests pass. Manually verify key scenarios: 1) Trailing debounce: rapidly change payloads and confirm selection reflects latest payload immediately while server fetch is delayed until ms elapses; assert server request history shows only the final payload. 2) Leading:true: initial payload in a burst fetches immediately, later changes are debounced; confirm request count increments accordingly. 3) maxWait: repeatedly change payloads and confirm a fetch occurs when maxWait is reached. 4) ensureIsLoaded assertion: using ensureIsLoaded with debouncePayload should throw in development for useItem and useListQuery. Also test edge cases: false/null/'' payloads, off-screen context, and preload/loadFromStateOnly behavior remains unchanged.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
