### PR TITLE
Serialize async storage writes with session writer locks

### DIFF
--- a/src/persistentStorage/asyncStorageAdapter.ts
+++ b/src/persistentStorage/asyncStorageAdapter.ts
@@ -45,6 +45,9 @@ export const ASYNC_STORAGE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 export const ASYNC_STORAGE_STARTUP_CLEANUP_COOLDOWN_MS = 12 * 60 * 60 * 1000;
 export const ASYNC_STORAGE_RECENCY_BUCKET_MS = 6 * 60 * 60 * 1000;
 export const ASYNC_MAINTENANCE_LOCAL_STORAGE_KEY = 'tsdf._am.g';
+const ASYNC_STORAGE_WRITER_LOCK_NAME_PREFIX = 'tsdf-async-write:';
+const ASYNC_STORAGE_WRITER_LOCK_WARNING =
+  '[TSDF] navigator.locks is unavailable; async persistentStorage is using unlocked writer coordination.';
 const ASYNC_STARTUP_CLEANUP_LOCK_NAME = 'tsdf-async-storage-maintenance';
 const ASYNC_STARTUP_CLEANUP_LOCK_WARNING =
   '[TSDF] navigator.locks is unavailable; async OPFS startup cleanup is using unlocked coordination.';
@@ -458,8 +461,6 @@ export async function readAsyncStorageNamespaceIndexStateUsingDriver(
     valid: true,
   };
 }
-
-type AsyncStorageManagedReadMode = 'cached' | 'fresh';
 
 type AsyncStoragePayloadReadState = { value: unknown };
 
@@ -974,6 +975,17 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     registerAsyncStorageReadCacheParticipant(this);
   }
 
+  async #runWithSessionWriterLock<T>(
+    sessionKey: string,
+    callback: () => T | Promise<T>,
+  ): Promise<T> {
+    return runWithNavigatorLock(
+      `${ASYNC_STORAGE_WRITER_LOCK_NAME_PREFIX}${sessionKey}`,
+      ASYNC_STORAGE_WRITER_LOCK_WARNING,
+      callback,
+    );
+  }
+
   openNamespace<
     TValue,
     TCustomMetadata extends Record<string, unknown> = Record<string, never>,
@@ -989,12 +1001,16 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
   }
 
   async clearSession(sessionKey: string): Promise<void> {
-    await this.flushAllPendingNamespaceCommits();
-    const scopesToClear = await this.#listDiscoveredScopes(sessionKey);
+    await this.#runWithSessionWriterLock(sessionKey, async () => {
+      await this.#flushPendingNamespaceCommitsForSessionUnlocked(sessionKey);
+      const scopesToClear = await this.#listDiscoveredScopes(sessionKey);
 
-    await Promise.all(
-      scopesToClear.map((scope) => this.clearManagedNamespace(scope)),
-    );
+      await Promise.all(
+        scopesToClear.map((scope) =>
+          this.#clearManagedNamespaceUnlocked(scope),
+        ),
+      );
+    });
   }
 
   async readProtectedStorageKeys(
@@ -1043,8 +1059,6 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     protectedKeys: Iterable<string>,
     previousProtectedKeys: Iterable<string> = [],
   ): Promise<void> {
-    await this.flushAllPendingNamespaceCommits();
-
     const nextProtectedRefSet = new Set(protectedKeys);
     const previousProtectedRefSet = new Set(previousProtectedKeys);
     const changedProtectedRefs = [
@@ -1057,15 +1071,6 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     ];
 
     if (changedProtectedRefs.length === 0) return;
-
-    const managedCapabilities = getManagedDriverCapabilities(this.driver);
-    if (managedCapabilities?.syncSessionProtectedKeys !== undefined) {
-      await managedCapabilities.syncSessionProtectedKeys(
-        sessionKey,
-        nextProtectedRefSet,
-      );
-      return;
-    }
 
     const updatesByScope = new Map<
       string,
@@ -1103,60 +1108,72 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
       });
     }
 
-    await Promise.all(
-      [...updatesByScope.values()].map(async ({ scope, protectionByKey }) => {
-        const indexState = await this.#readNamespaceIndexStateUsingDriver(
-          this.driver,
-          scope,
-          { mode: 'fresh' },
+    await this.#runWithSessionWriterLock(sessionKey, async () => {
+      await this.#flushPendingNamespaceCommitsForSessionUnlocked(sessionKey);
+
+      const managedCapabilities = getManagedDriverCapabilities(this.driver);
+      if (managedCapabilities?.syncSessionProtectedKeys !== undefined) {
+        await managedCapabilities.syncSessionProtectedKeys(
+          sessionKey,
+          nextProtectedRefSet,
         );
-        const indexEntries =
-          indexState.valid && indexState.entries !== null
-            ? indexState.entries
-            : new Map<string, InternalManagedMetadataRecord>();
-        let changed = false;
-
-        for (const [key, shouldProtect] of protectionByKey.entries()) {
-          const existingMetadata = indexEntries.get(key);
-          if (existingMetadata === undefined) continue;
-          if (
-            isOfflineProtectedMetadata(existingMetadata.customMetadata) ===
-            shouldProtect
-          ) {
-            continue;
-          }
-
-          const nextCustomMetadata = setOfflineProtectionMetadata(
-            existingMetadata.customMetadata,
-            shouldProtect,
-          );
-          const nextMetadata: InternalManagedMetadataRecord = {
-            ...existingMetadata,
-          };
-          if (nextCustomMetadata !== undefined) {
-            nextMetadata.customMetadata = nextCustomMetadata;
-          } else {
-            delete nextMetadata.customMetadata;
-          }
-
-          indexEntries.set(key, nextMetadata);
-          changed = true;
-        }
-
-        if (changed) {
-          await this.#persistNamespaceIndexUsingDriver(this.driver, scope, {
-            entries: indexEntries,
-            staticPolicy: await this.#readNamespaceIndexStaticPolicyUsingDriver(
-              this.driver,
-              scope,
-              undefined,
-              'fresh',
-            ),
-          });
+        for (const { scope } of updatesByScope.values()) {
+          this.#invalidateCachedNamespace(scope);
           this.#broadcastNamespaceInvalidation(scope, 'commit');
         }
-      }),
-    );
+        return;
+      }
+
+      await Promise.all(
+        [...updatesByScope.values()].map(async ({ scope, protectionByKey }) => {
+          const indexState = await this.#readNamespaceIndexStateUsingDriver(
+            this.driver,
+            scope,
+          );
+          const indexEntries =
+            indexState.valid && indexState.entries !== null
+              ? indexState.entries
+              : new Map<string, InternalManagedMetadataRecord>();
+          let changed = false;
+
+          for (const [key, shouldProtect] of protectionByKey.entries()) {
+            const existingMetadata = indexEntries.get(key);
+            if (existingMetadata === undefined) continue;
+            if (
+              isOfflineProtectedMetadata(existingMetadata.customMetadata) ===
+              shouldProtect
+            ) {
+              continue;
+            }
+
+            const nextCustomMetadata = setOfflineProtectionMetadata(
+              existingMetadata.customMetadata,
+              shouldProtect,
+            );
+            const nextMetadata: InternalManagedMetadataRecord = {
+              ...existingMetadata,
+            };
+            if (nextCustomMetadata !== undefined) {
+              nextMetadata.customMetadata = nextCustomMetadata;
+            } else {
+              delete nextMetadata.customMetadata;
+            }
+
+            indexEntries.set(key, nextMetadata);
+            changed = true;
+          }
+
+          if (changed) {
+            await this.#persistNamespaceIndexUsingDriver(this.driver, scope, {
+              entries: indexEntries,
+              staticPolicy: normalizeStaticPolicy(indexState.staticPolicy),
+            });
+            this.#invalidateCachedNamespace(scope);
+            this.#broadcastNamespaceInvalidation(scope, 'commit');
+          }
+        }),
+      );
+    });
   }
 
   resetForTests(): void {
@@ -1270,6 +1287,26 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     ) {
       return;
     }
+
+    await this.#runWithSessionWriterLock(scope.sessionKey, async () => {
+      await this.#flushPendingNamespaceCommitUnlocked(scope, keys);
+    });
+  }
+
+  async #flushPendingNamespaceCommitUnlocked(
+    scope: AsyncStorageNamespaceScope,
+    keys?: readonly string[],
+  ): Promise<void> {
+    const namespaceKey = getNamespaceId(scope);
+    const pending = this.#pendingNamespaceCommits.get(namespaceKey);
+    if (!pending) return;
+    if (
+      keys !== undefined &&
+      keys.length > 0 &&
+      !this.#hasPendingBarrierForKeys(pending, keys)
+    ) {
+      return;
+    }
     if (pending.flushPromise) {
       await pending.flushPromise;
       return;
@@ -1364,6 +1401,18 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     );
   }
 
+  async #flushPendingNamespaceCommitsForSessionUnlocked(
+    sessionKey: string,
+  ): Promise<void> {
+    await Promise.all(
+      [...this.#pendingNamespaceCommits.values()]
+        .filter((pending) => pending.scope.sessionKey === sessionKey)
+        .map((pending) =>
+          this.#flushPendingNamespaceCommitUnlocked(pending.scope),
+        ),
+    );
+  }
+
   clearRecentTouchedBucketsForNamespace(
     scope: AsyncStorageNamespaceScope,
   ): void {
@@ -1379,12 +1428,11 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     driver: AsyncStorageDriver,
     scope: AsyncStorageNamespaceScope,
     knownRecordKeys?: string[] | null,
-    mode: AsyncStorageManagedReadMode = 'cached',
   ): Promise<Map<string, InternalManagedMetadataRecord>> {
     const state = await this.#readNamespaceIndexStateUsingDriver(
       driver,
       scope,
-      { knownRecordKeys, mode },
+      { knownRecordKeys },
     );
     return state.valid && state.entries !== null ? state.entries : new Map();
   }
@@ -1393,12 +1441,11 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     driver: AsyncStorageDriver,
     scope: AsyncStorageNamespaceScope,
     knownRecordKeys?: string[] | null,
-    mode: AsyncStorageManagedReadMode = 'cached',
   ): Promise<AsyncStorageNamespaceStaticPolicy | null> {
     const state = await this.#readNamespaceIndexStateUsingDriver(
       driver,
       scope,
-      { knownRecordKeys, mode },
+      { knownRecordKeys },
     );
     return state.valid ? normalizeStaticPolicy(state.staticPolicy) : null;
   }
@@ -1406,15 +1453,11 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
   async #readNamespaceIndexStateUsingDriver(
     driver: AsyncStorageDriver,
     scope: AsyncStorageNamespaceScope,
-    args: {
-      knownRecordKeys?: string[] | null;
-      mode?: AsyncStorageManagedReadMode;
-    } = {},
+    args: { knownRecordKeys?: string[] | null } = {},
   ): Promise<AsyncStorageNamespaceIndexReadState> {
-    const mode = args.mode ?? 'cached';
     const knownRecordKeys = args.knownRecordKeys;
     const namespaceKey = getNamespaceId(scope);
-    const shouldUseCache = driver === this.driver && mode === 'cached';
+    const shouldUseCache = driver === this.driver;
 
     if (knownRecordKeys != null) {
       if (!knownRecordKeys.includes(ASYNC_NAMESPACE_INDEX_RECORD_KEY)) {
@@ -1679,6 +1722,14 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
   async clearManagedNamespace(
     scope: AsyncStorageNamespaceScope,
   ): Promise<void> {
+    await this.#runWithSessionWriterLock(scope.sessionKey, async () => {
+      await this.#clearManagedNamespaceUnlocked(scope);
+    });
+  }
+
+  async #clearManagedNamespaceUnlocked(
+    scope: AsyncStorageNamespaceScope,
+  ): Promise<void> {
     const managedCapabilities = getManagedDriverCapabilities(this.driver);
     if (managedCapabilities?.clearManagedNamespace !== undefined) {
       await managedCapabilities.clearManagedNamespace(scope);
@@ -1750,7 +1801,6 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     const currentIndexState = await this.#readNamespaceIndexStateUsingDriver(
       this.driver,
       scope,
-      { mode: 'fresh' },
     );
     const indexEntries =
       currentIndexState.valid && currentIndexState.entries !== null
@@ -1914,37 +1964,37 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     const uniqueKeys = [...new Set(keys)];
     if (uniqueKeys.length === 0) return;
 
-    this.#invalidateCachedNamespace(scope);
-    await this.#driverRemoveManyFrom(
-      driver,
-      scope,
-      uniqueKeys.map((key) => getPayloadRecordKey(key)),
-    );
-
-    const indexState = await this.#readNamespaceIndexStateUsingDriver(
-      driver,
-      scope,
-      { mode: 'fresh' },
-    );
-    if (!indexState.valid || indexState.entries === null) return;
-
-    let changed = false;
-    for (const key of uniqueKeys) {
-      changed = indexState.entries.delete(key) || changed;
-    }
-    if (changed) {
-      await this.#persistNamespaceIndexUsingDriver(
+    await this.#runWithSessionWriterLock(scope.sessionKey, async () => {
+      const indexState = await this.#readNamespaceIndexStateUsingDriver(
         driver,
         scope,
-        {
-          entries: indexState.entries,
-          staticPolicy: normalizeStaticPolicy(indexState.staticPolicy),
-        },
-        false,
       );
-    }
 
-    this.#broadcastNamespaceInvalidation(scope, 'remove');
+      await this.#driverRemoveManyFrom(
+        driver,
+        scope,
+        uniqueKeys.map((key) => getPayloadRecordKey(key)),
+      );
+
+      for (const key of uniqueKeys) {
+        this.#invalidateCachedPayloadValue(scope, key);
+      }
+
+      if (indexState.valid && indexState.entries !== null) {
+        let changed = false;
+        for (const key of uniqueKeys) {
+          changed = indexState.entries.delete(key) || changed;
+        }
+        if (changed) {
+          await this.#persistNamespaceIndexUsingDriver(driver, scope, {
+            entries: indexState.entries,
+            staticPolicy: normalizeStaticPolicy(indexState.staticPolicy),
+          });
+        }
+      }
+
+      this.#broadcastNamespaceInvalidation(scope, 'remove');
+    });
   }
 
   async #driverSetManyFrom(
@@ -2002,11 +2052,10 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
     driver: AsyncStorageDriver,
     scope: AsyncStorageNamespaceScope,
     keys: string[],
-    mode: AsyncStorageManagedReadMode = 'cached',
   ): Promise<unknown[]> {
     if (keys.length === 0) return [];
 
-    const shouldUseCache = driver === this.driver && mode === 'cached';
+    const shouldUseCache = driver === this.driver;
     if (!shouldUseCache) {
       return driverGetManyFrom(
         driver,
@@ -2269,9 +2318,43 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
 
   async #performStartupCleanup(): Promise<void> {
     await this.flushAllPendingNamespaceCommits();
-    const scopesToInvalidate = await this.#withCleanupDriver((driver) =>
-      this.#performStartupCleanupWithDriver(driver),
-    );
+    const scopesToInvalidate = await this.#withCleanupDriver(async (driver) => {
+      const discoveredScopes = await this.#listDiscoveredCleanupScopes(driver);
+      const discoveredScopesBySession = new Map<
+        string,
+        AsyncStorageDiscoveredScope[]
+      >();
+
+      for (const discoveredScope of discoveredScopes) {
+        const existing = discoveredScopesBySession.get(
+          discoveredScope.scope.sessionKey,
+        );
+        if (existing !== undefined) {
+          existing.push(discoveredScope);
+        } else {
+          discoveredScopesBySession.set(discoveredScope.scope.sessionKey, [
+            discoveredScope,
+          ]);
+        }
+      }
+
+      const invalidatedScopesBySession = await Promise.all(
+        [...discoveredScopesBySession.entries()].map(
+          async ([sessionKey, sessionDiscoveredScopes]) =>
+            this.#runWithSessionWriterLock(sessionKey, async () => {
+              await this.#flushPendingNamespaceCommitsForSessionUnlocked(
+                sessionKey,
+              );
+              return this.#performStartupCleanupWithDriver(driver, {
+                discoveredScopes: sessionDiscoveredScopes,
+                sessionKey,
+              });
+            }),
+        ),
+      );
+
+      return invalidatedScopesBySession.flat();
+    });
     for (const scope of scopesToInvalidate) {
       this.#invalidateCachedNamespace(scope);
       this.#broadcastNamespaceInvalidation(scope, 'startup-cleanup');
@@ -2280,13 +2363,19 @@ class ManagedAsyncStorageAdapter implements AsyncStorageAdapter {
 
   async #performStartupCleanupWithDriver(
     driver: AsyncStorageDriver,
+    args: {
+      discoveredScopes?: AsyncStorageDiscoveredScope[];
+      sessionKey?: string;
+    } = {},
   ): Promise<AsyncStorageNamespaceScope[]> {
     // WORKAROUND: Startup cleanup only runs through the cleanup-capable driver path, but this shared helper keeps the broader AsyncStorageDriver parameter.
     const cleanupActionDriver = __LEGIT_CAST__<
       AsyncStorageStartupCleanupActionCapableDriver,
       AsyncStorageDriver
     >(driver);
-    const discoveredScopes = await this.#listDiscoveredCleanupScopes(driver);
+    const discoveredScopes =
+      args.discoveredScopes ??
+      (await this.#listDiscoveredCleanupScopes(driver, args.sessionKey));
     const now = Date.now();
     const uniqueSessionKeys = [
       ...new Set(discoveredScopes.map(({ scope }) => scope.sessionKey)),

--- a/tests/persistent-storage/async-storage-efficiency/collection.test.ts
+++ b/tests/persistent-storage/async-storage-efficiency/collection.test.ts
@@ -17,10 +17,10 @@ import {
   createCollectionEnv,
   createDocumentEnv,
   flushInvalidationPersistence,
-  markEntryOfflineProtected,
   setProtectedKeysSnapshot,
   settleStartupBackgroundScan,
   setupAsyncStorageEfficiencyTestSuite,
+  syncEntriesOfflineProtectedFromSiblingTab,
   waitForScheduledCleanup,
 } from './shared';
 
@@ -401,17 +401,15 @@ describe('async storage efficiency: collection', () => {
       1.003s | 📖 #1 tsdf/sess1/col-max-items-metadata/ci._i.r.json
              |    └ (namespace index) | 0.17 kb
              ·
-      1.046s | 📖 #1 tsdf/sess1/col-max-items-metadata/ci._i.r.json
-             |    └ (namespace index) | 0.17 kb
-      1.049s | 🗑️ #2 ✅ tsdf/sess1/col-max-items-metadata/ci.h~1374750182.p.json
+      1.046s | 🗑️ #2 ✅ tsdf/sess1/col-max-items-metadata/ci.h~1374750182.p.json
              |    └ (entry data, <"b>)
       .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/col-max-items-metadata/ci.h~2103001283.p.json
              |    └ (entry data)
-      1.052s | ✍️ #3 tsdf/sess1/col-max-items-metadata/ci.h~2103001283.p.json
+      1.049s | ✍️ #3 tsdf/sess1/col-max-items-metadata/ci.h~2103001283.p.json
              |    └ (entry data) | 0.00 kb -> 0.07 kb
-      1.056s | ✍️ #1 tsdf/sess1/col-max-items-metadata/ci._i.r.json
+      1.053s | ✍️ #1 tsdf/sess1/col-max-items-metadata/ci._i.r.json
              |    └ (namespace index) | 0.17 kb -> 0.17 kb
-      1.058s | end
+      1.055s | end
       "
     `);
 
@@ -473,19 +471,17 @@ describe('async storage efficiency: collection', () => {
       1.003s | 📖 #1 tsdf/sess1/col-expired-during-max-items/ci._i.r.json
              |    └ (namespace index) | 0.21 kb
              ·
-      1.046s | 📖 #1 tsdf/sess1/col-expired-during-max-items/ci._i.r.json
-             |    └ (namespace index) | 0.21 kb
-      1.049s | 🗑️ #2 ✅ tsdf/sess1/col-expired-during-max-items/ci.h~3986551515.p.json
+      1.046s | 🗑️ #2 ✅ tsdf/sess1/col-expired-during-max-items/ci.h~3986551515.p.json
              |    └ (entry data, <"a>)
       .      | 🗑️ #3 ✅ tsdf/sess1/col-expired-during-max-items/ci.h~1374750182.p.json
              |    └ (entry data, <"b>)
       .      | 👁️ #4 file-open-or-create 🆕 tsdf/sess1/col-expired-during-max-items/ci.h~2103001283.p.json
              |    └ (entry data)
-      1.052s | ✍️ #4 tsdf/sess1/col-expired-during-max-items/ci.h~2103001283.p.json
+      1.049s | ✍️ #4 tsdf/sess1/col-expired-during-max-items/ci.h~2103001283.p.json
              |    └ (entry data) | 0.00 kb -> 0.07 kb
-      1.056s | ✍️ #1 tsdf/sess1/col-expired-during-max-items/ci._i.r.json
+      1.053s | ✍️ #1 tsdf/sess1/col-expired-during-max-items/ci._i.r.json
              |    └ (namespace index) | 0.21 kb -> 0.17 kb
-      1.058s | end
+      1.055s | end
       "
     `);
   });
@@ -536,28 +532,24 @@ describe('async storage efficiency: collection', () => {
       1.003s | 📖 #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
              |    └ (namespace index) | 0.17 kb
              ·
-      1.046s | 📖 #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
-             |    └ (namespace index) | 0.17 kb
-      1.049s | 🗑️ #2 ✅ tsdf/sess1/col-inline-overflow-cleanup/ci.h~3986551515.p.json
+      1.046s | 🗑️ #2 ✅ tsdf/sess1/col-inline-overflow-cleanup/ci.h~3986551515.p.json
              |    └ (entry data, <"a>)
       .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/col-inline-overflow-cleanup/ci.h~3994120284.p.json
              |    └ (entry data)
-      1.052s | ✍️ #3 tsdf/sess1/col-inline-overflow-cleanup/ci.h~3994120284.p.json
+      1.049s | ✍️ #3 tsdf/sess1/col-inline-overflow-cleanup/ci.h~3994120284.p.json
              |    └ (entry data) | 0.00 kb -> 0.07 kb
-      1.056s | ✍️ #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
+      1.053s | ✍️ #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
              |    └ (namespace index) | 0.17 kb -> 0.17 kb
              ·
-      2.14s  | 📖 #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
-             |    └ (namespace index) | 0.17 kb
-      2.143s | 🗑️ #4 ✅ tsdf/sess1/col-inline-overflow-cleanup/ci.h~1374750182.p.json
+      2.14s  | 🗑️ #4 ✅ tsdf/sess1/col-inline-overflow-cleanup/ci.h~1374750182.p.json
              |    └ (entry data)
       .      | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/col-inline-overflow-cleanup/ci.h~2103001283.p.json
              |    └ (entry data, <"d>)
-      2.146s | ✍️ #5 tsdf/sess1/col-inline-overflow-cleanup/ci.h~2103001283.p.json
+      2.143s | ✍️ #5 tsdf/sess1/col-inline-overflow-cleanup/ci.h~2103001283.p.json
              |    └ (entry data, <"d>) | 0.00 kb -> 0.07 kb
-      2.15s  | ✍️ #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
+      2.147s | ✍️ #1 tsdf/sess1/col-inline-overflow-cleanup/ci._i.r.json
              |    └ (namespace index) | 0.17 kb -> 0.17 kb
-      2.152s | end
+      2.149s | end
       "
     `);
   });
@@ -697,11 +689,9 @@ describe('async storage efficiency: collection', () => {
     expect(mutationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.04s  | 📖 #1 tsdf/sess1/col-mutation-flow/ci._i.r.json
-             |    └ (namespace index) | 0.08 kb
-      1.045s | ✍️ #2 tsdf/sess1/col-mutation-flow/ci.h~3574006234.p.json
+      1.042s | ✍️ #1 tsdf/sess1/col-mutation-flow/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | 0.08 kb -> 0.08 kb
-      1.047s | end
+      1.044s | end
       "
     `);
   });
@@ -766,18 +756,16 @@ describe('async storage efficiency: collection', () => {
       0      | 🗑️ #1 ✅ tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
              |    └ (entry data, <"1>)
              ·
-      1.041s | 📖 #2 tsdf/sess1/col-mutation-retry-after-delete/ci._i.r.json
-             |    └ (namespace index) | 0.08 kb
-      1.044s | ✍️ #1 ❌ retryable-createWritable tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
+      1.041s | ✍️ #1 ❌ retryable-createWritable tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | NotFoundError
-      1.045s | 📁 dir-open-or-create ✅ tsdf/sess1 (session directory)
-      1.046s | 📁 dir-open-or-create ✅ tsdf/sess1/col-mutation-retry-after-delete
+      1.042s | 📁 dir-open-or-create ✅ tsdf/sess1 (session directory)
+      1.043s | 📁 dir-open-or-create ✅ tsdf/sess1/col-mutation-retry-after-delete
              |    └ (store directory)
-      1.047s | 👁️ #1 file-open-or-create 🆕 tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
+      1.044s | 👁️ #1 file-open-or-create 🆕 tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
              |    └ (entry data, <"1>)
-      1.05s  | ✍️ #1 tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
+      1.047s | ✍️ #1 tsdf/sess1/col-mutation-retry-after-delete/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | 0.00 kb -> 0.10 kb
-      1.052s | end
+      1.049s | end
       "
     `);
   });
@@ -815,7 +803,7 @@ describe('async storage efficiency: collection', () => {
         draft.value.name = 'Edited during write';
       });
     });
-    await advanceTime(1045);
+    await advanceTime(1041);
     const deletePromise = deleteTarget.storeDir.removeEntry(
       deleteTarget.fileName,
     );
@@ -823,7 +811,6 @@ describe('async storage efficiency: collection', () => {
     await deletePromise;
     await flushInvalidationPersistence(0);
     const mutationOperations = mutationCapture.finish().timelineString;
-
     expect(
       getParsedOpfsFileData(
         'tsdf/sess1/col-mutation-retry-during-write/ci.%221.p.json',
@@ -840,20 +827,18 @@ describe('async storage efficiency: collection', () => {
     expect(mutationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.04s  | 📖 #1 tsdf/sess1/col-mutation-retry-during-write/ci._i.r.json
-             |    └ (namespace index) | 0.08 kb
-      1.045s | 🗑️ #2 ✅ tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
+      1.041s | 🗑️ #1 ✅ tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
              |    └ (entry data, <"1>)
-      .      | ✍️ #2 ❌ retryable-close tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
+      1.042s | ✍️ #1 ❌ retryable-close tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | NotFoundError
-      1.047s | 📁 dir-open-or-create ✅ tsdf/sess1 (session directory)
-      1.048s | 📁 dir-open-or-create ✅ tsdf/sess1/col-mutation-retry-during-write
+      1.044s | 📁 dir-open-or-create ✅ tsdf/sess1 (session directory)
+      1.045s | 📁 dir-open-or-create ✅ tsdf/sess1/col-mutation-retry-during-write
              |    └ (store directory)
-      1.049s | 👁️ #2 file-open-or-create 🆕 tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
+      1.046s | 👁️ #1 file-open-or-create 🆕 tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
              |    └ (entry data, <"1>)
-      1.052s | ✍️ #2 tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
+      1.049s | ✍️ #1 tsdf/sess1/col-mutation-retry-during-write/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | 0.00 kb -> 0.10 kb
-      1.054s | end
+      1.051s | end
       "
     `);
   });
@@ -888,13 +873,11 @@ describe('async storage efficiency: collection', () => {
     expect(deleteOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.04s  | 📖 #1 tsdf/sess1/col-delete-flow/ci._i.r.json
-             |    └ (namespace index) | 0.15 kb
-      1.043s | 🗑️ #2 ✅ tsdf/sess1/col-delete-flow/ci.h~3574006234.p.json
+      1.04s  | 🗑️ #1 ✅ tsdf/sess1/col-delete-flow/ci.h~3574006234.p.json
              |    └ (entry data, <"1>)
-      1.046s | ✍️ #1 tsdf/sess1/col-delete-flow/ci._i.r.json
+      1.043s | ✍️ #2 tsdf/sess1/col-delete-flow/ci._i.r.json
              |    └ (namespace index) | 0.15 kb -> 0.08 kb
-      1.048s | end
+      1.045s | end
       "
     `);
   });
@@ -944,11 +927,9 @@ describe('async storage efficiency: collection', () => {
     expect(invalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/col-invalidation-flow/ci._i.r.json
-             |    └ (namespace index) | 0.08 kb
-      1.855s | ✍️ #2 tsdf/sess1/col-invalidation-flow/ci.h~3574006234.p.json
+      1.852s | ✍️ #1 tsdf/sess1/col-invalidation-flow/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | 0.08 kb -> 0.08 kb
-      1.857s | end
+      1.854s | end
       "
     `);
   });
@@ -981,7 +962,7 @@ describe('async storage efficiency: collection', () => {
     await flushInvalidationPersistence(0);
 
     // Simulate another tab marking this cached item as offline-protected.
-    markEntryOfflineProtected(mockAdapter, storageKey);
+    await syncEntriesOfflineProtectedFromSiblingTab(sessionKey, [storageKey]);
 
     // A normal invalidation save should keep the externally-added offline marker.
     act(() => {
@@ -1071,11 +1052,9 @@ describe('async storage efficiency: collection', () => {
     expect(secondInvalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/col-coalesced-invalidations/ci._i.r.json
-             |    └ (namespace index) | 0.08 kb
-      1.855s | ✍️ #2 tsdf/sess1/col-coalesced-invalidations/ci.h~3574006234.p.json
+      1.852s | ✍️ #1 tsdf/sess1/col-coalesced-invalidations/ci.h~3574006234.p.json
              |    └ (entry data, <"1>) | 0.08 kb -> 0.08 kb
-      1.857s | end
+      1.854s | end
       "
     `);
   });
@@ -1180,11 +1159,9 @@ describe('async storage efficiency: collection', () => {
       7ms  | 📖 #2 tsdf/sess1/col-remount-stale-touch/ci.h~3574006234.p.json
            |    └ (entry data, <"1>) | 0.08 kb
            ·
-      50ms | 📖 #1 tsdf/sess1/col-remount-stale-touch/ci._i.r.json
-           |    └ (namespace index) | 0.08 kb
-      55ms | ✍️ #1 tsdf/sess1/col-remount-stale-touch/ci._i.r.json
+      52ms | ✍️ #1 tsdf/sess1/col-remount-stale-touch/ci._i.r.json
            |    └ (namespace index) | 0.08 kb -> 0.08 kb
-      57ms | end
+      54ms | end
       "
     `);
     expect(remountOperations).toMatchInlineSnapshot(`"empty"`);

--- a/tests/persistent-storage/async-storage-efficiency/document.test.ts
+++ b/tests/persistent-storage/async-storage-efficiency/document.test.ts
@@ -16,9 +16,9 @@ import {
   captureHookRemount,
   createDocumentEnv,
   flushInvalidationPersistence,
-  markEntryOfflineProtected,
   settleStartupBackgroundScan,
   setupAsyncStorageEfficiencyTestSuite,
+  syncEntriesOfflineProtectedFromSiblingTab,
 } from './shared';
 
 setupAsyncStorageEfficiencyTestSuite();
@@ -147,11 +147,9 @@ describe('async storage efficiency: document', () => {
       7ms  | 📖 #2 tsdf/sess1/doc-remount-stale-touch/d.e.p.json
            |    └ (entry data) | 0.09 kb
            ·
-      50ms | 📖 #1 tsdf/sess1/doc-remount-stale-touch/d._i.r.json
-           |    └ (namespace index) | 0.06 kb
-      55ms | ✍️ #1 tsdf/sess1/doc-remount-stale-touch/d._i.r.json
+      52ms | ✍️ #1 tsdf/sess1/doc-remount-stale-touch/d._i.r.json
            |    └ (namespace index) | 0.06 kb -> 0.06 kb
-      57ms | end
+      54ms | end
       "
     `);
     expect(remountOperations).toMatchInlineSnapshot(`"empty"`);
@@ -270,7 +268,7 @@ describe('async storage efficiency: document', () => {
     await resolveAfterAllTimers(preloadPromise);
 
     // Simulate another tab marking the document as offline-protected before the touch runs.
-    markEntryOfflineProtected(mockAdapter, storageKey);
+    await syncEntriesOfflineProtectedFromSiblingTab(sessionKey, [storageKey]);
     expect(getParsedOpfsFileData(metadataPath)).toMatchInlineSnapshot(`
       e:
         - { a: 1735664400000, o: '✅' }
@@ -291,16 +289,14 @@ describe('async storage efficiency: document', () => {
     expect(operationsBreakdown).toMatchInlineSnapshot(`
       "
       time   |
-      40ms   | 📖 #1 tsdf/sess1/doc-startup-touch-offline-marker/d._i.r.json
+      28ms   | 📖 #1 tsdf/sess1/doc-startup-touch-offline-marker/d._i.r.json
              |    └ (namespace index) | 0.08 kb
-      45ms   | ✍️ #1 tsdf/sess1/doc-startup-touch-offline-marker/d._i.r.json
+      33ms   | ✍️ #1 tsdf/sess1/doc-startup-touch-offline-marker/d._i.r.json
              |    └ (namespace index) | 0.08 kb -> 0.08 kb
              ·
-      1.04s  | 📖 #1 tsdf/sess1/doc-startup-touch-offline-marker/d._i.r.json
-             |    └ (namespace index) | 0.08 kb
-      1.045s | ✍️ #2 tsdf/sess1/doc-startup-touch-offline-marker/d.e.p.json
+      1.03s  | ✍️ #2 tsdf/sess1/doc-startup-touch-offline-marker/d.e.p.json
              |    └ (entry data) | 0.09 kb -> 0.09 kb ⚠️ UNCHANGED
-      1.047s | end
+      1.032s | end
       "
     `);
   });
@@ -344,11 +340,9 @@ describe('async storage efficiency: document', () => {
     expect(mutationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.04s  | 📖 #1 tsdf/sess1/doc-mutation-flow/d._i.r.json
-             |    └ (namespace index) | 0.06 kb
-      1.045s | ✍️ #2 tsdf/sess1/doc-mutation-flow/d.e.p.json
+      1.042s | ✍️ #1 tsdf/sess1/doc-mutation-flow/d.e.p.json
              |    └ (entry data) | 0.09 kb -> 0.09 kb
-      1.047s | end
+      1.044s | end
       "
     `);
   });
@@ -394,11 +388,9 @@ describe('async storage efficiency: document', () => {
     expect(invalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/doc-invalidation-flow/d._i.r.json
-             |    └ (namespace index) | 0.06 kb
-      1.855s | ✍️ #2 tsdf/sess1/doc-invalidation-flow/d.e.p.json
+      1.852s | ✍️ #1 tsdf/sess1/doc-invalidation-flow/d.e.p.json
              |    └ (entry data) | 0.09 kb -> 0.09 kb
-      1.857s | end
+      1.854s | end
       "
     `);
   });
@@ -464,11 +456,9 @@ describe('async storage efficiency: document', () => {
     expect(secondInvalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/doc-coalesced-invalidations/d._i.r.json
-             |    └ (namespace index) | 0.06 kb
-      1.855s | ✍️ #2 tsdf/sess1/doc-coalesced-invalidations/d.e.p.json
+      1.852s | ✍️ #1 tsdf/sess1/doc-coalesced-invalidations/d.e.p.json
              |    └ (entry data) | 0.09 kb -> 0.09 kb
-      1.857s | end
+      1.854s | end
       "
     `);
   });
@@ -497,7 +487,7 @@ describe('async storage efficiency: document', () => {
     await flushInvalidationPersistence(0);
 
     // Simulate another tab marking this document as offline-protected.
-    markEntryOfflineProtected(mockAdapter, storageKey);
+    await syncEntriesOfflineProtectedFromSiblingTab(sessionKey, [storageKey]);
 
     // A normal invalidation save should keep the externally-added offline marker.
     act(() => {

--- a/tests/persistent-storage/async-storage-efficiency/list-query.test.ts
+++ b/tests/persistent-storage/async-storage-efficiency/list-query.test.ts
@@ -18,11 +18,11 @@ import {
   createDocumentEnv,
   createListQueryEnv,
   flushInvalidationPersistence,
-  markEntryOfflineProtected,
   rawItemPayload,
   settleStartupBackgroundScan,
   setupAsyncStorageEfficiencyTestSuite,
   storeItemKey,
+  syncEntriesOfflineProtectedFromSiblingTab,
   waitForScheduledCleanup,
 } from './shared';
 
@@ -387,27 +387,25 @@ describe('async storage efficiency: list-query', () => {
       1.813s | 📖 #1 tsdf/sess1/lq-query-metadata/lq._i.r.json
              |    └ (queries index) | 0.28 kb
              ·
-      1.856s | 👁️ #2 file-open ❌ tsdf/sess1/lq-query-metadata/li._i.r.json
-             |    └ (items index)
-      .      | 📖 #1 tsdf/sess1/lq-query-metadata/lq._i.r.json
-             |    └ (queries index) | 0.28 kb
-      1.857s | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-query-metadata/li.h~4006559409.p.json
-             |    └ (item data)
-      1.859s | 🗑️ #4 ✅ tsdf/sess1/lq-query-metadata/lq.h~4141397404.p.json
+      1.856s | 🗑️ #2 ✅ tsdf/sess1/lq-query-metadata/lq.h~4141397404.p.json
              |    └ (query data, <{tableId:"first"}>)
-      .      | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/lq-query-metadata/lq.h~3601729766.p.json
+      .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-query-metadata/lq.h~3601729766.p.json
              |    └ (query data)
-      1.86s  | ✍️ #3 tsdf/sess1/lq-query-metadata/li.h~4006559409.p.json
-             |    └ (item data) | 0.00 kb -> 0.04 kb
-      1.862s | 👁️ #2 file-open-or-create 🆕 tsdf/sess1/lq-query-metadata/li._i.r.json
+      .      | 👁️ #4 file-open ❌ tsdf/sess1/lq-query-metadata/li._i.r.json
              |    └ (items index)
-      .      | ✍️ #5 tsdf/sess1/lq-query-metadata/lq.h~3601729766.p.json
+      1.857s | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/lq-query-metadata/li.h~4006559409.p.json
+             |    └ (item data)
+      1.859s | ✍️ #3 tsdf/sess1/lq-query-metadata/lq.h~3601729766.p.json
              |    └ (query data) | 0.00 kb -> 0.03 kb
-      1.865s | ✍️ #2 tsdf/sess1/lq-query-metadata/li._i.r.json
-             |    └ (items index) | 0.00 kb -> 0.11 kb
-      1.866s | ✍️ #1 tsdf/sess1/lq-query-metadata/lq._i.r.json
+      1.86s  | ✍️ #5 tsdf/sess1/lq-query-metadata/li.h~4006559409.p.json
+             |    └ (item data) | 0.00 kb -> 0.04 kb
+      1.862s | 👁️ #4 file-open-or-create 🆕 tsdf/sess1/lq-query-metadata/li._i.r.json
+             |    └ (items index)
+      1.863s | ✍️ #1 tsdf/sess1/lq-query-metadata/lq._i.r.json
              |    └ (queries index) | 0.28 kb -> 0.30 kb
-      1.868s | end
+      1.865s | ✍️ #4 tsdf/sess1/lq-query-metadata/li._i.r.json
+             |    └ (items index) | 0.00 kb -> 0.11 kb
+      1.867s | end
       "
     `);
     expect(getParsedOpfsFileData('tsdf/sess1/lq-query-metadata/li._i.r.json'))
@@ -430,7 +428,7 @@ describe('async storage efficiency: list-query', () => {
             a: 1735689600100
             p: { tableId: 'second' }
           {tableId:"third"}:
-            a: 1735689604959
+            a: 1735689604956
             p: { tableId: 'third' }
 
         s: { m: 2 }
@@ -497,48 +495,42 @@ describe('async storage efficiency: list-query', () => {
       1.813s | 📖 #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
              |    └ (queries index) | 0.28 kb
              ·
-      1.856s | 👁️ #2 file-open ❌ tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
-             |    └ (items index)
-      .      | 📖 #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
-             |    └ (queries index) | 0.28 kb
-      1.857s | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
-             |    └ (item data)
-      1.859s | 🗑️ #4 ✅ tsdf/sess1/lq-coalesced-query-maintenance/lq.h~4141397404.p.json
+      1.856s | 🗑️ #2 ✅ tsdf/sess1/lq-coalesced-query-maintenance/lq.h~4141397404.p.json
              |    └ (query data, <{tableId:"first"}>)
-      .      | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3601729766.p.json
+      .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3601729766.p.json
              |    └ (query data)
-      1.86s  | ✍️ #3 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
-             |    └ (item data) | 0.00 kb -> 0.04 kb
-      1.862s | 👁️ #2 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
+      .      | 👁️ #4 file-open ❌ tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
              |    └ (items index)
-      .      | ✍️ #5 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3601729766.p.json
+      1.857s | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
+             |    └ (item data)
+      1.859s | ✍️ #3 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3601729766.p.json
              |    └ (query data) | 0.00 kb -> 0.03 kb
-      1.865s | ✍️ #2 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
-             |    └ (items index) | 0.00 kb -> 0.11 kb
-      1.866s | ✍️ #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
+      1.86s  | ✍️ #5 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
+             |    └ (item data) | 0.00 kb -> 0.04 kb
+      1.862s | 👁️ #4 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
+             |    └ (items index)
+      1.863s | ✍️ #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
              |    └ (queries index) | 0.28 kb -> 0.30 kb
+      1.865s | ✍️ #4 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
+             |    └ (items index) | 0.00 kb -> 0.11 kb
              ·
-      3.66s  | 📖 #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
-             |    └ (queries index) | 0.30 kb
-      .      | 📖 #2 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      3.663s | 🗑️ #6 ✅ tsdf/sess1/lq-coalesced-query-maintenance/lq.h~2817177027.p.json
+      3.66s  | 🗑️ #6 ✅ tsdf/sess1/lq-coalesced-query-maintenance/lq.h~2817177027.p.json
              |    └ (query data)
       .      | 👁️ #7 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3370518832.p.json
              |    └ (query data, <{tableId:"fourth"}>)
       .      | 👁️ #8 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/li.h~1322690187.p.json
              |    └ (item data, <"fourth||2>)
-      3.665s | ✍️ #3 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
+      3.662s | ✍️ #5 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
              |    └ (item data, <"third||1>) | 0.04 kb -> 0.04 kb ⚠️ UNCHANGED
-      3.666s | ✍️ #7 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3370518832.p.json
+      3.663s | ✍️ #7 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3370518832.p.json
              |    └ (query data, <{tableId:"fourth"}>) | 0.00 kb -> 0.03 kb
       .      | ✍️ #8 tsdf/sess1/lq-coalesced-query-maintenance/li.h~1322690187.p.json
              |    └ (item data, <"fourth||2>) | 0.00 kb -> 0.05 kb
-      3.67s  | ✍️ #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
+      3.667s | ✍️ #1 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
              |    └ (queries index) | 0.30 kb -> 0.30 kb
-      .      | ✍️ #2 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
+      .      | ✍️ #4 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
              |    └ (items index) | 0.11 kb -> 0.27 kb
-      3.672s | end
+      3.669s | end
       "
     `);
   });
@@ -662,17 +654,13 @@ describe('async storage efficiency: list-query', () => {
     expect(invalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/lq-query-becomes-empty/lq._i.r.json
-             |    └ (queries index) | 0.14 kb
-      .      | 📖 #2 tsdf/sess1/lq-query-becomes-empty/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      1.855s | ✍️ #3 tsdf/sess1/lq-query-becomes-empty/lq.h~2902406637.p.json
+      1.852s | ✍️ #1 tsdf/sess1/lq-query-becomes-empty/lq.h~2902406637.p.json
              |    └ (query data, <{tableId:"users"}>) | 0.03 kb -> 0.00 kb
-      .      | ✍️ #4 tsdf/sess1/lq-query-becomes-empty/li.h~228010772.p.json
+      .      | ✍️ #2 tsdf/sess1/lq-query-becomes-empty/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.06 kb ⚠️ UNCHANGED
-      1.859s | ✍️ #2 tsdf/sess1/lq-query-becomes-empty/li._i.r.json
+      1.856s | ✍️ #3 tsdf/sess1/lq-query-becomes-empty/li._i.r.json
              |    └ (items index) | 0.11 kb -> 0.17 kb
-      1.861s | end
+      1.858s | end
       "
     `);
     expect(
@@ -756,17 +744,15 @@ describe('async storage efficiency: list-query', () => {
       1.003s | 📖 #1 tsdf/sess1/lq-item-metadata/li._i.r.json
              |    └ (items index) | 0.20 kb
              ·
-      1.046s | 📖 #1 tsdf/sess1/lq-item-metadata/li._i.r.json
-             |    └ (items index) | 0.20 kb
-      1.049s | 🗑️ #2 ✅ tsdf/sess1/lq-item-metadata/li.h~228010772.p.json
+      1.046s | 🗑️ #2 ✅ tsdf/sess1/lq-item-metadata/li.h~228010772.p.json
              |    └ (item data, <"users||1>)
       .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-item-metadata/li.h~3224064498.p.json
              |    └ (item data)
-      1.052s | ✍️ #3 tsdf/sess1/lq-item-metadata/li.h~3224064498.p.json
+      1.049s | ✍️ #3 tsdf/sess1/lq-item-metadata/li.h~3224064498.p.json
              |    └ (item data) | 0.00 kb -> 0.04 kb
-      1.056s | ✍️ #1 tsdf/sess1/lq-item-metadata/li._i.r.json
+      1.053s | ✍️ #1 tsdf/sess1/lq-item-metadata/li._i.r.json
              |    └ (items index) | 0.20 kb -> 0.22 kb
-      1.058s | end
+      1.055s | end
       "
     `);
   });
@@ -852,8 +838,8 @@ describe('async storage efficiency: list-query', () => {
       ),
     ).toMatchInlineSnapshot(`
       e:
-        "admins||4: { a: 1735689610115, p: 'admins||4' }
-        "standalone||1: { a: 1735689610115, p: 'standalone||1' }
+        "admins||4: { a: 1735689610111, p: 'admins||4' }
+        "standalone||1: { a: 1735689610111, p: 'standalone||1' }
 
       s: { m: 2 }
     `);
@@ -864,7 +850,7 @@ describe('async storage efficiency: list-query', () => {
     ).toMatchInlineSnapshot(`
       e:
         {tableId:"admins"}:
-          a: 1735689610115
+          a: 1735689610111
           p: { tableId: 'admins' }
         {tableId:"users"}:
           a: 1735689607151
@@ -873,31 +859,27 @@ describe('async storage efficiency: list-query', () => {
     expect(operationsBreakdown).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/lq-expired-during-max-items/lq._i.r.json
-             |    └ (queries index) | 0.14 kb
-      .      | 📖 #2 tsdf/sess1/lq-expired-during-max-items/li._i.r.json
-             |    └ (items index) | 0.31 kb
-      1.853s | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/lq.h~2316387135.p.json
+      1.85s  | 👁️ #1 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/lq.h~2316387135.p.json
              |    └ (query data)
-      .      | 🗑️ #4 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~3224064498.p.json
+      .      | 🗑️ #2 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~3224064498.p.json
              |    └ (item data, <"users||3>)
-      .      | 🗑️ #5 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~3111345837.p.json
+      .      | 🗑️ #3 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~3111345837.p.json
              |    └ (item data, <"standalone||2>)
-      .      | 👁️ #6 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~2775221404.p.json
+      .      | 👁️ #4 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~2775221404.p.json
              |    └ (item data)
-      .      | 👁️ #7 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
+      .      | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
              |    └ (item data)
-      1.856s | ✍️ #3 tsdf/sess1/lq-expired-during-max-items/lq.h~2316387135.p.json
+      1.853s | ✍️ #1 tsdf/sess1/lq-expired-during-max-items/lq.h~2316387135.p.json
              |    └ (query data) | 0.00 kb -> 0.03 kb
-      .      | ✍️ #6 tsdf/sess1/lq-expired-during-max-items/li.h~2775221404.p.json
+      .      | ✍️ #4 tsdf/sess1/lq-expired-during-max-items/li.h~2775221404.p.json
              |    └ (item data) | 0.00 kb -> 0.06 kb
-      .      | ✍️ #7 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
+      .      | ✍️ #5 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
              |    └ (item data) | 0.00 kb -> 0.08 kb
-      1.86s  | ✍️ #1 tsdf/sess1/lq-expired-during-max-items/lq._i.r.json
+      1.857s | ✍️ #6 tsdf/sess1/lq-expired-during-max-items/lq._i.r.json
              |    └ (queries index) | 0.14 kb -> 0.28 kb
-      .      | ✍️ #2 tsdf/sess1/lq-expired-during-max-items/li._i.r.json
+      .      | ✍️ #7 tsdf/sess1/lq-expired-during-max-items/li._i.r.json
              |    └ (items index) | 0.31 kb -> 0.25 kb
-      1.862s | end
+      1.859s | end
       "
     `);
 
@@ -1143,20 +1125,17 @@ describe('async storage efficiency: list-query', () => {
     expect(deleteOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.04s  | 📖 #1 tsdf/sess1/lq-delete-flow/lq._i.r.json
-             |    └ (queries index) | 0.48 kb
-      .      | 📖 #2 tsdf/sess1/lq-delete-flow/li._i.r.json (items index) | 0.20 kb
-      1.043s | 🗑️ #3 ✅ tsdf/sess1/lq-delete-flow/li.h~228010772.p.json
+      1.04s  | 🗑️ #1 ✅ tsdf/sess1/lq-delete-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>)
-      1.045s | ✍️ #4 tsdf/sess1/lq-delete-flow/lq.h~2902406637.p.json
+      1.042s | ✍️ #2 tsdf/sess1/lq-delete-flow/lq.h~2902406637.p.json
              |    └ (query data, <{tableId:"users"}>) | 0.05 kb -> 0.03 kb
-      .      | ✍️ #5 tsdf/sess1/lq-delete-flow/lq.h~1805955701.p.json
+      .      | ✍️ #3 tsdf/sess1/lq-delete-flow/lq.h~1805955701.p.json
              |    └ (query data, <{filters:[{field:"name",op:"eq",value:"Alice"}],tableId:"users"}>) | 0.03 kb -> 0.00 kb
-      .      | ✍️ #6 tsdf/sess1/lq-delete-flow/li.h~1937155452.p.json
+      .      | ✍️ #4 tsdf/sess1/lq-delete-flow/li.h~1937155452.p.json
              |    └ (item data, <"users||2>) | 0.04 kb -> 0.04 kb ⚠️ UNCHANGED
-      1.049s | ✍️ #2 tsdf/sess1/lq-delete-flow/li._i.r.json
+      1.046s | ✍️ #5 tsdf/sess1/lq-delete-flow/li._i.r.json
              |    └ (items index) | 0.20 kb -> 0.17 kb
-      1.051s | end
+      1.048s | end
       "
     `);
   });
@@ -1213,14 +1192,12 @@ describe('async storage efficiency: list-query', () => {
       1.003s | 📖 #1 tsdf/sess1/lq-cold-delete-flow/li._i.r.json
              |    └ (items index) | 0.11 kb
              ·
-      1.046s | 📖 #1 tsdf/sess1/lq-cold-delete-flow/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      1.049s | 🗑️ #2 ✅ tsdf/sess1/lq-cold-delete-flow/li.h~228010772.p.json
+      1.046s | 🗑️ #2 ✅ tsdf/sess1/lq-cold-delete-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>)
-      1.05s  | 🗑️ #1 ✅ tsdf/sess1/lq-cold-delete-flow/li._i.r.json (items index)
-      1.051s | 🧹 del-dir ✅ tsdf/sess1/lq-cold-delete-flow (store directory)
-      1.052s | 🧹 del-dir ✅ tsdf/sess1 (session directory)
-      1.053s | end
+      1.047s | 🗑️ #1 ✅ tsdf/sess1/lq-cold-delete-flow/li._i.r.json (items index)
+      1.048s | 🧹 del-dir ✅ tsdf/sess1/lq-cold-delete-flow (store directory)
+      1.049s | 🧹 del-dir ✅ tsdf/sess1 (session directory)
+      1.05s  | end
       "
     `);
   });
@@ -1520,13 +1497,11 @@ describe('async storage efficiency: list-query', () => {
     expect(invalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/lq-query-invalidation-flow/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      1.855s | ✍️ #2 tsdf/sess1/lq-query-invalidation-flow/li.h~228010772.p.json
+      1.852s | ✍️ #1 tsdf/sess1/lq-query-invalidation-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.05 kb
-      1.859s | ✍️ #1 tsdf/sess1/lq-query-invalidation-flow/li._i.r.json
+      1.856s | ✍️ #2 tsdf/sess1/lq-query-invalidation-flow/li._i.r.json
              |    └ (items index) | 0.11 kb -> 0.17 kb
-      1.861s | end
+      1.858s | end
       "
     `);
   });
@@ -1608,13 +1583,11 @@ describe('async storage efficiency: list-query', () => {
     expect(secondInvalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/lq-coalesced-invalidations/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      1.855s | ✍️ #2 tsdf/sess1/lq-coalesced-invalidations/li.h~228010772.p.json
+      1.852s | ✍️ #1 tsdf/sess1/lq-coalesced-invalidations/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.06 kb
-      1.859s | ✍️ #1 tsdf/sess1/lq-coalesced-invalidations/li._i.r.json
+      1.856s | ✍️ #2 tsdf/sess1/lq-coalesced-invalidations/li._i.r.json
              |    └ (items index) | 0.11 kb -> 0.17 kb
-      1.861s | end
+      1.858s | end
       "
     `);
   });
@@ -1657,8 +1630,10 @@ describe('async storage efficiency: list-query', () => {
     await flushInvalidationPersistence(0);
 
     // Simulate another tab marking the existing item and query entries as offline-protected.
-    markEntryOfflineProtected(mockAdapter, itemStorageKey);
-    markEntryOfflineProtected(mockAdapter, queryStorageKey);
+    await syncEntriesOfflineProtectedFromSiblingTab(sessionKey, [
+      itemStorageKey,
+      queryStorageKey,
+    ]);
 
     // The refetch rewrites both namespaces, and should keep the externally-added markers.
     act(() => {
@@ -1682,7 +1657,7 @@ describe('async storage efficiency: list-query', () => {
           f: ['age', 'email', 'id', 'name']
           o: '✅'
           p: 'users||1'
-        "users||2: { a: 1735689606971, p: 'users||2' }
+        "users||2: { a: 1735689606983, p: 'users||2' }
     `);
     expect(
       getParsedOpfsFileData(
@@ -1879,15 +1854,11 @@ describe('async storage efficiency: list-query', () => {
       15ms | 📖 #4 tsdf/sess1/lq-remount-stale-touch/li.h~228010772.p.json
            |    └ (item data, <"users||1>) | 0.06 kb
            ·
-      50ms | 📖 #1 tsdf/sess1/lq-remount-stale-touch/lq._i.r.json
-           |    └ (queries index) | 0.14 kb
-      55ms | ✍️ #1 tsdf/sess1/lq-remount-stale-touch/lq._i.r.json
+      52ms | ✍️ #1 tsdf/sess1/lq-remount-stale-touch/lq._i.r.json
            |    └ (queries index) | 0.14 kb -> 0.14 kb
-      58ms | 📖 #3 tsdf/sess1/lq-remount-stale-touch/li._i.r.json
-           |    └ (items index) | 0.11 kb
-      63ms | ✍️ #3 tsdf/sess1/lq-remount-stale-touch/li._i.r.json
+      60ms | ✍️ #3 tsdf/sess1/lq-remount-stale-touch/li._i.r.json
            |    └ (items index) | 0.11 kb -> 0.11 kb
-      65ms | end
+      62ms | end
       "
     `);
     expect(remountOperations).toMatchInlineSnapshot(`"empty"`);
@@ -1946,13 +1917,11 @@ describe('async storage efficiency: list-query', () => {
     expect(invalidationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/lq-item-invalidation-flow/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      1.855s | ✍️ #2 tsdf/sess1/lq-item-invalidation-flow/li.h~228010772.p.json
+      1.852s | ✍️ #1 tsdf/sess1/lq-item-invalidation-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.05 kb
-      1.859s | ✍️ #1 tsdf/sess1/lq-item-invalidation-flow/li._i.r.json
+      1.856s | ✍️ #2 tsdf/sess1/lq-item-invalidation-flow/li._i.r.json
              |    └ (items index) | 0.11 kb -> 0.17 kb
-      1.861s | end
+      1.858s | end
       "
     `);
   });
@@ -2211,13 +2180,11 @@ describe('async storage efficiency: list-query', () => {
     expect(mutationOperations).toMatchInlineSnapshot(`
       "
       time   |
-      1.04s  | 📖 #1 tsdf/sess1/lq-mutation-flow/li._i.r.json
-             |    └ (items index) | 0.11 kb
-      1.045s | ✍️ #2 tsdf/sess1/lq-mutation-flow/li.h~228010772.p.json
+      1.042s | ✍️ #1 tsdf/sess1/lq-mutation-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.06 kb
-      1.049s | ✍️ #1 tsdf/sess1/lq-mutation-flow/li._i.r.json
+      1.046s | ✍️ #2 tsdf/sess1/lq-mutation-flow/li._i.r.json
              |    └ (items index) | 0.11 kb -> 0.17 kb
-      1.051s | end
+      1.048s | end
       "
     `);
   });
@@ -2364,13 +2331,11 @@ describe('async storage efficiency: list-query', () => {
     expect(readCapture.finish().timelineString).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 📖 #1 tsdf/sess1/list-query-opfs-eviction-efficiency/li._i.r.json
-             |    └ (items index) | 0.30 kb
-      1.855s | ✍️ #2 tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~2924752681.p.json
+      1.852s | ✍️ #1 tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~2924752681.p.json
              |    └ (item data, <"projects||1>) | 0.05 kb -> 0.05 kb ⚠️ UNCHANGED
-      1.859s | ✍️ #1 tsdf/sess1/list-query-opfs-eviction-efficiency/li._i.r.json
+      1.856s | ✍️ #2 tsdf/sess1/list-query-opfs-eviction-efficiency/li._i.r.json
              |    └ (items index) | 0.30 kb -> 0.36 kb
-      1.861s | end
+      1.858s | end
       "
     `);
     expect(mockAdapter.payloadGetRequests).toMatchInlineSnapshot(`[]`);

--- a/tests/persistent-storage/async-storage-efficiency/shared.ts
+++ b/tests/persistent-storage/async-storage-efficiency/shared.ts
@@ -4,12 +4,16 @@ import { renderHook } from '@testing-library/react';
 import { rc_number, rc_object, rc_string } from 'runcheck';
 import { afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import type { OffsetPaginationConfig } from '../../../src/listQueryStore/types';
-import { serializeProtectedRef } from '../../../src/persistentStorage/asyncStorageAdapter';
+import {
+  createAsyncStorageAdapter,
+  serializeProtectedRef,
+} from '../../../src/persistentStorage/asyncStorageAdapter';
 import { DOCUMENT_PERSISTED_ENTRY_KEY } from '../../../src/persistentStorage/documentEntryKey';
 import {
   clearSessionProtectedKeysSnapshot,
   setSessionProtectedKeysSnapshot,
 } from '../../../src/persistentStorage/offline/sessionProtectionRegistry';
+import { OpfsAsyncStorageDriver } from '../../../src/persistentStorage/opfsAsyncStorageAdapter';
 import { opfsPersistentStorage } from '../../../src/persistentStorage/storageAdapter';
 import type { PersistentStorageSchema } from '../../../src/persistentStorage/types';
 import { createCollectionStoreTestEnv } from '../../mocks/collectionStoreTestEnv';
@@ -24,7 +28,11 @@ import {
 } from '../../mocks/listQueryStoreTestEnv';
 import { resetMockBrowserOpfsForTests } from '../../mocks/mockBrowserOpfs';
 import { TEST_INITIAL_TIME } from '../../mocks/testEnvUtils';
-import { advanceTime, flushAllTimers } from '../../utils/genericTestUtils';
+import {
+  advanceTime,
+  flushAllTimers,
+  resolveAfterAllTimers,
+} from '../../utils/genericTestUtils';
 import { createOpfsPersistentStorageTestStore } from '../../utils/opfsPersistentStorageTestStore';
 import { startOpfsPersistentStorageOperationCapture } from '../../utils/persistentStorageOptimizationTestUtils';
 
@@ -203,30 +211,20 @@ export function createListQueryEnv(options: {
   });
 }
 
-export function updateEntryCustomMetadata(
-  mockAdapter: MockOpfsAdapter,
-  key: string,
-  update: (current: Record<string, unknown>) => Record<string, unknown>,
-): void {
-  const currentMetadata = mockAdapter.readMetadata(key);
-  if (currentMetadata === null) {
-    throw new Error(`Expected metadata for ${key}.`);
-  }
-
-  mockAdapter.setMetadata(key, {
-    ...currentMetadata,
-    customMetadata: update(currentMetadata.customMetadata),
-  });
-}
-
-export function markEntryOfflineProtected(
-  mockAdapter: MockOpfsAdapter,
-  key: string,
-): void {
-  updateEntryCustomMetadata(mockAdapter, key, (current) => ({
-    ...current,
-    o: true,
-  }));
+export async function syncEntriesOfflineProtectedFromSiblingTab(
+  sessionKey: string,
+  keys: string[],
+): Promise<void> {
+  const siblingAdapter = createAsyncStorageAdapter(
+    new OpfsAsyncStorageDriver(),
+  );
+  await resolveAfterAllTimers(
+    siblingAdapter.syncSessionProtectedKeys(
+      sessionKey,
+      keys.map((key) => serializeProtectedStorageKey(key)),
+      [],
+    ),
+  );
 }
 
 export function setProtectedKeysSnapshot(

--- a/tests/persistent-storage/storage-adapter.test.ts
+++ b/tests/persistent-storage/storage-adapter.test.ts
@@ -12,7 +12,11 @@ import {
   vi,
 } from 'vitest';
 import { clearSessionStorage } from '../../src/main';
-import { createAsyncStorageAdapter } from '../../src/persistentStorage/asyncStorageAdapter';
+import {
+  ASYNC_STORAGE_COMMIT_DEBOUNCE_MS,
+  createAsyncStorageAdapter,
+  serializeProtectedRef,
+} from '../../src/persistentStorage/asyncStorageAdapter';
 import {
   ASYNC_NAMESPACE_INDEX_RECORD_KEY,
   getPayloadRecordKey,
@@ -21,6 +25,7 @@ import { resetManagedLocalStorageState } from '../../src/persistentStorage/local
 import type {
   AsyncStorageDiscoveredScope,
   AsyncStorageDriver,
+  AsyncStorageNamespaceCommitArgs,
   AsyncStorageNamespaceScope,
   PersistentStorageSchema,
 } from '../../src/persistentStorage/types';
@@ -222,6 +227,111 @@ function installMockBroadcastChannel() {
     vi.unstubAllGlobals();
     vi.stubGlobal('BroadcastChannel', OriginalBroadcastChannel);
   };
+}
+
+function installMockNavigatorLocks() {
+  const originalLocksDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis.navigator,
+    'locks',
+  );
+  const tailsByName = new Map<string, Promise<void>>();
+
+  const locks = {
+    async request<T>(
+      name: string,
+      optionsOrCallback: LockOptions | LockGrantedCallback<T>,
+      maybeCallback?: LockGrantedCallback<T>,
+    ): Promise<Awaited<T>> {
+      const callback =
+        typeof optionsOrCallback === 'function'
+          ? optionsOrCallback
+          : maybeCallback;
+      if (callback === undefined) {
+        throw new Error('Expected a lock callback.');
+      }
+
+      const previousTail = tailsByName.get(name) ?? Promise.resolve();
+      let releaseCurrentTail!: () => void;
+      const currentTail = new Promise<void>((resolve) => {
+        releaseCurrentTail = resolve;
+      });
+      const nextTail = previousTail.then(() => currentTail);
+      tailsByName.set(name, nextTail);
+
+      await previousTail;
+
+      try {
+        return await callback(null);
+      } finally {
+        releaseCurrentTail();
+        if (tailsByName.get(name) === nextTail) {
+          tailsByName.delete(name);
+        }
+      }
+    },
+  };
+
+  Object.defineProperty(globalThis.navigator, 'locks', {
+    value: __LEGIT_CAST__<LockManager, unknown>(locks),
+    writable: true,
+    configurable: true,
+  });
+
+  return () => {
+    if (originalLocksDescriptor) {
+      Object.defineProperty(
+        globalThis.navigator,
+        'locks',
+        originalLocksDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(globalThis.navigator, 'locks');
+    }
+  };
+}
+
+function createManagedLockTestDriver(options: { delayMs?: number } = {}) {
+  const baseDriver = createInMemoryAsyncStorageDriver();
+  const operations: string[] = [];
+  const delayMs = options.delayMs ?? 25;
+  const driver: AsyncStorageDriver & { operations: string[] } = __LEGIT_CAST__<
+    AsyncStorageDriver & { operations: string[] },
+    unknown
+  >({
+    ...baseDriver,
+    __tsdfManagedStorage: {
+      applyManagedCommit: async (
+        scope: AsyncStorageNamespaceScope,
+        args: AsyncStorageNamespaceCommitArgs<unknown, Record<string, unknown>>,
+      ) => {
+        operations.push(
+          `commit:start:${scope.sessionKey}:${[
+            ...(args.upserts ?? []).map((upsert) => upsert.key),
+            ...(args.removes ?? []).map((key) => `-${key}`),
+          ].join(',')}`,
+        );
+        await new Promise((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+        operations.push(
+          `commit:end:${scope.sessionKey}:${[
+            ...(args.upserts ?? []).map((upsert) => upsert.key),
+            ...(args.removes ?? []).map((key) => `-${key}`),
+          ].join(',')}`,
+        );
+      },
+      syncSessionProtectedKeys: async (sessionKey: string) => {
+        operations.push(`protect:start:${sessionKey}`);
+        await new Promise((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+        operations.push(`protect:end:${sessionKey}`);
+      },
+    },
+    operations,
+  });
+
+  return driver;
 }
 
 function createDocumentEnv(options: {
@@ -862,6 +972,144 @@ describe('persistent storage integration', () => {
 
       value: { value: 'first' }
     `);
+  });
+
+  test('same-session sibling adapters serialize managed commits through the shared writer lock', async () => {
+    const restoreNavigatorLocks = installMockNavigatorLocks();
+    const driver = createManagedLockTestDriver();
+    const scope = {
+      sessionKey: 'sess1',
+      storeName: 'async-session-writer-lock',
+      kind: 'collection.item',
+    } satisfies AsyncStorageNamespaceScope;
+
+    try {
+      const adapterA = createAsyncStorageAdapter(driver);
+      const adapterB = createAsyncStorageAdapter(driver);
+      const namespaceA = adapterA.openNamespace<{ value: string }>(scope);
+      const namespaceB = adapterB.openNamespace<{ value: string }>(scope);
+
+      const firstCommit = namespaceA.commit({
+        upserts: [{ key: 'a', value: { value: 'first' }, version: 1 }],
+      });
+      const secondCommit = namespaceB.commit({
+        upserts: [{ key: 'b', value: { value: 'second' }, version: 1 }],
+      });
+
+      await flushAllTimers();
+      await Promise.all([firstCommit, secondCommit]);
+
+      expect(driver.operations).toMatchInlineSnapshot(`
+        - 'commit:start:sess1:a'
+        - 'commit:end:sess1:a'
+        - 'commit:start:sess1:b'
+        - 'commit:end:sess1:b'
+      `);
+    } finally {
+      restoreNavigatorLocks();
+    }
+  });
+
+  test('same-session writer locks also serialize protected-key sync with sibling commits', async () => {
+    const restoreNavigatorLocks = installMockNavigatorLocks();
+    const driver = createManagedLockTestDriver({ delayMs: 50 });
+    const scope = {
+      sessionKey: 'sess1',
+      storeName: 'async-session-protection-lock',
+      kind: 'collection.item',
+    } satisfies AsyncStorageNamespaceScope;
+
+    try {
+      const adapterA = createAsyncStorageAdapter(driver);
+      const adapterB = createAsyncStorageAdapter(driver);
+      const namespace = adapterA.openNamespace<{ value: string }>(scope);
+
+      const commitPromise = namespace.commit({
+        upserts: [{ key: 'a', value: { value: 'first' }, version: 1 }],
+      });
+      await advanceTime(ASYNC_STORAGE_COMMIT_DEBOUNCE_MS);
+
+      const syncPromise = adapterB.syncSessionProtectedKeys(
+        'sess1',
+        [serializeProtectedRef({ ...scope, key: 'a' })],
+        [],
+      );
+
+      await flushAllTimers();
+      await Promise.all([commitPromise, syncPromise]);
+
+      expect(driver.operations).toMatchInlineSnapshot(`
+        - 'commit:start:sess1:a'
+        - 'commit:end:sess1:a'
+        - 'protect:start:sess1'
+        - 'protect:end:sess1'
+      `);
+    } finally {
+      restoreNavigatorLocks();
+    }
+  });
+
+  test('async writer locks fall back to unlocked coordination with a single warning', async () => {
+    const originalLocksDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis.navigator,
+      'locks',
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const driver = createInMemoryAsyncStorageDriver();
+    const adapter = createAsyncStorageAdapter(driver);
+    const scope = {
+      sessionKey: 'sess1',
+      storeName: 'async-without-locks',
+      kind: 'collection.item',
+    } satisfies AsyncStorageNamespaceScope;
+    const namespace = adapter.openNamespace<{ value: string }>(scope);
+
+    Object.defineProperty(globalThis.navigator, 'locks', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const firstCommit = namespace.commit({
+        upserts: [{ key: 'a', value: { value: 'first' }, version: 1 }],
+      });
+      await advanceTime(ASYNC_STORAGE_COMMIT_DEBOUNCE_MS);
+      await firstCommit;
+
+      const secondCommit = namespace.commit({
+        upserts: [{ key: 'b', value: { value: 'second' }, version: 1 }],
+      });
+      await advanceTime(ASYNC_STORAGE_COMMIT_DEBOUNCE_MS);
+      await secondCommit;
+
+      expect(await namespace.get('a')).toMatchInlineSnapshot(`
+        metadata:
+          customMetadata: {}
+          key: 'a'
+          lastAccessAt: 1735689600040
+          payloadRef: '__tsdf_payload__:a'
+          version: 1
+          writtenAt: 1735689600040
+
+        value: { value: 'first' }
+      `);
+      expect(warnSpy.mock.calls).toMatchInlineSnapshot(`
+        - - '[TSDF] navigator.locks is unavailable; async persistentStorage is using unlocked writer coordination.'
+      `);
+    } finally {
+      warnSpy.mockRestore();
+
+      if (originalLocksDescriptor) {
+        Object.defineProperty(
+          globalThis.navigator,
+          'locks',
+          originalLocksDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(globalThis.navigator, 'locks');
+      }
+    }
   });
 
   test('document persistence still hydrates and refetches when navigator.locks is unavailable', async () => {


### PR DESCRIPTION
## Summary

This PR adds session-scoped writer locking for async persistent storage operations so same-session commits, clears, protections, and cleanup run without racing each other. It also preserves cache consistency by invalidating state after protected-key sync and removal flows, improving correctness under concurrent tabs and writer activity.
### Changes

- Introduce a shared writer-lock helper for async storage session operations.
- Wrap session clear, protected-key sync, namespace clear, removals, and startup cleanup in navigator.locks coordination.
- Flush pending commits within the session before running destructive or metadata-updating operations.
- Simplify namespace reads to use the current adapter cache path consistently.
- Update efficiency tests to reflect reduced redundant reads and new sibling-tab protection syncing behavior.
- Add integration coverage for lock-serialized commits, protected-key sync, and unlocked fallback warnings when navigator.locks is unavailable.

### Testing Notes

Verify concurrent commits from two adapters in the same session execute sequentially and both persist successfully. Also test protected-key sync racing with a pending commit, startup cleanup across multiple sessions, and the fallback path when navigator.locks is absent or null to confirm the warning is emitted once and writes still complete.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
