### PR TITLE
Add hybrid offline mutations with online fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist
 test-results/.last-run.json
 notes
 .vscode/review-state.json
+report/jscpd-report.json

--- a/src/collectionStore/collectionStore.ts
+++ b/src/collectionStore/collectionStore.ts
@@ -1595,49 +1595,8 @@ export function createCollectionStore<
       'mutationStart',
       hasPayload ? { mutationId, payload } : { mutationId },
     );
-    if (!offline) {
-      const result = await performMutationWithLifecycle({
-        startMutation: () =>
-          hasPayload ? startMutation(payload) : () => undefined,
-        optimisticUpdate: optimisticUpdate
-          ? () =>
-              runWithBroadcastConsistency('optimistic', () =>
-                optimisticUpdate(payload),
-              )
-          : undefined,
-        debounce: _debounce,
-        blockWindowClose: blockWindowClose ?? undefined,
-        mutation: () => mutation(payload),
-        onSuccess: (result) => {
-          if (hasPayload && revalidateOnSuccess) {
-            invalidateItem(payload);
-          }
 
-          onSuccess?.(result, payload);
-        },
-        onError: (exception) => {
-          const error = errorNormalizer(unknownToError(exception));
-
-          if (!silentErrors && onMutationError) {
-            onMutationError(exception, { silentErrors });
-          }
-
-          if (hasPayload) {
-            invalidateItem(payload);
-          }
-
-          return error;
-        },
-      });
-
-      storeEvents.emit(
-        'mutationEnd',
-        hasPayload
-          ? { mutationId, payload, success: result.ok }
-          : { mutationId, success: result.ok },
-      );
-      return result;
-    }
+    const directMutation = () => mutation(payload);
 
     const result = await performMutationWithLifecycle({
       startMutation: () =>
@@ -1650,12 +1609,17 @@ export function createCollectionStore<
         : undefined,
       debounce: _debounce,
       blockWindowClose: blockWindowClose ?? undefined,
-      mutation: () =>
-        runHybridOfflineMutation({
-          controller: offlineController,
-          offline,
-          directMutation: () => mutation(payload),
-        }),
+      mutation: offline
+        ? () =>
+            runHybridOfflineMutation({
+              controller: offlineController,
+              offline,
+              directMutation,
+            })
+        : async () => ({
+            kind: 'online' as const,
+            data: await directMutation(),
+          }),
       onSuccess: (result) => {
         if (hasPayload && revalidateOnSuccess && result.kind === 'online') {
           invalidateItem(payload);
@@ -1686,6 +1650,11 @@ export function createCollectionStore<
         ? { mutationId, payload, success: result.ok }
         : { mutationId, success: result.ok },
     );
+
+    if (!offline && result.ok && result.value.kind === 'online') {
+      return Result.ok(result.value.data);
+    }
+
     return result;
   }
 

--- a/src/collectionStore/collectionStore.ts
+++ b/src/collectionStore/collectionStore.ts
@@ -22,6 +22,10 @@ import {
   offlineSessionUnavailableError,
 } from '../persistentStorage/offline/storeController';
 import {
+  type OfflineMutationResult,
+  runHybridOfflineMutation,
+} from '../persistentStorage/offline/mutationRuntime';
+import {
   createOfflineEntityLookup,
   getIsPendingOfflineSync,
 } from '../persistentStorage/offline/entityMetadata';
@@ -1505,6 +1509,63 @@ export function createCollectionStore<
     return someItemWasUpdated;
   }
 
+  type CollectionMutationArgs<
+    T,
+    TMutationPayload extends ItemPayload | undefined | null,
+  > = {
+    optimisticUpdate?: (payload: TMutationPayload) => void | boolean;
+    mutation: (payload: TMutationPayload) => Promise<T>;
+    onSuccess?: (response: Awaited<T>, payload: TMutationPayload) => void;
+    revalidateOnSuccess?: boolean;
+    silentErrors?: boolean;
+    debounce?: { context: string; payload: __LEGIT_ANY__; ms: number };
+  };
+
+  type CollectionOnlineMutationArgs<
+    T,
+    TMutationPayload extends ItemPayload | undefined | null,
+  > = CollectionMutationArgs<T, TMutationPayload> & { offline?: undefined };
+
+  type CollectionOfflineMutationArgs<
+    T,
+    TMutationPayload extends ItemPayload | undefined | null,
+  > = CollectionMutationArgs<T, TMutationPayload> & {
+    /**
+     * When provided, the mutation tries the direct request while the session is
+     * online, but degrades into durable offline queueing when the session is
+     * already offline or the failure is classified as offline/outage. Callers
+     * must not assume a successful result always includes the server payload.
+     */
+    offline: TOfflineOperations extends null
+      ? never
+      : OfflineMutationDescriptor<Exclude<TOfflineOperations, null>>;
+  };
+
+  async function performMutation<
+    T,
+    TMutationPayload extends ItemPayload | undefined | null,
+  >(
+    payload: TMutationPayload,
+    args: CollectionOnlineMutationArgs<T, TMutationPayload>,
+  ): Promise<ResultType<Awaited<T>, StoreError | true>>;
+  async function performMutation<
+    T,
+    TMutationPayload extends ItemPayload | undefined | null,
+  >(
+    payload: TMutationPayload,
+    args: CollectionOfflineMutationArgs<T, TMutationPayload>,
+  ): Promise<ResultType<OfflineMutationResult<T>, StoreError | true>>;
+  async function performMutation<
+    T,
+    TMutationPayload extends ItemPayload | undefined | null,
+  >(
+    payload: TMutationPayload,
+    args:
+      | CollectionOnlineMutationArgs<T, TMutationPayload>
+      | CollectionOfflineMutationArgs<T, TMutationPayload>,
+  ): Promise<
+    ResultType<Awaited<T> | OfflineMutationResult<T>, StoreError | true>
+  >;
   async function performMutation<
     T,
     TMutationPayload extends ItemPayload | undefined | null,
@@ -1518,23 +1579,12 @@ export function createCollectionStore<
       onSuccess,
       debounce: _debounce,
       offline,
-    }: {
-      optimisticUpdate?: (payload: TMutationPayload) => void | boolean;
-      mutation: (payload: TMutationPayload) => Promise<T>;
-      onSuccess?: (response: Awaited<T>, payload: TMutationPayload) => void;
-      revalidateOnSuccess?: boolean;
-      silentErrors?: boolean;
-      debounce?: { context: string; payload: __LEGIT_ANY__; ms: number };
-      /**
-       * When provided, the mutation is durably queued and replayed by the
-       * offline sync controller. The immediate result only reflects queue
-       * persistence.
-       */
-      offline?: TOfflineOperations extends null
-        ? never
-        : OfflineMutationDescriptor<Exclude<TOfflineOperations, null>>;
-    },
-  ): Promise<ResultType<Awaited<T>, StoreError | true>> {
+    }:
+      | CollectionOnlineMutationArgs<T, TMutationPayload>
+      | CollectionOfflineMutationArgs<T, TMutationPayload>,
+  ): Promise<
+    ResultType<Awaited<T> | OfflineMutationResult<T>, StoreError | true>
+  > {
     if (offline && offlineController && !offlineController.canQueueMutation()) {
       return Result.err(offlineSessionUnavailableError);
     }
@@ -1545,6 +1595,50 @@ export function createCollectionStore<
       'mutationStart',
       hasPayload ? { mutationId, payload } : { mutationId },
     );
+    if (!offline) {
+      const result = await performMutationWithLifecycle({
+        startMutation: () =>
+          hasPayload ? startMutation(payload) : () => undefined,
+        optimisticUpdate: optimisticUpdate
+          ? () =>
+              runWithBroadcastConsistency('optimistic', () =>
+                optimisticUpdate(payload),
+              )
+          : undefined,
+        debounce: _debounce,
+        blockWindowClose: blockWindowClose ?? undefined,
+        mutation: () => mutation(payload),
+        onSuccess: (result) => {
+          if (hasPayload && revalidateOnSuccess) {
+            invalidateItem(payload);
+          }
+
+          onSuccess?.(result, payload);
+        },
+        onError: (exception) => {
+          const error = errorNormalizer(unknownToError(exception));
+
+          if (!silentErrors && onMutationError) {
+            onMutationError(exception, { silentErrors });
+          }
+
+          if (hasPayload) {
+            invalidateItem(payload);
+          }
+
+          return error;
+        },
+      });
+
+      storeEvents.emit(
+        'mutationEnd',
+        hasPayload
+          ? { mutationId, payload, success: result.ok }
+          : { mutationId, success: result.ok },
+      );
+      return result;
+    }
+
     const result = await performMutationWithLifecycle({
       startMutation: () =>
         hasPayload ? startMutation(payload) : () => undefined,
@@ -1556,24 +1650,19 @@ export function createCollectionStore<
         : undefined,
       debounce: _debounce,
       blockWindowClose: blockWindowClose ?? undefined,
-      mutation: async () => {
-        if (offline && offlineController) {
-          await offlineController.queueMutation({
-            operationName: offline.operation,
-            input: offline.input,
-          });
-          return __LEGIT_CAST__<Awaited<T>, undefined>(undefined);
-        }
-
-        return mutation(payload);
-      },
+      mutation: () =>
+        runHybridOfflineMutation({
+          controller: offlineController,
+          offline,
+          directMutation: () => mutation(payload),
+        }),
       onSuccess: (result) => {
-        if (hasPayload && revalidateOnSuccess && !offline) {
+        if (hasPayload && revalidateOnSuccess && result.kind === 'online') {
           invalidateItem(payload);
         }
 
-        if (onSuccess && !offline) {
-          onSuccess(result, payload);
+        if (onSuccess && result.kind === 'online') {
+          onSuccess(result.data, payload);
         }
       },
       onError: (exception) => {
@@ -1597,7 +1686,6 @@ export function createCollectionStore<
         ? { mutationId, payload, success: result.ok }
         : { mutationId, success: result.ok },
     );
-
     return result;
   }
 

--- a/src/documentStore.ts
+++ b/src/documentStore.ts
@@ -835,38 +835,9 @@ export function createDocumentStore<
 
     const mutationId = getAutoIncrementId();
     storeEvents.emit('mutationStart', { mutationId });
-    if (!offline) {
-      const result = await performMutationWithLifecycle({
-        startMutation,
-        optimisticUpdate: optimisticUpdate
-          ? () =>
-              runWithBroadcastConsistency('optimistic', () =>
-                optimisticUpdate(store.state.data),
-              )
-          : undefined,
-        debounce,
-        blockWindowClose: blockWindowClose ?? undefined,
-        mutation: () =>
-          mutation({ updateState, currentState: store.state.data }),
-        onSuccess: () => {
-          if (revalidateOnSuccess) {
-            invalidateData();
-          }
-        },
-        onError: (exception) => {
-          if (onMutationError) {
-            onMutationError(exception, { dontShowToast: dontShowErrorToast });
-          }
 
-          invalidateData();
-
-          return errorNormalizer(unknownToError(exception));
-        },
-      });
-
-      storeEvents.emit('mutationEnd', { mutationId, success: result.ok });
-      return result;
-    }
+    const directMutation = () =>
+      mutation({ updateState, currentState: store.state.data });
 
     const result = await performMutationWithLifecycle({
       startMutation,
@@ -878,13 +849,17 @@ export function createDocumentStore<
         : undefined,
       debounce,
       blockWindowClose: blockWindowClose ?? undefined,
-      mutation: () =>
-        runHybridOfflineMutation({
-          controller: offlineController,
-          offline,
-          directMutation: () =>
-            mutation({ updateState, currentState: store.state.data }),
-        }),
+      mutation: offline
+        ? () =>
+            runHybridOfflineMutation({
+              controller: offlineController,
+              offline,
+              directMutation,
+            })
+        : async () => ({
+            kind: 'online' as const,
+            data: await directMutation(),
+          }),
       onSuccess: (result) => {
         if (revalidateOnSuccess && result.kind === 'online') {
           invalidateData();
@@ -902,6 +877,11 @@ export function createDocumentStore<
     });
 
     storeEvents.emit('mutationEnd', { mutationId, success: result.ok });
+
+    if (!offline && result.ok && result.value.kind === 'online') {
+      return Result.ok(result.value.data);
+    }
+
     return result;
   }
 

--- a/src/documentStore.ts
+++ b/src/documentStore.ts
@@ -38,6 +38,10 @@ import {
   offlineConnectivityError,
 } from './persistentStorage/offline/fetchRuntime';
 import {
+  type OfflineMutationResult,
+  runHybridOfflineMutation,
+} from './persistentStorage/offline/mutationRuntime';
+import {
   createOfflineStoreController,
   initializeOfflineStoreController,
   offlineSessionUnavailableError,
@@ -276,6 +280,9 @@ export function createDocumentStore<
           getEntityRefs: () => [
             { entityKey: DOC_TARGET_KEY, entityKind: 'document' },
           ],
+          normalizeEntityRefs: () => [
+            { entityKey: DOC_TARGET_KEY, entityKind: 'document' },
+          ],
           getProtectedCacheKeys: () => {
             const sessionKey = getSessionKey();
             if (sessionKey === false) return [];
@@ -291,6 +298,18 @@ export function createDocumentStore<
           applyPendingEntity: ({ pendingEntity }) => {
             if (!pendingEntity || typeof pendingEntity !== 'object') return;
             updateState((draft) => Object.assign(draft, pendingEntity));
+          },
+          reconcileTempEntity: ({ reconciliation }) => {
+            if (
+              !reconciliation.finalData ||
+              typeof reconciliation.finalData !== 'object'
+            ) {
+              return;
+            }
+
+            updateState((draft) =>
+              Object.assign(draft, reconciliation.finalData),
+            );
           },
         },
       })
@@ -762,6 +781,44 @@ export function createDocumentStore<
     return scheduler.startMutation(DOC_REQUEST_ID);
   }
 
+  type DocumentMutationArgs<T> = {
+    optimisticUpdate?: (currentState: State | null) => void | boolean;
+    mutation: (ctx: {
+      updateState: typeof updateState;
+      currentState: State | null;
+    }) => Promise<T>;
+    debounce?: { context: string; payload: __LEGIT_ANY__; ms: number };
+    dontShowErrorToast?: boolean;
+    revalidateOnSuccess?: boolean;
+  };
+
+  type DocumentOnlineMutationArgs<T> = DocumentMutationArgs<T> & {
+    offline?: undefined;
+  };
+
+  type DocumentOfflineMutationArgs<T> = DocumentMutationArgs<T> & {
+    /**
+     * When provided, the mutation tries the direct request while the session is
+     * online, but degrades into durable offline queueing when the session is
+     * already offline or the failure is classified as offline/outage. Callers
+     * must not assume a successful result always includes the server payload.
+     */
+    offline: TOfflineOperations extends null
+      ? never
+      : OfflineMutationDescriptor<Exclude<TOfflineOperations, null>>;
+  };
+
+  async function performMutation<T>(
+    args: DocumentOnlineMutationArgs<T>,
+  ): Promise<ResultType<Awaited<T>, StoreError | true>>;
+  async function performMutation<T>(
+    args: DocumentOfflineMutationArgs<T>,
+  ): Promise<ResultType<OfflineMutationResult<T>, StoreError | true>>;
+  async function performMutation<T>(
+    args: DocumentOnlineMutationArgs<T> | DocumentOfflineMutationArgs<T>,
+  ): Promise<
+    ResultType<Awaited<T> | OfflineMutationResult<T>, StoreError | true>
+  >;
   async function performMutation<T>({
     optimisticUpdate,
     mutation,
@@ -769,29 +826,48 @@ export function createDocumentStore<
     dontShowErrorToast,
     revalidateOnSuccess,
     offline,
-  }: {
-    optimisticUpdate?: (currentState: State | null) => void | boolean;
-    debounce?: { context: string; payload: __LEGIT_ANY__; ms: number };
-    dontShowErrorToast?: boolean;
-    mutation: (ctx: {
-      updateState: typeof updateState;
-      currentState: State | null;
-    }) => Promise<T>;
-    revalidateOnSuccess?: boolean;
-    /**
-     * When provided, the mutation is durably queued and replayed by the offline
-     * sync controller. The immediate result only reflects queue persistence.
-     */
-    offline?: TOfflineOperations extends null
-      ? never
-      : OfflineMutationDescriptor<Exclude<TOfflineOperations, null>>;
-  }): Promise<ResultType<Awaited<T>, StoreError | true>> {
+  }: DocumentOnlineMutationArgs<T> | DocumentOfflineMutationArgs<T>): Promise<
+    ResultType<Awaited<T> | OfflineMutationResult<T>, StoreError | true>
+  > {
     if (offline && offlineController && !offlineController.canQueueMutation()) {
       return Result.err(offlineSessionUnavailableError);
     }
 
     const mutationId = getAutoIncrementId();
     storeEvents.emit('mutationStart', { mutationId });
+    if (!offline) {
+      const result = await performMutationWithLifecycle({
+        startMutation,
+        optimisticUpdate: optimisticUpdate
+          ? () =>
+              runWithBroadcastConsistency('optimistic', () =>
+                optimisticUpdate(store.state.data),
+              )
+          : undefined,
+        debounce,
+        blockWindowClose: blockWindowClose ?? undefined,
+        mutation: () =>
+          mutation({ updateState, currentState: store.state.data }),
+        onSuccess: () => {
+          if (revalidateOnSuccess) {
+            invalidateData();
+          }
+        },
+        onError: (exception) => {
+          if (onMutationError) {
+            onMutationError(exception, { dontShowToast: dontShowErrorToast });
+          }
+
+          invalidateData();
+
+          return errorNormalizer(unknownToError(exception));
+        },
+      });
+
+      storeEvents.emit('mutationEnd', { mutationId, success: result.ok });
+      return result;
+    }
+
     const result = await performMutationWithLifecycle({
       startMutation,
       optimisticUpdate: optimisticUpdate
@@ -802,19 +878,15 @@ export function createDocumentStore<
         : undefined,
       debounce,
       blockWindowClose: blockWindowClose ?? undefined,
-      mutation: async () => {
-        if (offline && offlineController) {
-          await offlineController.queueMutation({
-            operationName: offline.operation,
-            input: offline.input,
-          });
-          return __LEGIT_CAST__<Awaited<T>, undefined>(undefined);
-        }
-
-        return mutation({ updateState, currentState: store.state.data });
-      },
-      onSuccess: () => {
-        if (revalidateOnSuccess && !offline) {
+      mutation: () =>
+        runHybridOfflineMutation({
+          controller: offlineController,
+          offline,
+          directMutation: () =>
+            mutation({ updateState, currentState: store.state.data }),
+        }),
+      onSuccess: (result) => {
+        if (revalidateOnSuccess && result.kind === 'online') {
           invalidateData();
         }
       },
@@ -830,7 +902,6 @@ export function createDocumentStore<
     });
 
     storeEvents.emit('mutationEnd', { mutationId, success: result.ok });
-
     return result;
   }
 

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -792,58 +792,7 @@ export function createMutationApi<
 
     storeEvents.emit('mutationStart', { mutationId, items: affectedItems });
 
-    if (!offline) {
-      const result = await performMutationWithLifecycle({
-        startMutation: () => startItemMutation(payloadToUse),
-        optimisticUpdate: optimisticUpdate
-          ? () =>
-              runWithBroadcastConsistency('optimistic', () =>
-                optimisticUpdate(payloadToUse),
-              )
-          : undefined,
-        debounce,
-        blockWindowClose: blockWindowClose ?? undefined,
-        mutation: () => mutation(payloadToUse),
-        onSuccess: (result) => {
-          if (revalidateOnSuccess) {
-            invalidateQueryAndItems({
-              itemPayload:
-                revalidateOnSuccess === 'queries' ? false : payloadToUse,
-              queryPayload: getRevalidateOnSuccessQueries,
-            });
-          }
-
-          onSuccess?.(result, payloadToUse);
-        },
-        onError: (exception) => {
-          const error = errorNormalizer(unknownToError(exception));
-
-          if (!silentErrors && onMutationError) {
-            onMutationError(exception, { silentErrors });
-          }
-
-          if (!dontRevalidateOnError) {
-            invalidateQueryAndItems({
-              itemPayload: payloadToUse,
-              queryPayload: getRelatedQueries,
-            });
-          }
-
-          if (onError) {
-            onError(error);
-          }
-
-          return error;
-        },
-      });
-
-      storeEvents.emit('mutationEnd', {
-        mutationId,
-        items: affectedItems,
-        success: result.ok,
-      });
-      return result;
-    }
+    const directMutation = () => mutation(payloadToUse);
 
     const result = await performMutationWithLifecycle({
       startMutation: () => startItemMutation(payloadToUse),
@@ -855,12 +804,17 @@ export function createMutationApi<
         : undefined,
       debounce,
       blockWindowClose: blockWindowClose ?? undefined,
-      mutation: () =>
-        runHybridOfflineMutation({
-          controller: offlineController,
-          offline,
-          directMutation: () => mutation(payloadToUse),
-        }),
+      mutation: offline
+        ? () =>
+            runHybridOfflineMutation({
+              controller: offlineController,
+              offline,
+              directMutation,
+            })
+        : async () => ({
+            kind: 'online' as const,
+            data: await directMutation(),
+          }),
       onSuccess: (result) => {
         if (revalidateOnSuccess && result.kind === 'online') {
           invalidateQueryAndItems({
@@ -901,6 +855,11 @@ export function createMutationApi<
       items: affectedItems,
       success: result.ok,
     });
+
+    if (!offline && result.ok && result.value.kind === 'online') {
+      return Result.ok(result.value.data);
+    }
+
     return result;
   }
 

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -4,13 +4,17 @@ import { evtmitter } from 'evtmitter';
 import { klona } from 'klona/json';
 import { Result, unknownToError, type Result as ResultType } from 't-result';
 import { Store } from 't-state';
+import {
+  type OfflineMutationResult,
+  runHybridOfflineMutation,
+  type OfflineAwareMutationController,
+} from '../persistentStorage/offline/mutationRuntime';
 import { offlineSessionUnavailableError } from '../persistentStorage/offline/storeController';
 import { FetchType, getAutoIncrementId } from '../requestScheduler';
 import type {
   AnyOfflineOperationDefinition,
   ListQueryOfflineEntityRef,
   OfflineMutationDescriptor,
-  OperationInput,
 } from '../persistentStorage/offline/types';
 import { type SnapshotConsistency } from '../utils/browserTabsSync';
 import {
@@ -124,15 +128,9 @@ export type CreateMutationApiOptions<
   emitInvalidateQuery: (event: InvalidateQueryEvent) => void;
   emitInvalidateItem: (event: InvalidateItemEvent) => void;
   blockWindowClose: BlockWindowCloseHandler | null;
-  offlineController?: {
-    canQueueMutation: () => boolean;
-    queueMutation: <
-      TName extends keyof Exclude<TOfflineOperations, null>,
-    >(args: {
-      operationName: TName;
-      input: OperationInput<Exclude<TOfflineOperations, null>, TName>;
-    }) => Promise<void>;
-  } | null;
+  offlineController?: OfflineAwareMutationController<
+    Exclude<TOfflineOperations, null>
+  > | null;
   runWithBroadcastConsistency: <T>(
     consistency: SnapshotConsistency,
     callback: () => T,
@@ -721,6 +719,49 @@ export function createMutationApi<
     itemPendingInvalidationFields.clear();
   }
 
+  type ListQueryMutationArgs<T> = {
+    optimisticUpdate?: (payload: MutationPayloadToUse) => void | boolean;
+    mutation: (payload: MutationPayloadToUse) => Promise<T>;
+    revalidateOnSuccess?: boolean | 'queries';
+    dontRevalidateOnError?: boolean;
+    getRelatedQueries?: FilterQuery;
+    getRevalidateOnSuccessQueries?: FilterQuery;
+    onSuccess?: (response: Awaited<T>, payload: MutationPayloadToUse) => void;
+    onError?: (error: StoreError | true) => void;
+    silentErrors?: boolean;
+    debounce?: { context: string; payload: __LEGIT_ANY__; ms: number };
+  };
+
+  type ListQueryOnlineMutationArgs<T> = ListQueryMutationArgs<T> & {
+    offline?: undefined;
+  };
+
+  type ListQueryOfflineMutationArgs<T> = ListQueryMutationArgs<T> & {
+    /**
+     * When provided, the mutation tries the direct request while the session is
+     * online, but degrades into durable offline queueing when the session is
+     * already offline or the failure is classified as offline/outage. Callers
+     * must not assume a successful result always includes the server payload.
+     */
+    offline: TOfflineOperations extends null
+      ? never
+      : OfflineMutationDescriptor<Exclude<TOfflineOperations, null>>;
+  };
+
+  async function performMutation<T>(
+    payload: MutationPayload,
+    args: ListQueryOnlineMutationArgs<T>,
+  ): Promise<ResultType<Awaited<T>, StoreError | true>>;
+  async function performMutation<T>(
+    payload: MutationPayload,
+    args: ListQueryOfflineMutationArgs<T>,
+  ): Promise<ResultType<OfflineMutationResult<T>, StoreError | true>>;
+  async function performMutation<T>(
+    payload: MutationPayload,
+    args: ListQueryOnlineMutationArgs<T> | ListQueryOfflineMutationArgs<T>,
+  ): Promise<
+    ResultType<Awaited<T> | OfflineMutationResult<T>, StoreError | true>
+  >;
   async function performMutation<T>(
     payload: MutationPayload,
     {
@@ -735,27 +776,10 @@ export function createMutationApi<
       onError,
       debounce,
       offline,
-    }: {
-      optimisticUpdate?: (payload: MutationPayloadToUse) => void | boolean;
-      mutation: (payload: MutationPayloadToUse) => Promise<T>;
-      revalidateOnSuccess?: boolean | 'queries';
-      dontRevalidateOnError?: boolean;
-      getRelatedQueries?: FilterQuery;
-      getRevalidateOnSuccessQueries?: FilterQuery;
-      onSuccess?: (response: Awaited<T>, payload: MutationPayloadToUse) => void;
-      onError?: (error: StoreError | true) => void;
-      silentErrors?: boolean;
-      debounce?: { context: string; payload: __LEGIT_ANY__; ms: number };
-      /**
-       * When provided, the mutation is durably queued and replayed by the
-       * offline sync controller. The immediate result only reflects queue
-       * persistence.
-       */
-      offline?: TOfflineOperations extends null
-        ? never
-        : OfflineMutationDescriptor<Exclude<TOfflineOperations, null>>;
-    },
-  ): Promise<ResultType<Awaited<T>, StoreError | true>> {
+    }: ListQueryOnlineMutationArgs<T> | ListQueryOfflineMutationArgs<T>,
+  ): Promise<
+    ResultType<Awaited<T> | OfflineMutationResult<T>, StoreError | true>
+  > {
     const matchAllItems: FilterItem = () => true;
     const payloadToUse: MutationPayloadToUse = payload ?? matchAllItems;
 
@@ -768,6 +792,59 @@ export function createMutationApi<
 
     storeEvents.emit('mutationStart', { mutationId, items: affectedItems });
 
+    if (!offline) {
+      const result = await performMutationWithLifecycle({
+        startMutation: () => startItemMutation(payloadToUse),
+        optimisticUpdate: optimisticUpdate
+          ? () =>
+              runWithBroadcastConsistency('optimistic', () =>
+                optimisticUpdate(payloadToUse),
+              )
+          : undefined,
+        debounce,
+        blockWindowClose: blockWindowClose ?? undefined,
+        mutation: () => mutation(payloadToUse),
+        onSuccess: (result) => {
+          if (revalidateOnSuccess) {
+            invalidateQueryAndItems({
+              itemPayload:
+                revalidateOnSuccess === 'queries' ? false : payloadToUse,
+              queryPayload: getRevalidateOnSuccessQueries,
+            });
+          }
+
+          onSuccess?.(result, payloadToUse);
+        },
+        onError: (exception) => {
+          const error = errorNormalizer(unknownToError(exception));
+
+          if (!silentErrors && onMutationError) {
+            onMutationError(exception, { silentErrors });
+          }
+
+          if (!dontRevalidateOnError) {
+            invalidateQueryAndItems({
+              itemPayload: payloadToUse,
+              queryPayload: getRelatedQueries,
+            });
+          }
+
+          if (onError) {
+            onError(error);
+          }
+
+          return error;
+        },
+      });
+
+      storeEvents.emit('mutationEnd', {
+        mutationId,
+        items: affectedItems,
+        success: result.ok,
+      });
+      return result;
+    }
+
     const result = await performMutationWithLifecycle({
       startMutation: () => startItemMutation(payloadToUse),
       optimisticUpdate: optimisticUpdate
@@ -778,19 +855,14 @@ export function createMutationApi<
         : undefined,
       debounce,
       blockWindowClose: blockWindowClose ?? undefined,
-      mutation: async () => {
-        if (offline && offlineController) {
-          await offlineController.queueMutation({
-            operationName: offline.operation,
-            input: offline.input,
-          });
-          return __LEGIT_CAST__<Awaited<T>, undefined>(undefined);
-        }
-
-        return mutation(payloadToUse);
-      },
+      mutation: () =>
+        runHybridOfflineMutation({
+          controller: offlineController,
+          offline,
+          directMutation: () => mutation(payloadToUse),
+        }),
       onSuccess: (result) => {
-        if (revalidateOnSuccess && !offline) {
+        if (revalidateOnSuccess && result.kind === 'online') {
           invalidateQueryAndItems({
             itemPayload:
               revalidateOnSuccess === 'queries' ? false : payloadToUse,
@@ -798,8 +870,8 @@ export function createMutationApi<
           });
         }
 
-        if (onSuccess && !offline) {
-          onSuccess(result, payloadToUse);
+        if (onSuccess && result.kind === 'online') {
+          onSuccess(result.data, payloadToUse);
         }
       },
       onError: (exception) => {
@@ -829,7 +901,6 @@ export function createMutationApi<
       items: affectedItems,
       success: result.ok,
     });
-
     return result;
   }
 

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -679,6 +679,15 @@ export function createListQueryStore<
   };
   const offlineMutationController = {
     canQueueMutation: () => offlineController?.canQueueMutation() ?? false,
+    prepareForMutation: <
+      TName extends keyof Exclude<TOfflineOperations, null>,
+    >(args: {
+      operationName: TName;
+      input: OperationInput<Exclude<TOfflineOperations, null>, TName>;
+    }) =>
+      offlineController
+        ? offlineController.prepareForMutation(args)
+        : Promise.reject(new Error('Offline mutation controller unavailable')),
     queueMutation: <
       TName extends keyof Exclude<TOfflineOperations, null>,
     >(args: {
@@ -1157,7 +1166,9 @@ export function createListQueryStore<
       events.emit('invalidateItem', event);
     },
     blockWindowClose,
-    offlineController: offlineMutationController,
+    offlineController: persistentStorageConfig?.offlineMode
+      ? offlineMutationController
+      : null,
     runWithBroadcastConsistency,
     publishQuerySnapshot,
     publishItemSnapshot,

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,8 @@ export type {
   OfflineSyncState,
 } from './persistentStorage/offline/types';
 
+export type { OfflineMutationResult } from './persistentStorage/offline/mutationRuntime';
+
 export {
   getGlobalOfflineEntities,
   getGlobalOfflineStatus,

--- a/src/persistentStorage/offline/mutationRuntime.ts
+++ b/src/persistentStorage/offline/mutationRuntime.ts
@@ -1,0 +1,69 @@
+import type { OperationInput, OfflineOperationSchemaShape } from './types';
+
+/**
+ * Successful result of an offline-enabled mutation attempt.
+ *
+ * `online` means the direct request completed and returned the server payload.
+ * `queued` means the mutation was durably persisted for offline replay.
+ */
+export type OfflineMutationResult<T> =
+  | { kind: 'online'; data: Awaited<T> }
+  | { kind: 'queued' };
+
+export type PreparedOfflineMutation = {
+  effectiveOffline: boolean;
+  queueMutation: () => Promise<void>;
+  classifyError: (error: unknown) => Promise<boolean>;
+};
+
+export type OfflineAwareMutationController<
+  TOperations extends Record<string, OfflineOperationSchemaShape>,
+> = {
+  canQueueMutation: () => boolean;
+  prepareForMutation: <TName extends keyof TOperations>(args: {
+    operationName: TName;
+    input: OperationInput<TOperations, TName>;
+  }) => Promise<PreparedOfflineMutation>;
+};
+
+export async function runHybridOfflineMutation<
+  T,
+  TOperations extends Record<string, OfflineOperationSchemaShape>,
+  TName extends keyof TOperations,
+>({
+  controller,
+  offline,
+  directMutation,
+}: {
+  controller?: OfflineAwareMutationController<TOperations> | null;
+  offline?:
+    | { operation: TName; input: OperationInput<TOperations, TName> }
+    | undefined;
+  directMutation: () => Promise<T>;
+}): Promise<OfflineMutationResult<T>> {
+  if (!offline || !controller) {
+    return { kind: 'online', data: await directMutation() };
+  }
+
+  const prepared = await controller.prepareForMutation({
+    operationName: offline.operation,
+    input: offline.input,
+  });
+
+  if (prepared.effectiveOffline) {
+    await prepared.queueMutation();
+    return { kind: 'queued' };
+  }
+
+  try {
+    return { kind: 'online', data: await directMutation() };
+  } catch (error) {
+    const shouldQueue = await prepared.classifyError(error);
+    if (!shouldQueue) {
+      throw error;
+    }
+
+    await prepared.queueMutation();
+    return { kind: 'queued' };
+  }
+}

--- a/src/persistentStorage/offline/storeController.ts
+++ b/src/persistentStorage/offline/storeController.ts
@@ -9,6 +9,7 @@ import {
 } from '../storageEntryPrefixes';
 import type { StorageAdapter } from '../types';
 import { validateWithSchema } from '../validateWithSchema';
+import type { PreparedOfflineMutation } from './mutationRuntime';
 import { getOrCreateSessionOfflineCoordinator } from './sessionCoordinator';
 import type {
   AnyOfflineOperationDefinition,
@@ -125,6 +126,10 @@ export type OfflineStoreController<
 > = {
   hydrateIfNeeded: () => Promise<void>;
   canQueueMutation: () => boolean;
+  prepareForMutation: <TName extends keyof TOperations>(args: {
+    operationName: TName;
+    input: OperationInput<TOperations, TName>;
+  }) => Promise<PreparedOfflineMutation>;
   queueMutation: <TName extends keyof TOperations>(args: {
     operationName: TName;
     input: OperationInput<TOperations, TName>;
@@ -223,7 +228,16 @@ export function createOfflineStoreController<
 
   function ensureActiveSession(): ActiveSessionState | null {
     const sessionKey = getSessionKey();
-    if (sessionKey === false) return null;
+    if (sessionKey === false) {
+      activeSession?.unregister?.();
+      activeSession = null;
+      resetConfirmationRetries();
+      queueEntries.clear();
+      conflicts.clear();
+      hydratedSessionKey = null;
+      hydratedPromise = null;
+      return null;
+    }
 
     if (activeSession?.sessionKey === sessionKey) return activeSession;
 
@@ -563,6 +577,19 @@ export function createOfflineStoreController<
     current: ActiveSessionState,
     args: { operationName: TName; input: unknown },
   ): Promise<void> {
+    const prepared = prepareMutationWithSession(current, args);
+    await queuePreparedMutation(prepared);
+  }
+
+  function prepareMutationWithSession<TName extends keyof TOperations>(
+    current: ActiveSessionState,
+    args: { operationName: TName; input: unknown },
+  ): {
+    currentSessionKey: string;
+    operationName: string;
+    operation: AnyOfflineOperationDefinition;
+    validatedInput: unknown;
+  } {
     const operationName = String(args.operationName);
     const operation = offlineMode.operations[operationName];
     if (!operation) {
@@ -578,6 +605,34 @@ export function createOfflineStoreController<
     if (validatedInput === null) {
       throw new Error(`Invalid offline operation input for "${operationName}"`);
     }
+
+    return {
+      currentSessionKey: current.sessionKey,
+      operationName,
+      operation,
+      validatedInput,
+    };
+  }
+
+  function getPreparedSessionOrThrow(args: {
+    currentSessionKey: string;
+  }): ActiveSessionState {
+    const current = ensureActiveSession();
+    if (!current || current.sessionKey !== args.currentSessionKey) {
+      throw offlineSessionUnavailableError;
+    }
+
+    return current;
+  }
+
+  async function queuePreparedMutation(args: {
+    currentSessionKey: string;
+    operationName: string;
+    operation: AnyOfflineOperationDefinition;
+    validatedInput: unknown;
+  }): Promise<void> {
+    const current = getPreparedSessionOrThrow(args);
+    const { operation, operationName, validatedInput } = args;
 
     const tempEntity = operation.tempEntity;
     const tempId = tempEntity?.createTempId(validatedInput);
@@ -845,6 +900,48 @@ export function createOfflineStoreController<
     await queueMutationWithSession(current, args);
   }
 
+  async function prepareForMutation<TName extends keyof TOperations>(args: {
+    operationName: TName;
+    input: OperationInput<TOperations, TName>;
+  }): Promise<PreparedOfflineMutation> {
+    await hydrateIfNeeded();
+    const current = ensureActiveSession();
+    if (!current) {
+      throw offlineSessionUnavailableError;
+    }
+
+    const prepared = prepareMutationWithSession(current, args);
+    await current.session.refreshNetworkState();
+
+    return {
+      effectiveOffline: current.session.getStatus().effectiveOffline,
+      queueMutation: () => queuePreparedMutation(prepared),
+      classifyError: async (error) => {
+        const preparedCurrent = getPreparedSessionOrThrow(prepared);
+
+        await preparedCurrent.session.refreshNetworkState();
+        if (preparedCurrent.session.getStatus().effectiveOffline) {
+          return true;
+        }
+
+        const classification = await preparedCurrent.session.classifyFailure(
+          error,
+          {
+            phase: 'mutation',
+            storeType,
+            operationName: prepared.operationName,
+            sessionKey: preparedCurrent.sessionKey,
+          },
+        );
+
+        return (
+          classification === 'outage' ||
+          preparedCurrent.session.getStatus().effectiveOffline
+        );
+      },
+    };
+  }
+
   function getOfflineEntities(): GlobalOfflineEntity[] {
     const current = ensureActiveSession();
     if (!current) return [];
@@ -939,6 +1036,7 @@ export function createOfflineStoreController<
   return {
     hydrateIfNeeded,
     canQueueMutation,
+    prepareForMutation,
     queueMutation,
     getOfflineEntities,
     getOfflineConflicts,

--- a/src/persistentStorage/offline/storeController.ts
+++ b/src/persistentStorage/offline/storeController.ts
@@ -229,13 +229,15 @@ export function createOfflineStoreController<
   function ensureActiveSession(): ActiveSessionState | null {
     const sessionKey = getSessionKey();
     if (sessionKey === false) {
-      activeSession?.unregister?.();
-      activeSession = null;
-      resetConfirmationRetries();
-      queueEntries.clear();
-      conflicts.clear();
-      hydratedSessionKey = null;
-      hydratedPromise = null;
+      if (activeSession) {
+        activeSession.unregister?.();
+        activeSession = null;
+        resetConfirmationRetries();
+        queueEntries.clear();
+        conflicts.clear();
+        hydratedSessionKey = null;
+        hydratedPromise = null;
+      }
       return null;
     }
 
@@ -614,24 +616,16 @@ export function createOfflineStoreController<
     };
   }
 
-  function getPreparedSessionOrThrow(args: {
-    currentSessionKey: string;
-  }): ActiveSessionState {
-    const current = ensureActiveSession();
-    if (!current || current.sessionKey !== args.currentSessionKey) {
-      throw offlineSessionUnavailableError;
-    }
-
-    return current;
-  }
-
   async function queuePreparedMutation(args: {
     currentSessionKey: string;
     operationName: string;
     operation: AnyOfflineOperationDefinition;
     validatedInput: unknown;
   }): Promise<void> {
-    const current = getPreparedSessionOrThrow(args);
+    const current = ensureActiveSession();
+    if (!current || current.sessionKey !== args.currentSessionKey) {
+      throw offlineSessionUnavailableError;
+    }
     const { operation, operationName, validatedInput } = args;
 
     const tempEntity = operation.tempEntity;
@@ -917,7 +911,13 @@ export function createOfflineStoreController<
       effectiveOffline: current.session.getStatus().effectiveOffline,
       queueMutation: () => queuePreparedMutation(prepared),
       classifyError: async (error) => {
-        const preparedCurrent = getPreparedSessionOrThrow(prepared);
+        const preparedCurrent = ensureActiveSession();
+        if (
+          !preparedCurrent ||
+          preparedCurrent.sessionKey !== prepared.currentSessionKey
+        ) {
+          throw offlineSessionUnavailableError;
+        }
 
         await preparedCurrent.session.refreshNetworkState();
         if (preparedCurrent.session.getStatus().effectiveOffline) {

--- a/tests/offline/offline-hybrid-mutations.test.tsx
+++ b/tests/offline/offline-hybrid-mutations.test.tsx
@@ -1,0 +1,1049 @@
+import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { rc_object, rc_string } from 'runcheck';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { CollectionOfflineOperationDefinition } from '../../src/main';
+import { getGlobalOfflineStatus } from '../../src/persistentStorage/offline/sessionCoordinator';
+import { createCollectionStoreTestEnv } from '../mocks/collectionStoreTestEnv';
+import { createDocumentStoreTestEnv } from '../mocks/documentStoreTestEnv';
+import { createListQueryStoreTestEnv } from '../mocks/listQueryStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import { advanceTime } from '../utils/genericTestUtils';
+import { createOfflineNetworkMock } from '../utils/networkMock';
+import {
+  collectionCreateInputSchema,
+  collectionSchema,
+  docMutationInputSchema,
+  docSchema,
+  listQueryQueryPayloadSchema,
+} from './offlineTestShared';
+import {
+  type CreateUserOperations,
+  getOfflineQueueEntries,
+  getOfflineQueueEntryData,
+  type PatchUserOperations,
+  type UpdateValueConflictOperations,
+  type UpdateValueOperations,
+  userPatchSchema,
+  userRowSchema,
+} from './offlineReplayTestShared';
+
+const renameCollectionInputSchema = rc_object({
+  id: rc_string,
+  name: rc_string,
+});
+
+const quickRecoveryProbe = {
+  intervalMs: 1,
+  maxIntervalMs: 1,
+  backoffMultiplier: 1,
+  jitterRatio: 0,
+} as const;
+
+function classifyMutationOutage(error: unknown, phase: string) {
+  return (
+    phase === 'mutation' &&
+    error instanceof Error &&
+    error.message === 'offline-fallback'
+  );
+}
+
+async function waitForMicrotaskCondition(
+  condition: () => boolean,
+  maxTurns = 20,
+): Promise<void> {
+  for (let turn = 0; turn < maxTurns && !condition(); turn += 1) {
+    await Promise.resolve();
+  }
+}
+
+type RenameCollectionItemOperations = {
+  renameItem: CollectionOfflineOperationDefinition<
+    { value: { name: string } },
+    string,
+    { id: string; name: string }
+  >;
+};
+
+describe('hybrid offline mutation execution', () => {
+  let network = createOfflineNetworkMock();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_INITIAL_TIME);
+    network = createOfflineNetworkMock();
+    network.install();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  describe('document mutations', () => {
+    test('queue immediately when the session is already offline', async () => {
+      network.setOffline();
+      const sessionKey = 'hybrid-doc-offline-session';
+      const storeName = 'hybrid-doc-offline-store';
+      const directMutation = vi.fn(() => Promise.resolve(2));
+      const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+        getSessionKey: () => sessionKey,
+        testScenario: 'loaded',
+        persistentStorage: {
+          storeName,
+          adapter: 'local-sync',
+          schema: docSchema,
+          offlineMode: {
+            network: network.config,
+            operations: {
+              updateValue: {
+                inputSchema: docMutationInputSchema,
+                execute: ({ input }) => input,
+              },
+            },
+          },
+        },
+      });
+
+      // The browser is already offline, so we should persist the queue entry
+      // without ever invoking the direct mutation callback.
+      const result = await env.apiStore.performMutation({
+        mutation: directMutation,
+        offline: { operation: 'updateValue', input: { value: 2 } },
+      });
+
+      expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+      expect(directMutation).not.toHaveBeenCalled();
+      expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+    });
+
+    test('call the direct mutation while online and skip queueing on success', async () => {
+      const sessionKey = 'hybrid-doc-online-session';
+      const storeName = 'hybrid-doc-online-store';
+      const directMutation = vi.fn(() => Promise.resolve(2));
+      const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+        getSessionKey: () => sessionKey,
+        testScenario: 'loaded',
+        persistentStorage: {
+          storeName,
+          adapter: 'local-sync',
+          schema: docSchema,
+          offlineMode: {
+            network: network.config,
+            operations: {
+              updateValue: {
+                inputSchema: docMutationInputSchema,
+                execute: ({ input }) => input,
+              },
+            },
+          },
+        },
+      });
+
+      // Online offline-enabled mutations should behave like normal direct
+      // mutations until a failure is classified as connectivity-related.
+      const result = await env.apiStore.performMutation({
+        mutation: directMutation,
+        offline: { operation: 'updateValue', input: { value: 2 } },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        value: { kind: 'online', data: 2 },
+      });
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(
+        getOfflineQueueEntries(sessionKey, storeName),
+      ).toMatchInlineSnapshot(`[]`);
+    });
+
+    test('fallback to queueing when the direct failure is classified as offline', async () => {
+      const sessionKey = 'hybrid-doc-fallback-session';
+      const storeName = 'hybrid-doc-fallback-store';
+      const directMutation = vi.fn(() =>
+        Promise.reject(new Error('offline-fallback')),
+      );
+      const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+        getSessionKey: () => sessionKey,
+        testScenario: 'loaded',
+        persistentStorage: {
+          storeName,
+          adapter: 'local-sync',
+          schema: docSchema,
+          offlineMode: {
+            network: network.config,
+            outage: {
+              enabled: true,
+              classifyFailure: (error, ctx) =>
+                classifyMutationOutage(error, ctx.phase) ? 'outage' : 'ignore',
+              recoveryCheck: () => false,
+              recoveryProbe: quickRecoveryProbe,
+            },
+            operations: {
+              updateValue: {
+                inputSchema: docMutationInputSchema,
+                execute: ({ input }) => input,
+              },
+            },
+          },
+        },
+      });
+
+      // Direct failures that the session classifies as outage/offline should
+      // become a durable queued success instead of surfacing an error.
+      const result = await env.apiStore.performMutation({
+        mutation: directMutation,
+        offline: { operation: 'updateValue', input: { value: 2 } },
+      });
+
+      expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+      expect(getGlobalOfflineStatus(sessionKey)).toMatchObject({
+        effectiveOffline: true,
+        outage: { active: true, enabled: true },
+      });
+    });
+
+    test('preserve the normal error when the direct failure is not connectivity-related', async () => {
+      const sessionKey = 'hybrid-doc-error-session';
+      const storeName = 'hybrid-doc-error-store';
+      const directMutation = vi.fn(() =>
+        Promise.reject(new Error('validation-error')),
+      );
+      const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+        getSessionKey: () => sessionKey,
+        testScenario: 'loaded',
+        persistentStorage: {
+          storeName,
+          adapter: 'local-sync',
+          schema: docSchema,
+          offlineMode: {
+            network: network.config,
+            outage: {
+              enabled: true,
+              classifyFailure: (error, ctx) =>
+                classifyMutationOutage(error, ctx.phase) ? 'outage' : 'ignore',
+              recoveryCheck: () => false,
+              recoveryProbe: quickRecoveryProbe,
+            },
+            operations: {
+              updateValue: {
+                inputSchema: docMutationInputSchema,
+                execute: ({ input }) => input,
+              },
+            },
+          },
+        },
+      });
+
+      const result = await env.apiStore.performMutation({
+        mutation: directMutation,
+        offline: { operation: 'updateValue', input: { value: 2 } },
+      });
+
+      expect(result.ok).toBe(false);
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(
+        getOfflineQueueEntries(sessionKey, storeName),
+      ).toMatchInlineSnapshot(`[]`);
+    });
+
+    test('online direct mutations that return undefined still revalidate', async () => {
+      const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+        getSessionKey: () => 'hybrid-doc-void-online-session',
+        testScenario: 'loaded',
+        persistentStorage: {
+          storeName: 'hybrid-doc-void-online-store',
+          adapter: 'local-sync',
+          schema: docSchema,
+          offlineMode: {
+            network: network.config,
+            operations: {
+              updateValue: {
+                inputSchema: docMutationInputSchema,
+                execute: ({ input }) => input,
+              },
+            },
+          },
+        },
+      });
+      const documentHook = renderHook(() =>
+        env.apiStore.useDocument({
+          returnRefetchingStatus: true,
+          disableRefetchOnMount: true,
+        }),
+      );
+
+      env.serverMock.setData(2);
+
+      const result = await env.apiStore.performMutation({
+        mutation: () => Promise.resolve(undefined),
+        revalidateOnSuccess: true,
+        offline: { operation: 'updateValue', input: { value: 2 } },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        value: { kind: 'online', data: undefined },
+      });
+
+      await act(async () => {
+        await advanceTime(1_200);
+      });
+      await waitForMicrotaskCondition(
+        () => documentHook.result.current.data?.value === 2,
+      );
+
+      expect(documentHook.result.current.data).toMatchObject({ value: 2 });
+      documentHook.unmount();
+    });
+  });
+
+  describe('collection mutations', () => {
+    test('queue immediately when the session is already offline', async () => {
+      network.setOffline();
+      const sessionKey = 'hybrid-collection-offline-session';
+      const storeName = 'hybrid-collection-offline-store';
+      const directMutation = vi.fn(() =>
+        Promise.resolve({ value: { name: 'Grace' } }),
+      );
+      const env = createCollectionStoreTestEnv<
+        { name: string },
+        RenameCollectionItemOperations
+      >(
+        { 'users||1': { name: 'Ada' } },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: 'loaded',
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: collectionSchema,
+            payloadSchema: rc_string,
+            offlineMode: {
+              network: network.config,
+              operations: {
+                renameItem: {
+                  inputSchema: renameCollectionInputSchema,
+                  getEntityRefs: ({ input }) => [input.id],
+                  execute: ({ input }) => ({ value: { name: input.name } }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'renameItem',
+          input: { id: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+      expect(directMutation).not.toHaveBeenCalled();
+      expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+    });
+
+    test('call the direct mutation while online and skip queueing on success', async () => {
+      const sessionKey = 'hybrid-collection-online-session';
+      const storeName = 'hybrid-collection-online-store';
+      const directMutation = vi.fn(() =>
+        Promise.resolve({ value: { name: 'Grace' } }),
+      );
+      const env = createCollectionStoreTestEnv<
+        { name: string },
+        RenameCollectionItemOperations
+      >(
+        { 'users||1': { name: 'Ada' } },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: 'loaded',
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: collectionSchema,
+            payloadSchema: rc_string,
+            offlineMode: {
+              network: network.config,
+              operations: {
+                renameItem: {
+                  inputSchema: renameCollectionInputSchema,
+                  getEntityRefs: ({ input }) => [input.id],
+                  execute: ({ input }) => ({ value: { name: input.name } }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'renameItem',
+          input: { id: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        value: { kind: 'online', data: { value: { name: 'Grace' } } },
+      });
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(
+        getOfflineQueueEntries(sessionKey, storeName),
+      ).toMatchInlineSnapshot(`[]`);
+    });
+
+    test('fallback to queueing when the direct failure is classified as offline', async () => {
+      const sessionKey = 'hybrid-collection-fallback-session';
+      const storeName = 'hybrid-collection-fallback-store';
+      const directMutation = vi.fn(() =>
+        Promise.reject(new Error('offline-fallback')),
+      );
+      const env = createCollectionStoreTestEnv<
+        { name: string },
+        RenameCollectionItemOperations
+      >(
+        { 'users||1': { name: 'Ada' } },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: 'loaded',
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: collectionSchema,
+            payloadSchema: rc_string,
+            offlineMode: {
+              network: network.config,
+              outage: {
+                enabled: true,
+                classifyFailure: (error, ctx) =>
+                  classifyMutationOutage(error, ctx.phase)
+                    ? 'outage'
+                    : 'ignore',
+                recoveryCheck: () => false,
+                recoveryProbe: quickRecoveryProbe,
+              },
+              operations: {
+                renameItem: {
+                  inputSchema: renameCollectionInputSchema,
+                  getEntityRefs: ({ input }) => [input.id],
+                  execute: ({ input }) => ({ value: { name: input.name } }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'renameItem',
+          input: { id: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+      expect(getGlobalOfflineStatus(sessionKey)).toMatchObject({
+        effectiveOffline: true,
+      });
+    });
+
+    test('preserve the normal error when the direct failure is not connectivity-related', async () => {
+      const sessionKey = 'hybrid-collection-error-session';
+      const storeName = 'hybrid-collection-error-store';
+      const directMutation = vi.fn(() =>
+        Promise.reject(new Error('validation-error')),
+      );
+      const env = createCollectionStoreTestEnv<
+        { name: string },
+        RenameCollectionItemOperations
+      >(
+        { 'users||1': { name: 'Ada' } },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: 'loaded',
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: collectionSchema,
+            payloadSchema: rc_string,
+            offlineMode: {
+              network: network.config,
+              outage: {
+                enabled: true,
+                classifyFailure: (error, ctx) =>
+                  classifyMutationOutage(error, ctx.phase)
+                    ? 'outage'
+                    : 'ignore',
+                recoveryCheck: () => false,
+                recoveryProbe: quickRecoveryProbe,
+              },
+              operations: {
+                renameItem: {
+                  inputSchema: renameCollectionInputSchema,
+                  getEntityRefs: ({ input }) => [input.id],
+                  execute: ({ input }) => ({ value: { name: input.name } }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'renameItem',
+          input: { id: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(
+        getOfflineQueueEntries(sessionKey, storeName),
+      ).toMatchInlineSnapshot(`[]`);
+    });
+  });
+
+  describe('list-query mutations', () => {
+    test('queue immediately when the session is already offline', async () => {
+      network.setOffline();
+      const sessionKey = 'hybrid-list-offline-session';
+      const storeName = 'hybrid-list-offline-store';
+      const directMutation = vi.fn(() => Promise.resolve({ name: 'Grace' }));
+      const env = createListQueryStoreTestEnv<
+        { id: number; name: string },
+        false,
+        false,
+        PatchUserOperations
+      >(
+        { users: [{ id: 1, name: 'Ada' }] },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: { loaded: { queries: [{ tableId: 'users' }] } },
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: userRowSchema,
+            itemPayloadSchema: rc_string,
+            queryPayloadSchema: listQueryQueryPayloadSchema,
+            offlineMode: {
+              network: network.config,
+              operations: {
+                patchUserName: {
+                  inputSchema: userPatchSchema,
+                  getEntityRefs: ({ input }) => [input.itemId],
+                  execute: ({ input }) => ({ name: input.name }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'patchUserName',
+          input: { itemId: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+      expect(directMutation).not.toHaveBeenCalled();
+      expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+    });
+
+    test('call the direct mutation while online and skip queueing on success', async () => {
+      const sessionKey = 'hybrid-list-online-session';
+      const storeName = 'hybrid-list-online-store';
+      const directMutation = vi.fn(() => Promise.resolve({ name: 'Grace' }));
+      const env = createListQueryStoreTestEnv<
+        { id: number; name: string },
+        false,
+        false,
+        PatchUserOperations
+      >(
+        { users: [{ id: 1, name: 'Ada' }] },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: { loaded: { queries: [{ tableId: 'users' }] } },
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: userRowSchema,
+            itemPayloadSchema: rc_string,
+            queryPayloadSchema: listQueryQueryPayloadSchema,
+            offlineMode: {
+              network: network.config,
+              operations: {
+                patchUserName: {
+                  inputSchema: userPatchSchema,
+                  getEntityRefs: ({ input }) => [input.itemId],
+                  execute: ({ input }) => ({ name: input.name }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'patchUserName',
+          input: { itemId: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        value: { kind: 'online', data: { name: 'Grace' } },
+      });
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(
+        getOfflineQueueEntries(sessionKey, storeName),
+      ).toMatchInlineSnapshot(`[]`);
+    });
+
+    test('online direct mutations that return undefined still call onSuccess', async () => {
+      const onSuccess = vi.fn();
+      const env = createListQueryStoreTestEnv<
+        { id: number; name: string },
+        false,
+        false,
+        PatchUserOperations
+      >(
+        { users: [{ id: 1, name: 'Ada' }] },
+        {
+          getSessionKey: () => 'hybrid-list-void-online-session',
+          testScenario: { loaded: { queries: [{ tableId: 'users' }] } },
+          persistentStorage: {
+            storeName: 'hybrid-list-void-online-store',
+            adapter: 'local-sync',
+            schema: userRowSchema,
+            itemPayloadSchema: rc_string,
+            queryPayloadSchema: listQueryQueryPayloadSchema,
+            offlineMode: {
+              network: network.config,
+              operations: {
+                patchUserName: {
+                  inputSchema: userPatchSchema,
+                  getEntityRefs: ({ input }) => [input.itemId],
+                  execute: ({ input }) => ({ name: input.name }),
+                },
+              },
+            },
+          },
+        },
+      );
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: () => Promise.resolve(undefined),
+        onSuccess,
+        revalidateOnSuccess: true,
+        offline: {
+          operation: 'patchUserName',
+          input: { itemId: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        value: { kind: 'online', data: undefined },
+      });
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(onSuccess).toHaveBeenCalledWith(undefined, 'users||1');
+    });
+
+    test('fallback to queueing when the direct failure is classified as offline', async () => {
+      const sessionKey = 'hybrid-list-fallback-session';
+      const storeName = 'hybrid-list-fallback-store';
+      const directMutation = vi.fn(() =>
+        Promise.reject(new Error('offline-fallback')),
+      );
+      const env = createListQueryStoreTestEnv<
+        { id: number; name: string },
+        false,
+        false,
+        PatchUserOperations
+      >(
+        { users: [{ id: 1, name: 'Ada' }] },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: { loaded: { queries: [{ tableId: 'users' }] } },
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: userRowSchema,
+            itemPayloadSchema: rc_string,
+            queryPayloadSchema: listQueryQueryPayloadSchema,
+            offlineMode: {
+              network: network.config,
+              outage: {
+                enabled: true,
+                classifyFailure: (error, ctx) =>
+                  classifyMutationOutage(error, ctx.phase)
+                    ? 'outage'
+                    : 'ignore',
+                recoveryCheck: () => false,
+                recoveryProbe: quickRecoveryProbe,
+              },
+              operations: {
+                patchUserName: {
+                  inputSchema: userPatchSchema,
+                  getEntityRefs: ({ input }) => [input.itemId],
+                  execute: ({ input }) => ({ name: input.name }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'patchUserName',
+          input: { itemId: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+      expect(getGlobalOfflineStatus(sessionKey)).toMatchObject({
+        effectiveOffline: true,
+      });
+    });
+
+    test('preserve the normal error when the direct failure is not connectivity-related', async () => {
+      const sessionKey = 'hybrid-list-error-session';
+      const storeName = 'hybrid-list-error-store';
+      const directMutation = vi.fn(() =>
+        Promise.reject(new Error('validation-error')),
+      );
+      const env = createListQueryStoreTestEnv<
+        { id: number; name: string },
+        false,
+        false,
+        PatchUserOperations
+      >(
+        { users: [{ id: 1, name: 'Ada' }] },
+        {
+          getSessionKey: () => sessionKey,
+          testScenario: { loaded: { queries: [{ tableId: 'users' }] } },
+          persistentStorage: {
+            storeName,
+            adapter: 'local-sync',
+            schema: userRowSchema,
+            itemPayloadSchema: rc_string,
+            queryPayloadSchema: listQueryQueryPayloadSchema,
+            offlineMode: {
+              network: network.config,
+              outage: {
+                enabled: true,
+                classifyFailure: (error, ctx) =>
+                  classifyMutationOutage(error, ctx.phase)
+                    ? 'outage'
+                    : 'ignore',
+                recoveryCheck: () => false,
+                recoveryProbe: quickRecoveryProbe,
+              },
+              operations: {
+                patchUserName: {
+                  inputSchema: userPatchSchema,
+                  getEntityRefs: ({ input }) => [input.itemId],
+                  execute: ({ input }) => ({ name: input.name }),
+                },
+              },
+            },
+          },
+        },
+      );
+
+      const result = await env.apiStore.performMutation('users||1', {
+        mutation: directMutation,
+        offline: {
+          operation: 'patchUserName',
+          input: { itemId: 'users||1', name: 'Grace' },
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      expect(directMutation).toHaveBeenCalledTimes(1);
+      expect(
+        getOfflineQueueEntries(sessionKey, storeName),
+      ).toMatchInlineSnapshot(`[]`);
+    });
+  });
+
+  test('fallback queueing does not reapply the optimistic update', async () => {
+    const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+      getSessionKey: () => 'hybrid-doc-optimistic-session',
+      testScenario: 'loaded',
+      persistentStorage: {
+        storeName: 'hybrid-doc-optimistic-store',
+        adapter: 'local-sync',
+        schema: docSchema,
+        offlineMode: {
+          network: network.config,
+          outage: {
+            enabled: true,
+            classifyFailure: (error, ctx) =>
+              classifyMutationOutage(error, ctx.phase) ? 'outage' : 'ignore',
+            recoveryCheck: () => false,
+            recoveryProbe: quickRecoveryProbe,
+          },
+          operations: {
+            updateValue: {
+              inputSchema: docMutationInputSchema,
+              execute: ({ input }) => input,
+            },
+          },
+        },
+      },
+    });
+
+    // The optimistic write should happen once and stay visible after the
+    // direct request degrades into a queued mutation.
+    const result = await env.apiStore.performMutation({
+      optimisticUpdate: () => {
+        env.apiStore.updateState((draft) => {
+          draft.value += 1;
+        });
+      },
+      mutation: () => Promise.reject(new Error('offline-fallback')),
+      offline: { operation: 'updateValue', input: { value: 2 } },
+    });
+
+    expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+    expect(env.store.state.data).toMatchInlineSnapshot(`
+      value: 2
+    `);
+  });
+
+  test('fallback queueing still creates and reconciles temp entities', async () => {
+    const sessionKey = 'hybrid-temp-entity-session';
+    const storeName = 'hybrid-temp-entity-store';
+    const directMutation = vi.fn(() =>
+      Promise.reject(new Error('offline-fallback')),
+    );
+    const execute = vi.fn(({ input }: { input: { name: string } }) => ({
+      id: 'users||ada',
+      name: input.name,
+    }));
+    const env = createCollectionStoreTestEnv<
+      { name: string },
+      CreateUserOperations
+    >(
+      { 'users||1': { name: 'User 1' } },
+      {
+        getSessionKey: () => sessionKey,
+        testScenario: 'loaded',
+        persistentStorage: {
+          storeName,
+          adapter: 'local-sync',
+          schema: collectionSchema,
+          payloadSchema: rc_string,
+          offlineMode: {
+            network: network.config,
+            outage: {
+              enabled: true,
+              classifyFailure: (error, ctx) =>
+                classifyMutationOutage(error, ctx.phase) ? 'outage' : 'ignore',
+              recoveryCheck: () => true,
+              recoveryProbe: quickRecoveryProbe,
+            },
+            operations: {
+              createUser: {
+                inputSchema: collectionCreateInputSchema,
+                getEntityRefs: ({ input }) => [`temp:${input.name}`],
+                tempEntity: {
+                  createTempId: (input) => `temp:${input.name}`,
+                  buildPendingEntity: (input) => ({
+                    value: { name: `pending:${input.name}` },
+                  }),
+                  reconcileServerEntity: (result) => ({
+                    finalPayload: result.id,
+                    finalData: { value: { name: result.name } },
+                  }),
+                },
+                execute,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    // Even though the request started online, the queued fallback still needs
+    // to materialize the temp entity so replay can reconcile it later.
+    const result = await env.apiStore.performMutation('__create__', {
+      mutation: directMutation,
+      offline: { operation: 'createUser', input: { name: 'Ada' } },
+    });
+
+    expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+    expect(env.apiStore.getOfflineEntities()).toMatchObject([
+      { entityKey: 'temp:Ada', tempId: 'temp:Ada' },
+    ]);
+    expect(env.store.state[getCompositeKey('temp:Ada')]?.data).toMatchObject({
+      value: { name: 'pending:Ada' },
+    });
+
+    await act(async () => {
+      await advanceTime(1);
+    });
+    await waitForMicrotaskCondition(() => execute.mock.calls.length === 1);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(env.apiStore.getOfflineEntities()).toMatchInlineSnapshot(`[]`);
+    expect(env.store.state[getCompositeKey('temp:Ada')]).toBeNull();
+    expect(env.store.state[getCompositeKey('users||ada')]?.data).toMatchObject({
+      value: { name: 'Ada' },
+    });
+  });
+
+  test('accumulation still merges entries when the queue starts from a fallback', async () => {
+    const sessionKey = 'hybrid-accumulation-session';
+    const storeName = 'hybrid-accumulation-store';
+    const directMutation = vi.fn(() =>
+      Promise.reject(new Error('offline-fallback')),
+    );
+    const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+      getSessionKey: () => sessionKey,
+      testScenario: 'loaded',
+      persistentStorage: {
+        storeName,
+        adapter: 'local-sync',
+        schema: docSchema,
+        offlineMode: {
+          network: network.config,
+          outage: {
+            enabled: true,
+            classifyFailure: (error, ctx) =>
+              classifyMutationOutage(error, ctx.phase) ? 'outage' : 'ignore',
+            recoveryCheck: () => false,
+            recoveryProbe: quickRecoveryProbe,
+          },
+          operations: {
+            updateValue: {
+              inputSchema: docMutationInputSchema,
+              accumulation: {
+                mergeInput: ({ incomingInput }) => incomingInput,
+              },
+              execute: ({ input }) => input,
+            },
+          },
+        },
+      },
+    });
+
+    // The first mutation becomes a fallback-queued entry. Once the session is
+    // in outage mode, the next mutation should merge into that persisted entry.
+    await env.apiStore.performMutation({
+      optimisticUpdate: () => {
+        env.apiStore.updateState((draft) => {
+          draft.value = 2;
+        });
+      },
+      mutation: directMutation,
+      offline: { operation: 'updateValue', input: { value: 2 } },
+    });
+    await env.apiStore.performMutation({
+      optimisticUpdate: () => {
+        env.apiStore.updateState((draft) => {
+          draft.value = 3;
+        });
+      },
+      mutation: () => Promise.resolve(3),
+      offline: { operation: 'updateValue', input: { value: 3 } },
+    });
+
+    expect(directMutation).toHaveBeenCalledTimes(1);
+    expect(env.store.state.data).toMatchInlineSnapshot(`
+      value: 3
+    `);
+    expect(getOfflineQueueEntries(sessionKey, storeName)).toHaveLength(1);
+    expect(
+      getOfflineQueueEntryData(
+        getOfflineQueueEntries(sessionKey, storeName)[0]!,
+      ),
+    ).toMatchObject({ input: { value: 3 } });
+  });
+
+  test('conflict handling still works for mutations queued via fallback', async () => {
+    const execute = vi.fn(({ input }: { input: { value: number } }) => input);
+    const env = createDocumentStoreTestEnv<
+      number,
+      UpdateValueConflictOperations
+    >(1, {
+      getSessionKey: () => 'hybrid-conflict-session',
+      testScenario: 'loaded',
+      persistentStorage: {
+        storeName: 'hybrid-conflict-store',
+        adapter: 'local-sync',
+        schema: docSchema,
+        offlineMode: {
+          network: network.config,
+          outage: {
+            enabled: true,
+            classifyFailure: (error, ctx) =>
+              classifyMutationOutage(error, ctx.phase) ? 'outage' : 'ignore',
+            recoveryCheck: () => true,
+            recoveryProbe: quickRecoveryProbe,
+          },
+          operations: {
+            updateValue: {
+              inputSchema: docMutationInputSchema,
+              execute,
+              conflictHandling: {
+                detectConflict: ({ input }) =>
+                  input.value === 2 ? { reason: 'server-changed' } : false,
+                resolveConflict: () => undefined,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // A mutation that first fails online should still enter the normal replay
+    // conflict flow once it has been queued by the hybrid fallback.
+    const result = await env.apiStore.performMutation({
+      mutation: () => Promise.reject(new Error('offline-fallback')),
+      offline: { operation: 'updateValue', input: { value: 2 } },
+    });
+
+    expect(result).toMatchObject({ ok: true, value: { kind: 'queued' } });
+
+    await act(async () => {
+      await advanceTime(1);
+    });
+    await waitForMicrotaskCondition(
+      () => env.apiStore.getOfflineConflicts().length === 1,
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(env.apiStore.getOfflineConflicts()).toMatchObject([
+      {
+        conflict: { reason: 'server-changed' },
+        input: { value: 2 },
+        operation: 'updateValue',
+      },
+    ]);
+  });
+});

--- a/tests/offline/offline-mode.test.tsx
+++ b/tests/offline/offline-mode.test.tsx
@@ -144,6 +144,43 @@ describe('offline mode network and session', () => {
         mutation: () => Promise.resolve(2),
         offline: { operation: 'updateValue', input: { value: 2 } },
       });
+
+      async function queuedOfflineResultType_() {
+        const queued = await typedEnv.apiStore.performMutation({
+          mutation: () => Promise.resolve(2),
+          offline: { operation: 'updateValue', input: { value: 2 } },
+        });
+
+        if (queued.ok) {
+          const queuedValue:
+            | { kind: 'online'; data: number }
+            | { kind: 'queued' } = queued.value;
+          void queuedValue;
+
+          if (queued.value.kind === 'online') {
+            const serverValue: number = queued.value.data;
+            void serverValue;
+          }
+
+          // @ts-expect-error - queued offline mutations do not always expose a server payload directly
+          const serverValue: number = queued.value.data;
+          void serverValue;
+        }
+      }
+
+      async function onlineResultType_() {
+        const result = await typedEnv.apiStore.performMutation({
+          mutation: () => Promise.resolve(2),
+        });
+
+        if (result.ok) {
+          const serverValue: number = result.value;
+          void serverValue;
+        }
+      }
+
+      void queuedOfflineResultType_;
+      void onlineResultType_;
     }
 
     void typeCheck_;
@@ -169,10 +206,95 @@ describe('offline mode network and session', () => {
         mutation: () => Promise.resolve({ value: { name: 'Grace' } }),
         offline: { operation: 'renameItem', input: { name: 'Grace' } },
       });
+
+      async function queuedOfflineResultType_() {
+        const queued = await typedEnv.apiStore.performMutation('users||1', {
+          mutation: () => Promise.resolve({ value: { name: 'Grace' } }),
+          offline: { operation: 'renameItem', input: { name: 'Grace' } },
+        });
+
+        if (queued.ok) {
+          const queuedValue:
+            | { kind: 'online'; data: { value: { name: string } } }
+            | { kind: 'queued' } = queued.value;
+          void queuedValue;
+
+          if (queued.value.kind === 'online') {
+            const serverValue: { value: { name: string } } = queued.value.data;
+            void serverValue;
+          }
+
+          // @ts-expect-error - queued offline mutations do not always expose a server payload directly
+          const serverValue: { value: { name: string } } = queued.value.data;
+          void serverValue;
+        }
+      }
+
+      async function onlineResultType_() {
+        const result = await typedEnv.apiStore.performMutation('users||1', {
+          mutation: () => Promise.resolve({ value: { name: 'Grace' } }),
+        });
+
+        if (result.ok) {
+          const serverValue: { value: { name: string } } = result.value;
+          void serverValue;
+        }
+      }
+
+      void queuedOfflineResultType_;
+      void onlineResultType_;
     }
 
     void typeCheck_;
     expect(true).toBe(true);
+  });
+
+  test('stores unregister their previous offline session when the session key becomes unavailable', async () => {
+    network.setOffline();
+
+    let currentSessionKey: string | false = 'offline-session-cleanup';
+    const env = createDocumentStoreTestEnv<number, UpdateValueOperations>(1, {
+      getSessionKey: () => currentSessionKey,
+      testScenario: 'loaded',
+      persistentStorage: {
+        storeName: 'offline-session-cleanup-doc',
+        adapter: 'local-sync',
+        schema: docSchema,
+        offlineMode: {
+          network: network.config,
+          operations: {
+            updateValue: {
+              inputSchema: docMutationInputSchema,
+              execute: ({ input }: UpdateValueExecuteContext) => input,
+            },
+          },
+        },
+      },
+    });
+
+    await act(async () => {
+      await env.apiStore.performMutation({
+        optimisticUpdate: () => {
+          env.apiStore.updateState((draft) => {
+            draft.value = 2;
+          });
+        },
+        mutation: () => Promise.resolve(2),
+        offline: { operation: 'updateValue', input: { value: 2 } },
+      });
+    });
+
+    expect(getGlobalOfflineEntities('offline-session-cleanup')).toMatchObject([
+      { entityKey: 'document', storeName: 'offline-session-cleanup-doc' },
+    ]);
+
+    // Simulate logout so the store no longer belongs to the previous session.
+    currentSessionKey = false;
+
+    expect(env.apiStore.getOfflineEntities()).toMatchInlineSnapshot(`[]`);
+    expect(
+      getGlobalOfflineEntities('offline-session-cleanup'),
+    ).toMatchInlineSnapshot(`[]`);
   });
 
   test('document offline mutations are queued durably and replay when the browser comes back online', async () => {

--- a/tests/offline/offline-replay-list-query.test.tsx
+++ b/tests/offline/offline-replay-list-query.test.tsx
@@ -128,6 +128,46 @@ describe('offline replay list-query behavior', () => {
           input: { itemId: 'users||1', name: 'Ada offline' },
         },
       });
+
+      async function queuedOfflineResultType_() {
+        const queued = await typedEnv.apiStore.performMutation('users||1', {
+          mutation: () => Promise.resolve({ name: 'Ada offline' }),
+          offline: {
+            operation: 'patchUserName',
+            input: { itemId: 'users||1', name: 'Ada offline' },
+          },
+        });
+
+        if (queued.ok) {
+          const queuedValue:
+            | { kind: 'online'; data: { name: string } }
+            | { kind: 'queued' } = queued.value;
+          void queuedValue;
+
+          if (queued.value.kind === 'online') {
+            const serverValue: { name: string } = queued.value.data;
+            void serverValue;
+          }
+
+          // @ts-expect-error - queued offline mutations do not always expose a server payload directly
+          const serverValue: { name: string } = queued.value.data;
+          void serverValue;
+        }
+      }
+
+      async function onlineResultType_() {
+        const result = await typedEnv.apiStore.performMutation('users||1', {
+          mutation: () => Promise.resolve({ name: 'Ada offline' }),
+        });
+
+        if (result.ok) {
+          const serverValue: { name: string } = result.value;
+          void serverValue;
+        }
+      }
+
+      void queuedOfflineResultType_;
+      void onlineResultType_;
     }
 
     void typeCheck_;

--- a/tests/offline/offline-replay-queueing.test.tsx
+++ b/tests/offline/offline-replay-queueing.test.tsx
@@ -358,6 +358,7 @@ describe('offline replay queueing and retry behavior', () => {
   });
 
   test('needs-confirmation entries retry execute when shouldSkipSync returns false', async () => {
+    network.setOffline();
     let skipCheckEnqueuedAt: number | null = null;
     const execute = vi
       .fn<
@@ -398,6 +399,7 @@ describe('offline replay queueing and retry behavior', () => {
         adapter: 'local-sync',
         schema: docSchema,
         offlineMode: {
+          network: network.config,
           operations: {
             updateValue: {
               inputSchema: docMutationInputSchema,
@@ -421,8 +423,10 @@ describe('offline replay queueing and retry behavior', () => {
 
     expect(mutationResult.ok).toBe(true);
 
-    await Promise.resolve();
-    await Promise.resolve();
+    act(() => {
+      network.goOnline();
+    });
+    await waitForMicrotaskCondition(() => execute.mock.calls.length === 1);
 
     expect(execute).toHaveBeenCalledTimes(1);
     expect(shouldSkipSync).toHaveBeenCalledTimes(0);
@@ -504,7 +508,7 @@ describe('offline replay queueing and retry behavior', () => {
   });
 
   test('needs-confirmation entries keep retrying shouldSkipSync while the session stays online', async () => {
-    network.setOnline();
+    network.setOffline();
     let skipCheckEnqueuedAt: number | null = null;
     const execute = vi
       .fn<
@@ -566,7 +570,15 @@ describe('offline replay queueing and retry behavior', () => {
       offline: { operation: 'updateValue', input: { value: 2 } },
     });
 
-    await Promise.resolve();
+    act(() => {
+      network.goOnline();
+    });
+    await waitForMicrotaskCondition(() => execute.mock.calls.length === 1);
+    await waitForMicrotaskCondition(
+      () =>
+        env.apiStore.getOfflineEntities()[0]?.syncState ===
+        'needs-confirmation',
+    );
     expect(execute).toHaveBeenCalledTimes(1);
     expect(shouldSkipSync).toHaveBeenCalledTimes(0);
     expect(env.apiStore.getOfflineEntities()).toMatchObject([

--- a/tests/user-facing-api/document-offline-usage.test.tsx
+++ b/tests/user-facing-api/document-offline-usage.test.tsx
@@ -403,3 +403,123 @@ test('direct document store offline public api supports the main operation hooks
 
   documentHook.unmount();
 });
+
+type TempDocumentOfflineOperations = DefineDocumentOfflineOperations<
+  DocState,
+  {
+    createTempDoc: DefineOfflineOperation<
+      ValueInput,
+      unknown,
+      { value: number }
+    >;
+  }
+>;
+
+test('document temp entities stay pending on the document key and reconcile after replay', async () => {
+  const network = createOfflineNetworkMock();
+  const sessionKey = 'document-temp-entity-session';
+  network.install();
+
+  let documentState: DocState = { value: 1, label: 'server' };
+
+  const documentStore = createDocumentStore<
+    DocState,
+    TempDocumentOfflineOperations
+  >({
+    id: 'document-temp-entity',
+    getSessionKey: () => sessionKey,
+    fetchFn: async () => {
+      await delay(FETCH_DELAY_MS);
+      return { ...documentState };
+    },
+    errorNormalizer: normalizeError,
+    lowPriorityThrottleMs: 5,
+    baseCoalescingWindowMs: 10,
+    blockWindowClose: null,
+    persistentStorage: {
+      storeName: 'document-temp-entity',
+      adapter: 'local-sync',
+      schema: docSchema,
+      offlineMode: {
+        network: network.config,
+        operations: {
+          createTempDoc: {
+            inputSchema: setValueInputSchema,
+            tempEntity: {
+              createTempId: (input) => `temp:${input.value}`,
+              buildPendingEntity: (input) => ({
+                value: input.value,
+                label: `pending:${input.value}`,
+              }),
+              reconcileServerEntity: (result) => ({
+                finalPayload: 'document',
+                finalData: {
+                  value: result.value,
+                  label: `server:${result.value}`,
+                },
+              }),
+            },
+            execute: ({ input }) => {
+              documentState = {
+                value: input.value,
+                label: `server:${input.value}`,
+              };
+
+              return { value: input.value };
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const documentHook = renderHook(() => documentStore.useDocument());
+  await flushAllTimers();
+
+  act(() => {
+    network.goOffline();
+  });
+  await Promise.resolve();
+
+  await act(async () => {
+    await documentStore.performMutation({
+      mutation: () => Promise.resolve({ value: 2 }),
+      offline: { operation: 'createTempDoc', input: { value: 2 } },
+    });
+  });
+
+  expect(documentStore.getOfflineEntities()).toMatchObject([
+    { entityKey: 'document', entityKind: 'document', tempId: 'temp:2' },
+  ]);
+  expect(
+    pick(documentHook.result.current, [
+      'data',
+      'status',
+      'isPendingOfflineSync',
+    ]),
+  ).toMatchInlineSnapshot(`
+    data: { label: 'pending:2', value: 2 }
+    isPendingOfflineSync: '✅'
+    status: 'success'
+  `);
+
+  await act(async () => {
+    network.goOnline();
+    await flushAllTimers();
+  });
+
+  expect(documentStore.getOfflineEntities()).toMatchInlineSnapshot(`[]`);
+  expect(
+    pick(documentHook.result.current, [
+      'data',
+      'status',
+      'isPendingOfflineSync',
+    ]),
+  ).toMatchInlineSnapshot(`
+    data: { label: 'server:2', value: 2 }
+    isPendingOfflineSync: '❌'
+    status: 'success'
+  `);
+
+  documentHook.unmount();
+});


### PR DESCRIPTION
## Summary

Introduce hybrid offline mutation handling so offline-enabled mutations can try a direct request first, then transparently queue when the session is offline or the failure is classified as an outage. This preserves normal online behavior while making offline-capable mutations more resilient and consistent across document, collection, and list-query stores.
### Changes

- Added shared hybrid mutation runtime and typed offline result handling.
- Updated document, collection, and list-query mutation APIs to support online-first execution with durable offline fallback.
- Enhanced offline session preparation and controller cleanup to better support fallback queueing and replay.
- Preserved revalidation, optimistic updates, and temp-entity reconciliation for queued mutations.
- Expanded offline tests to cover online success, offline queueing, outage fallback, error passthrough, and replay behavior.

### Testing Notes

Verify offline-enabled mutations still succeed normally while online, queue immediately when the network is unavailable, and fall back to queueing only for classified outage/offline failures. Also check revalidation, optimistic updates, temp-entity reconciliation, and replay/merge/conflict flows after the fallback path runs.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
