### PR TITLE
Support partial-resource snapshots with inferFields

### DIFF
--- a/apps/playground/src/stores/contactListStore.ts
+++ b/apps/playground/src/stores/contactListStore.ts
@@ -49,6 +49,7 @@ export const contactListStore = createListQueryStore<
   partialResources: {
     mergeItems: (prev, fetched) => ({ ...prev, ...fetched }),
     selectFields: (fields, item) => selectContactFields(item, fields),
+    inferFields: (item) => Object.keys(item),
   },
   optimisticListUpdates: [
     {

--- a/docs/partial-resources.md
+++ b/docs/partial-resources.md
@@ -44,10 +44,17 @@ const userStore = createListQueryStore<User, UserFilter, string, true>({
     selectFields: (fields, item) => {
       const result: Partial<User> = {};
       for (const field of fields) {
-        result[field] = item[field];
+        if (item[field] !== undefined) {
+          result[field] = item[field];
+        }
       }
       return result as User;
     },
+
+    // Infer which logical fields are present when TSDF has an item snapshot
+    // but no loaded-field metadata, such as manually added or offline items.
+    inferFields: (item) =>
+      Object.keys(item).filter((field) => item[field] !== undefined),
   },
 
   // ...other options
@@ -61,6 +68,7 @@ const userStore = createListQueryStore<User, UserFilter, string, true>({
 3. When a hook requests fields that haven't been loaded yet, a fetch is triggered requesting only the missing fields
 4. The `mergeItems` function combines the newly fetched data with previously loaded data
 5. The `selectFields` function extracts the requested fields for the hook's return value
+6. The `inferFields` function identifies fields in metadata-free item snapshots
 
 ## Using Fields in Hooks
 
@@ -166,3 +174,13 @@ selectFields: (fields: string[], item: ItemState) => ItemState;
 ```
 
 Called when a hook requests specific fields. Should return an item containing only the requested fields.
+
+### inferFields
+
+```ts
+inferFields: (item: ItemState) => string[] | '*';
+```
+
+Called when TSDF has an item snapshot but no `itemLoadedFields` metadata for it. This can happen for manually inserted items, persisted fallback snapshots, and offline optimistic rows. Return the logical fields that are available, or `'*'` if the snapshot is complete.
+
+TSDF does not infer fields by checking object keys internally. If your field names are top-level properties, implement that rule explicitly in `inferFields`; if your fields are logical or nested, return those logical field names instead.

--- a/skills/tsdf/SKILL.md
+++ b/skills/tsdf/SKILL.md
@@ -104,7 +104,7 @@ Docs: `docs/fetch-scheduling.md`, `docs/batch-fetching.md`.
 - **Batch groups** — `getItemsBatchKey` groups items into separate batch schedulers; return `false` to opt out for that item and use the per-item fetch function.
 - **Bulk hooks** — `useMultipleItems` and `useMultipleListQueries` let callers subscribe to many resources through one hook while sharing the same scheduler/cache machinery.
 - **Selectors + deep equality** — hook `selector` options reduce re-renders by returning only the data the component needs.
-- **Partial resources** — List Query stores with `TPartialResources = true` can fetch only requested item fields and track field-level invalidation.
+- **Partial resources** — List Query stores with `TPartialResources = true` can fetch only requested item fields and track field-level invalidation. `partialResources` requires `mergeItems`, `selectFields`, and `inferFields`; `inferFields` handles metadata-free snapshots such as manually added or offline items.
 - **Derived queries** — `derivedQueries` compute list results from already-loaded items when `isComplete(...)` returns `true`, avoiding unnecessary query fetches and query cache entries.
 - **Cache limits** — `maxItems`, `maxQueries`, and `onStateCleanup` bound memory while protecting mounted, fetching, and mutating entries.
 - **Adaptive throttling** — `lowPriorityThrottleMs`, `mediumPriorityDelayMs`, `baseCoalescingWindowMs`, and `dynamicRealtimeThrottleMs(...)` tune work for hook mounts, background refetches, focus/reconnect, and realtime updates.
@@ -257,7 +257,7 @@ Docs: `docs/real-time-updates.md`.
 ## List Query specific features
 
 - **`optimisticListUpdates`** — auto add/remove/re-sort items in matching queries when item state changes (`filterItem`, `sort`, `appendNewTo`). Docs: `docs/optimistic-list-updates.md`.
-- **Partial resources** (set `TPartialResources = true`) — fetch only specific fields per item; tracks loaded fields and supports per-field invalidation. `fetchListFn` / `fetchItemFn` receive `{ fields }`. Docs: `docs/partial-resources.md`.
+- **Partial resources** (set `TPartialResources = true`) — fetch only specific fields per item; tracks loaded fields and supports per-field invalidation. `partialResources` requires `mergeItems`, `selectFields`, and `inferFields`. `fetchListFn` / `fetchItemFn` receive `{ fields }`. Docs: `docs/partial-resources.md`.
 - **Offset pagination** (set `TOffsetPagination = true`) — real offset/limit pagination instead of size-mode re-fetches. `fetchListFn` receives `{ offset, limit }`; `offsetPagination: { maxInvalidationLimit, maxParallel }`. Docs: `docs/offset-pagination.md`.
 - **`derivedQueries`** — hook results computed locally from already-materialized items when `isComplete(...)` returns `true`; results expose `isDerived: true` and `hasMore: false`, and never materialize a query entry.
 - **`addItemToState(payload, data, { addItemToQueries: { queries, appendTo } })`** — insert a new item into specific queries with `'start' | 'end' | (payloads) => index` placement.

--- a/src/listQueryStore/createFetchApi.ts
+++ b/src/listQueryStore/createFetchApi.ts
@@ -26,9 +26,16 @@ import {
 } from '../utils/storeShared';
 import { executeItemBatchFetch } from './executeItemBatchFetch';
 import { executeQueryFetch } from './executeQueryFetch';
-import { fallbackItemHasRequestedFields } from './itemFieldUtils';
+import {
+  excludeLoadedFields,
+  fallbackItemHasRequestedFields,
+  getFallbackMissingRequestedFields,
+  getStaleOrMissingRequestedFields,
+  snapshotIsFullyLoaded,
+} from './itemFieldUtils';
 import {
   type FieldsInput,
+  type ItemLoadedFields,
   type OffsetPaginationConfig,
   type PartialResourcesConfig,
   type QueryFetchPayload,
@@ -126,7 +133,7 @@ type CreateFetchApiOptions<
       | {
           item: ItemState;
           itemQuery: TSDFItemQuery<ItemPayload>;
-          loadedFields: string[];
+          loadedFields: ItemLoadedFields | undefined;
         }
       | undefined;
     readHydratedQuery(
@@ -250,6 +257,8 @@ export function createFetchApi<
     ItemPayload
   >['onItemFetchSettled'],
   offlineController: OfflineAwareFetchController | null | undefined,
+  itemPendingInvalidationFields: Map<string, string[]>,
+  itemsPendingFullInvalidation: Set<string>,
 ) {
   type Query = TSFDListQuery<QueryPayload>;
 
@@ -739,7 +748,7 @@ export function createFetchApi<
     | {
         item: ItemState | null | undefined;
         itemQuery: TSDFItemQuery<ItemPayload> | null | undefined;
-        loadedFields: string[] | undefined;
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined {
     const hasItem = Object.hasOwn(store.state.items, itemKey);
@@ -765,7 +774,7 @@ export function createFetchApi<
     | {
         item: ItemState | null | undefined;
         itemQuery: TSDFItemQuery<ItemPayload> | null | undefined;
-        loadedFields: string[] | undefined;
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined {
     const materializedItemState = readMaterializedItemState(itemKey);
@@ -1064,7 +1073,11 @@ export function createFetchApi<
         (partialResources &&
           fields &&
           fields.length > 0 &&
-          !fallbackItemHasRequestedFields(state, fields))
+          !fallbackItemHasRequestedFields(
+            state,
+            fields,
+            partialResources.inferFields,
+          ))
       ) {
         return 'skipped';
       }
@@ -1092,7 +1105,9 @@ export function createFetchApi<
         for (const { itemKey, state } of appendedHydratedItems) {
           draft.items[itemKey] = state.item;
           draft.itemQueries[itemKey] = state.itemQuery;
-          draft.itemLoadedFields[itemKey] = state.loadedFields;
+          if (state.loadedFields !== undefined) {
+            draft.itemLoadedFields[itemKey] = state.loadedFields;
+          }
         }
       },
       { action: 'persistent-storage-load-more' },
@@ -1118,13 +1133,39 @@ export function createFetchApi<
     });
   }
 
-  function hasStaleRequestedFields(
-    itemKey: string,
-    fields: readonly string[],
-  ): boolean {
-    const invalidationFields = store.state.itemFieldInvalidationFields[itemKey];
-    if (!invalidationFields || invalidationFields.length === 0) return false;
-    return fields.some((field) => invalidationFields.includes(field));
+  /**
+   * Fields of an item still awaiting an invalidation re-fetch. Reads the
+   * state-level record first; when a fetch already consumed it (the record is
+   * deleted before the response lands), falls back to the in-memory pending
+   * list minus the fields that were re-loaded since the invalidation.
+   */
+  function getUnresolvedPendingInvalidationFields(itemKey: string): string[] {
+    const stateInvalidationFields =
+      store.state.itemFieldInvalidationFields[itemKey];
+    if (stateInvalidationFields && stateInvalidationFields.length > 0) {
+      return stateInvalidationFields;
+    }
+
+    return excludeLoadedFields(
+      store.state.itemLoadedFields[itemKey],
+      itemPendingInvalidationFields.get(itemKey),
+    );
+  }
+
+  /**
+   * Whether an item snapshot is fresh enough for a require-fresh
+   * (`ignoreStaleState: true`) full ('*') read: no unresolved full ('*')
+   * invalidation and no fields still awaiting an invalidation re-fetch.
+   */
+  function itemSnapshotIsFresh(itemKey: string): boolean {
+    if (
+      store.state.itemLoadedFields[itemKey] !== '*' &&
+      itemsPendingFullInvalidation.has(itemKey)
+    ) {
+      return false;
+    }
+
+    return getUnresolvedPendingInvalidationFields(itemKey).length === 0;
   }
 
   async function awaitListQueryFetch(
@@ -1181,7 +1222,9 @@ export function createFetchApi<
 
               draft.items[itemKey] = hydratedItem.item;
               draft.itemQueries[itemKey] = hydratedItem.itemQuery;
-              draft.itemLoadedFields[itemKey] = hydratedItem.loadedFields;
+              if (hydratedItem.loadedFields !== undefined) {
+                draft.itemLoadedFields[itemKey] = hydratedItem.loadedFields;
+              }
             }
           },
           { action: 'persistent-storage-hydrate' },
@@ -1230,6 +1273,7 @@ export function createFetchApi<
   > {
     const queryKey = getQueryKey(params);
     const fields = normalizeFieldsOption(options.fields);
+    const fullFieldsRequested = options.fields === '*';
     const query = getQueryStateByKey(queryKey);
     const includeStale = !!options.ignoreStaleState;
     const cachedQueryCanBeUsed =
@@ -1239,7 +1283,8 @@ export function createFetchApi<
 
     if (query && cachedQueryCanBeUsed) {
       const needsFieldCheck =
-        partialResources && Array.isArray(fields) && fields.length > 0;
+        partialResources &&
+        ((Array.isArray(fields) && fields.length > 0) || fullFieldsRequested);
 
       if (!needsFieldCheck) {
         return Result.ok({
@@ -1253,14 +1298,43 @@ export function createFetchApi<
 
       const queryNeedsFieldFetch = query.items.some((itemKey) => {
         const itemState = readItemState(itemKey);
-        const invalidation = includeStale
-          ? store.state.itemFieldInvalidationFields[itemKey]
-          : undefined;
 
-        return fields.some(
-          (field) =>
-            !fallbackItemHasRequestedFields(itemState, [field]) ||
-            (invalidation?.includes(field) ?? false),
+        if (fullFieldsRequested) {
+          return (
+            !snapshotIsFullyLoaded(
+              itemState?.loadedFields,
+              itemState?.item,
+              partialResources.inferFields,
+            ) ||
+            (includeStale && !itemSnapshotIsFresh(itemKey))
+          );
+        }
+
+        const requestedFields = Array.isArray(fields) ? fields : [];
+
+        if (includeStale) {
+          // Require-fresh reads must also refetch requested fields that are
+          // still awaiting an invalidation re-fetch (per-field or full), even
+          // when the stale data is present and vouchable in state.
+          return (
+            getStaleOrMissingRequestedFields(
+              itemKey,
+              itemState?.loadedFields,
+              itemState?.item,
+              requestedFields,
+              partialResources.inferFields,
+              itemsPendingFullInvalidation,
+              getUnresolvedPendingInvalidationFields(itemKey),
+            ).length > 0
+          );
+        }
+
+        return (
+          getFallbackMissingRequestedFields(
+            itemState,
+            requestedFields,
+            partialResources.inferFields,
+          ).length > 0
         );
       });
 
@@ -1382,7 +1456,9 @@ export function createFetchApi<
           (draft) => {
             draft.items[itemKey] = hydratedItem.item;
             draft.itemQueries[itemKey] = hydratedItem.itemQuery;
-            draft.itemLoadedFields[itemKey] = hydratedItem.loadedFields;
+            if (hydratedItem.loadedFields !== undefined) {
+              draft.itemLoadedFields[itemKey] = hydratedItem.loadedFields;
+            }
           },
           { action: 'persistent-storage-hydrate' },
         );
@@ -1416,24 +1492,54 @@ export function createFetchApi<
   ): Promise<ResultType<ItemState, StoreFetchError>> {
     const itemKey = getItemKey(itemPayload);
     const fields = normalizeFieldsOption(options.fields);
+    const fullFieldsRequested = options.fields === '*';
     const itemState = readItemState(itemKey);
     const item = itemState?.item;
     const itemQuery = itemState?.itemQuery;
     const includeStale = !!options.ignoreStaleState;
     const needsFieldCheck =
-      partialResources && Array.isArray(fields) && fields.length > 0;
+      partialResources &&
+      ((Array.isArray(fields) && fields.length > 0) || fullFieldsRequested);
     const itemHasAllFields =
-      !needsFieldCheck || fallbackItemHasRequestedFields(itemState, fields);
+      !needsFieldCheck ||
+      (fullFieldsRequested
+        ? snapshotIsFullyLoaded(
+            itemState?.loadedFields,
+            itemState?.item,
+            partialResources.inferFields,
+          )
+        : fallbackItemHasRequestedFields(
+            itemState,
+            Array.isArray(fields) ? fields : [],
+            partialResources.inferFields,
+          ));
     const itemQueryFresh =
       itemQuery?.status === 'success' &&
       !itemQuery.error &&
       !itemQuery.refetchOnMount;
+    // For require-fresh reads of specific fields, the requested fields that
+    // are stale (awaiting an invalidation re-fetch) or missing without a vouch.
+    const staleOrMissingRequestedFields =
+      needsFieldCheck && !fullFieldsRequested && includeStale
+        ? getStaleOrMissingRequestedFields(
+            itemKey,
+            itemState?.loadedFields,
+            item,
+            Array.isArray(fields) ? fields : [],
+            partialResources.inferFields,
+            itemsPendingFullInvalidation,
+            getUnresolvedPendingInvalidationFields(itemKey),
+          )
+        : undefined;
     const cachedItemCanBeUsed =
       item != null &&
       itemHasAllFields &&
       (!includeStale ||
         (itemQueryFresh &&
-          (!needsFieldCheck || !hasStaleRequestedFields(itemKey, fields))));
+          (!needsFieldCheck ||
+            (fullFieldsRequested
+              ? itemSnapshotIsFresh(itemKey)
+              : staleOrMissingRequestedFields?.length === 0))));
 
     if (cachedItemCanBeUsed) {
       return Result.ok(item);
@@ -1445,15 +1551,22 @@ export function createFetchApi<
 
     let fieldsToFetch: FieldsInput | undefined = options.fields;
 
-    if (needsFieldCheck && item != null && itemQueryFresh) {
-      const invalidation = includeStale
-        ? store.state.itemFieldInvalidationFields[itemKey]
-        : undefined;
-      fieldsToFetch = fields.filter(
-        (field) =>
-          !fallbackItemHasRequestedFields(itemState, [field]) ||
-          (invalidation?.includes(field) ?? false),
-      );
+    if (
+      needsFieldCheck &&
+      !fullFieldsRequested &&
+      item != null &&
+      itemQueryFresh
+    ) {
+      // Fetch only the fields that are actually stale or missing — for
+      // require-fresh reads that is `staleOrMissingRequestedFields`; default
+      // reads tolerate staleness and only fetch missing unvouched fields.
+      fieldsToFetch =
+        staleOrMissingRequestedFields ??
+        getFallbackMissingRequestedFields(
+          itemState,
+          Array.isArray(fields) ? fields : [],
+          partialResources.inferFields,
+        );
     }
 
     const result = await awaitItemFetch(itemPayload, {

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -40,6 +40,7 @@ import {
   type OnListQueryInvalidate,
   type OnListQueryItemInvalidate,
   type OptimisticListUpdate,
+  type ItemLoadedFields,
   type PartialResourcesConfig,
   type TSDFItemQuery,
   type TSFDListQuery,
@@ -253,6 +254,8 @@ export function createMutationApi<
   onOfflineTimelineEvent:
     | ((event: TestOfflineTimelineEvent) => void)
     | undefined,
+  itemPendingInvalidationFields: Map<string, string[]>,
+  itemsPendingFullInvalidation: Set<string>,
 ) {
   type FilterQuery = FilterQueryFn<QueryPayload>;
   type FilterItem = FilterItemFn<ItemState, ItemPayload>;
@@ -277,7 +280,7 @@ export function createMutationApi<
     itemKey: string;
     item: ItemState | null | undefined;
     itemQuery: TSDFItemQuery<ItemPayload> | null | undefined;
-    loadedFields: string[] | undefined;
+    loadedFields: ItemLoadedFields | undefined;
     invalidationFields: string[] | undefined;
     invalidationPriority: FetchType | undefined;
     pendingInvalidationFields: string[] | undefined;
@@ -438,7 +441,6 @@ export function createMutationApi<
   const queryInvalidationWasTriggered = new Set<string>();
   const itemInvalidationWasTriggered = new Set<string>();
   const itemFieldInvalidationPriorities = new Map<string, FetchType>();
-  const itemPendingInvalidationFields = new Map<string, string[]>();
 
   function invalidateQueryAndItems(args: InvalidateQueryAndItemsArgs) {
     const itemPayload: ItemPayload | ItemPayload[] | FilterItem | false =
@@ -530,9 +532,11 @@ export function createMutationApi<
               const loadedFields = draft.itemLoadedFields[itemKey];
               if (!loadedFields) continue;
 
-              draft.itemLoadedFields[itemKey] = loadedFields.filter(
-                (f) => !invalidateFields.includes(f),
-              );
+              if (loadedFields !== '*') {
+                draft.itemLoadedFields[itemKey] = loadedFields.filter(
+                  (f) => !invalidateFields.includes(f),
+                );
+              }
               const existingInvalidationFields =
                 draft.itemFieldInvalidationFields[itemKey] ?? [];
               draft.itemFieldInvalidationFields[itemKey] = Array.from(
@@ -573,16 +577,34 @@ export function createMutationApi<
 
       if (!item) continue;
 
-      const trackedInvalidationFields = partialResources
-        ? Array.from(
-            new Set([
-              ...(store.state.itemLoadedFields[itemKey] ?? []),
-              ...(itemPendingInvalidationFields.get(itemKey) ?? []),
-            ]),
-          ).sort()
-        : [];
+      // Metadata-free items (manually added, offline rows, hydrated fallback
+      // snapshots) have no `itemLoadedFields` entry — their staleness baseline
+      // is whatever `inferFields` currently vouches for, otherwise the
+      // invalidation would leave no durable marker behind.
+      let effectiveLoadedFields = store.state.itemLoadedFields[itemKey];
+      if (partialResources && effectiveLoadedFields === undefined) {
+        const itemState = store.state.items[itemKey];
+        if (itemState) {
+          effectiveLoadedFields = partialResources.inferFields(itemState);
+        }
+      }
+
+      const itemWasFullyLoaded =
+        partialResources && effectiveLoadedFields === '*';
+      const trackedInvalidationFields =
+        partialResources && !itemWasFullyLoaded
+          ? Array.from(
+              new Set([
+                ...(effectiveLoadedFields === '*'
+                  ? []
+                  : (effectiveLoadedFields ?? [])),
+                ...(itemPendingInvalidationFields.get(itemKey) ?? []),
+              ]),
+            ).sort()
+          : [];
       const trackedInvalidationPriority =
-        trackedInvalidationFields.length > 0
+        trackedInvalidationFields.length > 0 ||
+        itemsPendingFullInvalidation.has(itemKey)
           ? itemFieldInvalidationPriorities.get(itemKey)
           : undefined;
       const nextInvalidationPriority =
@@ -598,6 +620,24 @@ export function createMutationApi<
         fetchTypePriority[nextInvalidationPriority];
 
       if (currentInvalidationPriority >= newInvalidationPriority) continue;
+
+      // Update the invalidation tracking maps before the state change so
+      // subscribers notified by it see the same invalidation transaction.
+      if (itemWasFullyLoaded) {
+        // No enumerable field list for a '*' item — record the durable
+        // full-invalidation marker so catch-up hooks refetch their own fields
+        // instead of trusting the stale snapshot.
+        itemsPendingFullInvalidation.add(itemKey);
+        itemPendingInvalidationFields.delete(itemKey);
+        itemFieldInvalidationPriorities.set(itemKey, nextInvalidationPriority);
+      } else if (trackedInvalidationFields.length > 0) {
+        itemPendingInvalidationFields.set(itemKey, trackedInvalidationFields);
+        itemFieldInvalidationPriorities.set(itemKey, nextInvalidationPriority);
+      } else {
+        itemPendingInvalidationFields.delete(itemKey);
+        itemFieldInvalidationPriorities.delete(itemKey);
+      }
+      itemInvalidationWasTriggered.delete(itemKey);
 
       store.produceState(
         (draft) => {
@@ -615,14 +655,6 @@ export function createMutationApi<
         { action: 'invalidate-item' },
       );
 
-      if (trackedInvalidationFields.length > 0) {
-        itemPendingInvalidationFields.set(itemKey, trackedInvalidationFields);
-        itemFieldInvalidationPriorities.set(itemKey, nextInvalidationPriority);
-      } else {
-        itemPendingInvalidationFields.delete(itemKey);
-        itemFieldInvalidationPriorities.delete(itemKey);
-      }
-      itemInvalidationWasTriggered.delete(itemKey);
       emitInvalidateItem({ priority: nextInvalidationPriority, itemKey });
 
       if (onInvalidateItem) {
@@ -1024,6 +1056,7 @@ export function createMutationApi<
     for (const { itemKey } of itemsId) {
       itemFieldInvalidationPriorities.delete(itemKey);
       itemPendingInvalidationFields.delete(itemKey);
+      itemsPendingFullInvalidation.delete(itemKey);
       itemInvalidationWasTriggered.delete(itemKey);
       publishItemSnapshot(itemKey);
     }
@@ -1040,6 +1073,7 @@ export function createMutationApi<
     itemInvalidationWasTriggered.clear();
     itemFieldInvalidationPriorities.clear();
     itemPendingInvalidationFields.clear();
+    itemsPendingFullInvalidation.clear();
   }
 
   type ListQueryMutationArgs<T> = {
@@ -1339,7 +1373,6 @@ export function createMutationApi<
     queryInvalidationWasTriggered,
     itemInvalidationWasTriggered,
     itemFieldInvalidationPriorities,
-    itemPendingInvalidationFields,
     invalidateQueryAndItems,
     invalidateItem,
     startItemMutation,

--- a/src/listQueryStore/itemFieldUtils.ts
+++ b/src/listQueryStore/itemFieldUtils.ts
@@ -1,32 +1,159 @@
-import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { reusePrevIfEqual } from '../utils/reusePrevIfEqual';
 import type { ValidStoreState } from '../utils/storeShared';
-import type { PartialResourcesConfig } from './types';
+import type { ItemLoadedFields, PartialResourcesConfig } from './types';
+
+export function hasFullyLoadedFields(
+  loadedFields: ItemLoadedFields | undefined,
+): boolean {
+  return loadedFields === '*';
+}
+
+/**
+ * Whether a snapshot should be treated as holding every field of the item.
+ * True when the tracked `loadedFields` is the `'*'` sentinel, or when the
+ * snapshot carries no field metadata but `inferFields` reports the item is
+ * complete (`'*'`) — e.g. manually inserted items, offline optimistic rows, or
+ * persisted fallback snapshots.
+ */
+export function snapshotIsFullyLoaded<ItemState extends ValidStoreState>(
+  loadedFields: ItemLoadedFields | undefined,
+  item: ItemState | null | undefined,
+  inferFields: (item: ItemState) => ItemLoadedFields,
+): boolean {
+  if (loadedFields === '*') return true;
+  if (!item) return false;
+  return inferFields(item) === '*';
+}
+
+/**
+ * Like {@link snapshotIsFullyLoaded}, but also returns `false` when the item is
+ * awaiting a full ('*') re-fetch after a full invalidation. A fully-loaded
+ * snapshot that was fully invalidated has its `loadedFields` reset while the
+ * (now stale) item data is still present, so `inferFields` would otherwise
+ * wrongly vouch for it as complete.
+ */
+export function snapshotIsFullyLoadedAndFresh<
+  ItemState extends ValidStoreState,
+>(
+  itemKey: string,
+  loadedFields: ItemLoadedFields | undefined,
+  item: ItemState | null | undefined,
+  inferFields: (item: ItemState) => ItemLoadedFields,
+  itemsPendingFullInvalidation: Set<string>,
+): boolean {
+  if (loadedFields !== '*' && itemsPendingFullInvalidation.has(itemKey)) {
+    return false;
+  }
+  return snapshotIsFullyLoaded(loadedFields, item, inferFields);
+}
+
+/**
+ * Missing requested fields for an item snapshot, letting `inferFields` vouch
+ * for metadata-free item data (e.g. client-created items) — except for stale
+ * fields awaiting a re-fetch after an invalidation (per-field or full), when
+ * the item's stale data must not be vouched for.
+ */
+export function getStaleOrMissingRequestedFields<
+  ItemState extends ValidStoreState,
+>(
+  itemKey: string,
+  loadedFields: ItemLoadedFields | undefined,
+  item: ItemState | null | undefined,
+  requestedFields: readonly string[],
+  inferFields: (item: ItemState) => ItemLoadedFields,
+  itemsPendingFullInvalidation: Set<string>,
+  pendingInvalidationFields: readonly string[],
+): string[] {
+  // Requested fields awaiting an invalidation re-fetch are stale even when
+  // they are tracked as loaded — e.g. per-field invalidations on a fully
+  // loaded ('*') item keep `loadedFields === '*'` while the stale fields live
+  // only in the pending invalidation list.
+  const staleRequestedFields =
+    pendingInvalidationFields.length > 0
+      ? requestedFields.filter((field) =>
+          pendingInvalidationFields.includes(field),
+        )
+      : [];
+
+  const missingLoadedFields = excludeLoadedFields(
+    loadedFields,
+    requestedFields,
+  );
+  if (missingLoadedFields.length === 0) return staleRequestedFields;
+
+  // While a full ('*') invalidation is unresolved, or when there is no item
+  // data to inspect, `inferFields` must not vouch for any missing field.
+  const unvouchedMissingFields =
+    (loadedFields !== '*' && itemsPendingFullInvalidation.has(itemKey)) || !item
+      ? missingLoadedFields
+      : (() => {
+          const inferredFields = inferFields(item);
+          return missingLoadedFields.filter(
+            (field) =>
+              inferredFields !== '*' && !inferredFields.includes(field),
+          );
+        })();
+
+  if (staleRequestedFields.length === 0) return unvouchedMissingFields;
+
+  // Preserve the requested-fields order while deduping the stale ∪ missing
+  // union (a stale field is usually also missing from `loadedFields`).
+  const resultFields = new Set([
+    ...staleRequestedFields,
+    ...unvouchedMissingFields,
+  ]);
+  return requestedFields.filter((field) => resultFields.has(field));
+}
 
 export function fallbackItemHasRequestedFields<
   ItemState extends ValidStoreState,
 >(
   fallbackItemState:
-    | { item: ItemState | null | undefined; loadedFields: string[] | undefined }
+    | {
+        item: ItemState | null | undefined;
+        loadedFields: ItemLoadedFields | undefined;
+      }
     | undefined,
   requestedFields: readonly string[],
+  inferFields: (item: ItemState) => ItemLoadedFields,
 ): boolean {
-  const loadedFields = fallbackItemState?.loadedFields ?? [];
+  return (
+    getFallbackMissingRequestedFields(
+      fallbackItemState,
+      requestedFields,
+      inferFields,
+    ).length === 0
+  );
+}
 
-  if (requestedFields.every((field) => loadedFields.includes(field))) {
-    return true;
-  }
+export function getFallbackMissingRequestedFields<
+  ItemState extends ValidStoreState,
+>(
+  fallbackItemState:
+    | {
+        item: ItemState | null | undefined;
+        loadedFields: ItemLoadedFields | undefined;
+      }
+    | undefined,
+  requestedFields: readonly string[],
+  inferFields: (item: ItemState) => ItemLoadedFields,
+): string[] {
+  const loadedFields = fallbackItemState?.loadedFields;
+
+  if (loadedFields === '*') return [];
+
+  const missingLoadedFields = requestedFields.filter(
+    (field) => !(loadedFields?.includes(field) ?? false),
+  );
+  if (missingLoadedFields.length === 0) return [];
 
   const item = fallbackItemState?.item;
-  if (!item || typeof item !== 'object') return false;
+  if (!item) return missingLoadedFields;
 
-  const itemRecord =
-    // WORKAROUND: Fallback field checks need indexed property access, but ItemState is generic and does not expose a string index signature.
-    __LEGIT_CAST__<Record<string, unknown>, ItemState>(item);
+  const inferredFields = inferFields(item);
+  if (inferredFields === '*') return [];
 
-  return requestedFields.every(
-    (field) => field in itemRecord && itemRecord[field] !== undefined,
-  );
+  return missingLoadedFields.filter((field) => !inferredFields.includes(field));
 }
 
 /**
@@ -34,10 +161,11 @@ export function fallbackItemHasRequestedFields<
  * `loadedFields`. When either argument is `undefined` or empty, returns `[]`.
  */
 export function excludeLoadedFields(
-  loadedFields: string[] | undefined,
-  requestedFields: string[] | undefined,
+  loadedFields: ItemLoadedFields | undefined,
+  requestedFields: readonly string[] | undefined,
 ): string[] {
   if (!requestedFields || requestedFields.length === 0) return [];
+  if (loadedFields === '*') return [];
   if (!loadedFields || loadedFields.length === 0) return [...requestedFields];
 
   return requestedFields.filter((field) => !loadedFields.includes(field));
@@ -52,7 +180,7 @@ export function excludeLoadedFields(
 export function applyPartialItemMerge<ItemState extends ValidStoreState>(
   draft: {
     items: Record<string, ItemState | null>;
-    itemLoadedFields: Record<string, string[]>;
+    itemLoadedFields: Record<string, ItemLoadedFields>;
   },
   itemKey: string,
   data: ItemState,
@@ -64,11 +192,13 @@ export function applyPartialItemMerge<ItemState extends ValidStoreState>(
   draft.items[itemKey] = reusePrevIfEqual(prev, merged);
 
   if (fields && fields.length > 0) {
-    const existingFields = draft.itemLoadedFields[itemKey] ?? [];
-    const fieldSet = new Set([...existingFields, ...fields]);
+    const existingFields = draft.itemLoadedFields[itemKey];
+    if (existingFields === '*') return merged;
+
+    const fieldSet = new Set([...(existingFields ?? []), ...fields]);
     draft.itemLoadedFields[itemKey] = Array.from(fieldSet).sort();
   } else {
-    draft.itemLoadedFields[itemKey] = Object.keys(merged).sort();
+    draft.itemLoadedFields[itemKey] = '*';
   }
 
   return merged;

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -103,6 +103,7 @@ import { createMutationApi } from './createMutationApi';
 import {
   excludeLoadedFields,
   fallbackItemHasRequestedFields,
+  snapshotIsFullyLoaded,
 } from './itemFieldUtils';
 import { createListQueryCacheLimits } from './listQueryCacheLimits';
 import {
@@ -110,6 +111,7 @@ import {
   type FetchListFnReturn,
   type FieldsInput,
   type FieldsOption,
+  type ItemLoadedFields,
   type ListQueryOfflineOverlay,
   type ListQueryStoreInitialData,
   type ListQueryUseMultipleItemsQuery,
@@ -1041,7 +1043,13 @@ type ListQuerySnapshotItemEntry<
   itemKey: string;
   item: ItemState | null;
   itemQuery: TSDFItemQuery<ItemPayload> | null;
-  loadedFields: string[];
+  /**
+   * The sender's loaded-fields metadata, published as-is: `undefined` means
+   * the sender has no metadata for the item (`inferFields` governs), while an
+   * explicit `[]` means the item is fully invalidated on the sender and it
+   * vouches for nothing.
+   */
+  loadedFields: ItemLoadedFields | undefined;
 };
 
 /** @internal */
@@ -1063,7 +1071,8 @@ export type ListQueryBrowserTabsMessage<
       consistency: SnapshotConsistency;
       item: ItemState | null;
       itemQuery: TSDFItemQuery<ItemPayload> | null;
-      loadedFields: string[];
+      /** See {@link ListQuerySnapshotItemEntry.loadedFields}. */
+      loadedFields: ItemLoadedFields | undefined;
     })
   | (BrowserTabsMessageMeta & {
       kind: 'fetch-start';
@@ -1759,7 +1768,7 @@ export function createListQueryStore<
       itemKey,
       item: store.state.items[itemKey] ?? null,
       itemQuery: store.state.itemQueries[itemKey] ?? null,
-      loadedFields: store.state.itemLoadedFields[itemKey] ?? [],
+      loadedFields: store.state.itemLoadedFields[itemKey],
     }));
   }
 
@@ -1800,7 +1809,7 @@ export function createListQueryStore<
       consistency,
       item: store.state.items[itemKey] ?? null,
       itemQuery: store.state.itemQueries[itemKey] ?? null,
-      loadedFields: store.state.itemLoadedFields[itemKey] ?? [],
+      loadedFields: store.state.itemLoadedFields[itemKey],
     });
     if (!message) return;
 
@@ -1881,6 +1890,18 @@ export function createListQueryStore<
       preloaded: results[index] ?? false,
     }));
   }
+
+  // Invalidation obligations that outlive the state-level
+  // `itemFieldInvalidationFields` record (which is consumed when a re-fetch
+  // starts). Shared by the fetch api (require-fresh imperative reads), the
+  // mutation api (which records invalidations) and the hooks.
+  const itemPendingInvalidationFields = new Map<string, string[]>();
+  // Items whose entire ('*') snapshot was invalidated. A fully-loaded ('*')
+  // item has no enumerable field list to store in `itemPendingInvalidationFields`,
+  // so this set is the durable "everything is stale" marker that survives partial
+  // refetches. It keeps other mounted hooks from trusting the stale snapshot via
+  // `inferFields` until the item is fully reloaded (`loadedFields === '*'` again).
+  const itemsPendingFullInvalidation = new Set<string>();
 
   const {
     getQueryState,
@@ -2028,6 +2049,8 @@ export function createListQueryStore<
       }
     },
     offlineFetchController,
+    itemPendingInvalidationFields,
+    itemsPendingFullInvalidation,
   );
 
   const {
@@ -2035,7 +2058,6 @@ export function createListQueryStore<
     queryInvalidationWasTriggered,
     itemInvalidationWasTriggered,
     itemFieldInvalidationPriorities,
-    itemPendingInvalidationFields,
     invalidateQueryAndItems,
     invalidateItem,
     startItemMutation,
@@ -2079,6 +2101,8 @@ export function createListQueryStore<
     import.meta.env.TEST && testOptions
       ? testOptions.onOfflineTimelineEvent
       : undefined,
+    itemPendingInvalidationFields,
+    itemsPendingFullInvalidation,
   );
 
   if (resolvedPersistentStorageConfig && resolvedOfflineConfig) {
@@ -2242,15 +2266,28 @@ export function createListQueryStore<
   function applyLoadedFieldsFromSnapshot(
     draft: State,
     itemKey: string,
-    loadedFields: string[],
+    loadedFields: ItemLoadedFields | undefined,
   ): void {
-    if (loadedFields.length > 0) {
-      const existingLoadedFields = draft.itemLoadedFields[itemKey] ?? [];
-      draft.itemLoadedFields[itemKey] = Array.from(
-        new Set([...existingLoadedFields, ...loadedFields]),
-      ).sort();
-    } else {
-      delete draft.itemLoadedFields[itemKey];
+    // `undefined` means the sender has no metadata for the item (`inferFields`
+    // governs there) — it says nothing about what this tab has loaded.
+    if (loadedFields === undefined) return;
+
+    if (loadedFields === '*') {
+      draft.itemLoadedFields[itemKey] = '*';
+    } else if (loadedFields.length > 0) {
+      const existingLoadedFields = draft.itemLoadedFields[itemKey];
+      if (existingLoadedFields !== '*') {
+        draft.itemLoadedFields[itemKey] = Array.from(
+          new Set([...(existingLoadedFields ?? []), ...loadedFields]),
+        ).sort();
+      }
+    } else if (draft.itemLoadedFields[itemKey] === undefined) {
+      // An explicit `[]` means the item is fully invalidated on the sender.
+      // That is only adoptable when this tab has no metadata of its own —
+      // local metadata must never be erased by a snapshot that vouches for
+      // nothing (e.g. a mutation published while the sender's invalidation
+      // refetch is still in flight).
+      draft.itemLoadedFields[itemKey] = [];
     }
 
     const invalidationFields = draft.itemFieldInvalidationFields[itemKey];
@@ -2270,10 +2307,24 @@ export function createListQueryStore<
 
   function pruneItemInvalidationTracking(): void {
     for (const [itemKey, pendingFields] of itemPendingInvalidationFields) {
+      // Fields still owed from earlier invalidations: the ones not yet
+      // reloaded, plus any per-field invalidations still recorded in state —
+      // the state record must never *replace* the tracked pending fields, or
+      // fields owed from an earlier (e.g. full) invalidation would be dropped.
       const remainingFields = excludeLoadedFields(
         store.state.itemLoadedFields[itemKey],
         pendingFields,
       );
+
+      const stateInvalidationFields =
+        store.state.itemFieldInvalidationFields[itemKey];
+      if (stateInvalidationFields && stateInvalidationFields.length > 0) {
+        const mergedFields = Array.from(
+          new Set([...stateInvalidationFields, ...remainingFields]),
+        ).sort();
+        itemPendingInvalidationFields.set(itemKey, mergedFields);
+        continue;
+      }
 
       if (remainingFields.length > 0) {
         itemPendingInvalidationFields.set(itemKey, remainingFields);
@@ -2282,13 +2333,28 @@ export function createListQueryStore<
       }
     }
 
+    // A full-invalidation marker is resolved once the item is fully reloaded
+    // ('*' again); until then it stays so late-mounting hooks keep refetching
+    // their own not-yet-reloaded fields.
+    for (const itemKey of itemsPendingFullInvalidation) {
+      if (store.state.itemLoadedFields[itemKey] === '*') {
+        itemsPendingFullInvalidation.delete(itemKey);
+      }
+    }
+
     for (const itemKey of itemFieldInvalidationPriorities.keys()) {
       const hasPendingStateInvalidation =
         !!store.state.itemFieldInvalidationFields[itemKey];
       const hasPendingTrackedInvalidation =
         (itemPendingInvalidationFields.get(itemKey)?.length ?? 0) > 0;
+      const hasPendingFullInvalidation =
+        itemsPendingFullInvalidation.has(itemKey);
 
-      if (!hasPendingStateInvalidation && !hasPendingTrackedInvalidation) {
+      if (
+        !hasPendingStateInvalidation &&
+        !hasPendingTrackedInvalidation &&
+        !hasPendingFullInvalidation
+      ) {
         itemFieldInvalidationPriorities.delete(itemKey);
       }
     }
@@ -2297,6 +2363,7 @@ export function createListQueryStore<
   function cleanupItemStateMetadata(itemKey: string): void {
     itemFieldInvalidationPriorities.delete(itemKey);
     itemPendingInvalidationFields.delete(itemKey);
+    itemsPendingFullInvalidation.delete(itemKey);
     itemInvalidationWasTriggered.delete(itemKey);
     itemCacheRuntime.clear(itemKey);
   }
@@ -2416,18 +2483,35 @@ export function createListQueryStore<
 
   function itemSnapshotSatisfiesRequestedFields(
     item: ItemState | null,
-    loadedFields: string[],
+    loadedFields: ItemLoadedFields | undefined,
     requestedFields: readonly string[] | undefined,
   ): boolean {
-    if (!partialResources || !requestedFields || requestedFields.length === 0) {
-      return true;
-    }
+    if (!partialResources) return true;
 
     if (item === null) return true;
+
+    // An explicit `[]` means the item is fully invalidated on the sender — the
+    // snapshot vouches for no field, so it must not cancel a pending fetch.
+    if (
+      loadedFields !== undefined &&
+      loadedFields !== '*' &&
+      loadedFields.length === 0
+    ) {
+      return false;
+    }
+
+    if (!requestedFields || requestedFields.length === 0) {
+      return snapshotIsFullyLoaded(
+        loadedFields,
+        item,
+        partialResources.inferFields,
+      );
+    }
 
     return fallbackItemHasRequestedFields(
       { item, loadedFields },
       requestedFields,
+      partialResources.inferFields,
     );
   }
 
@@ -2445,9 +2529,7 @@ export function createListQueryStore<
     }
 
     const requestedFields = request.payload.fields;
-    if (!partialResources || !requestedFields || requestedFields.length === 0) {
-      return true;
-    }
+    if (!partialResources) return true;
 
     const coveredItemKeys = message.query.items.slice(
       request.payload.offset,
@@ -2501,6 +2583,8 @@ export function createListQueryStore<
           );
 
           if (!message.itemQuery && message.item === null) {
+            // The item was deleted on the sender — drop all local metadata.
+            delete draft.itemLoadedFields[message.itemKey];
             delete draft.itemFieldInvalidationFields[message.itemKey];
 
             for (const query of Object.values(draft.queries)) {
@@ -2827,6 +2911,7 @@ export function createListQueryStore<
       queryInvalidationWasTriggered,
       itemFieldInvalidationPriorities,
       itemPendingInvalidationFields,
+      itemsPendingFullInvalidation,
       globalDisableRefetchOnMount,
       partialResources,
       derivedQueries,
@@ -2914,6 +2999,7 @@ export function createListQueryStore<
       itemInvalidationWasTriggered,
       itemFieldInvalidationPriorities,
       itemPendingInvalidationFields,
+      itemsPendingFullInvalidation,
       globalDisableRefetchOnMount,
       fetchItemFn,
       partialResources,

--- a/src/listQueryStore/types.ts
+++ b/src/listQueryStore/types.ts
@@ -41,6 +41,9 @@ export type TSDFItemQuery<ItemPayload extends ValidPayload> = {
   payload: ItemPayload;
 };
 
+/** Loaded partial-resource fields for one item, or `'*'` when fully loaded. */
+export type ItemLoadedFields = string[] | '*';
+
 /** Raw t-state shape used by a list-query store. */
 export type TSFDListQueryState<
   ItemState extends ValidStoreState,
@@ -54,7 +57,7 @@ export type TSFDListQueryState<
   /** Item query records keyed by item store key. */
   itemQueries: Record<string, TSDFItemQuery<ItemPayload> | null>;
   /** Loaded partial-resource fields for each item key. */
-  itemLoadedFields: Record<string, string[]>;
+  itemLoadedFields: Record<string, ItemLoadedFields>;
   /** Pending field invalidations for each item key. */
   itemFieldInvalidationFields: Record<string, string[]>;
 };
@@ -342,6 +345,11 @@ export type PartialResourcesConfig<ItemState extends ValidStoreState> = {
   mergeItems: (prev: ItemState | undefined, fetched: ItemState) => ItemState;
   /** Returns an item containing only the requested fields. */
   selectFields: (fields: string[], item: ItemState) => ItemState;
+  /**
+   * Infers which logical fields are present in an item snapshot when loaded
+   * field metadata is unavailable.
+   */
+  inferFields: (item: ItemState) => ItemLoadedFields;
 };
 
 export type DerivedQuerySummary<QueryPayload extends ValidPayload> = {

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -41,10 +41,15 @@ import {
 import {
   excludeLoadedFields,
   fallbackItemHasRequestedFields,
+  getFallbackMissingRequestedFields,
+  getStaleOrMissingRequestedFields,
+  hasFullyLoadedFields,
+  snapshotIsFullyLoaded,
 } from './itemFieldUtils';
 import type { ListQueryStoreEvents } from './listQueryStore';
 import {
   type FieldsInput,
+  type ItemLoadedFields,
   type ListQueryOfflineOverlay,
   type ListQueryUseMultipleItemsQuery,
   type PartialResourcesConfig,
@@ -131,13 +136,14 @@ export function useMultipleItems<
         | {
             item: ItemState | null | undefined;
             itemQuery: TSDFItemQuery<ItemPayload> | null | undefined;
-            loadedFields: string[] | undefined;
+            loadedFields: ItemLoadedFields | undefined;
           }
         | undefined)
     | undefined,
   itemInvalidationWasTriggered: Set<string>,
   itemFieldInvalidationPriorities: Map<string, FetchType>,
   itemPendingInvalidationFields: Map<string, string[]>,
+  itemsPendingFullInvalidation: Set<string>,
   globalDisableRefetchOnMount: boolean | undefined,
   fetchItemFn: unknown,
   partialResources: PartialResourcesConfig<ItemState> | undefined,
@@ -234,6 +240,12 @@ export function useMultipleItems<
   );
   const getUnresolvedPendingInvalidationFields = useCallback(
     (itemKey: string): string[] => {
+      const stateInvalidationFields =
+        store.state.itemFieldInvalidationFields[itemKey];
+      if (stateInvalidationFields && stateInvalidationFields.length > 0) {
+        return stateInvalidationFields;
+      }
+
       return excludeLoadedFields(
         store.state.itemLoadedFields[itemKey],
         itemPendingInvalidationFields.get(itemKey),
@@ -368,50 +380,75 @@ export function useMultipleItems<
             fields.length > 0 &&
             (status === 'success' || status === 'refetching')
           ) {
-            const missingFields = excludeLoadedFields(loadedFields, fields);
-            const hasMissingFields = missingFields.length > 0;
-            let missingFieldsAreAvailableInState = false;
+            // Fields genuinely absent from the snapshot: not tracked as loaded
+            // and not vouched by `inferFields`. This is the same signal the
+            // fetch effect uses, so a `loading` override here is always
+            // matched by a scheduled fetch (and vice versa: unvouched data is
+            // never exposed as `success`). Fields may be logical names, so raw
+            // key presence must not be used here.
+            const absentFields = getFallbackMissingRequestedFields(
+              { item: rawItemState, loadedFields },
+              fields,
+              partialResources.inferFields,
+            );
 
-            if (
-              hasMissingFields &&
-              rawItemState &&
-              typeof rawItemState === 'object'
-            ) {
-              const itemRecord =
-                // WORKAROUND: Partial-resource checks need indexed property access, but ItemState is generic and does not expose a string index signature.
-                __LEGIT_CAST__<Record<string, unknown>, ItemState>(
-                  rawItemState,
-                );
-
-              missingFieldsAreAvailableInState = missingFields.every(
-                (f) => f in itemRecord && itemRecord[f] !== undefined,
-              );
-            }
-
-            if (hasMissingFields && !missingFieldsAreAvailableInState) {
+            if (absentFields.length > 0) {
               status =
                 hasCachedDataInState && showPartialAsRefetching
                   ? 'refetching'
                   : 'loading';
             }
+          } else if (
+            partialResources &&
+            fields === '*' &&
+            (status === 'success' || status === 'refetching')
+          ) {
+            if (
+              !snapshotIsFullyLoaded(
+                loadedFields,
+                rawItemState,
+                partialResources.inferFields,
+              )
+            ) {
+              status =
+                hasCachedDataInState && showPartialAsRefetching
+                  ? 'refetching'
+                  : 'loading';
+            } else if (
+              itemFieldInvalidationFields &&
+              itemFieldInvalidationFields.length > 0
+            ) {
+              status = 'refetching';
+            }
           }
 
           if (partialResources && showPartialAsRefetching) {
             if (Array.isArray(fields) && fields.length > 0) {
-              const pendingRequestedFields = excludeLoadedFields(
+              // Same stale-or-missing signal the fetch effect uses: absent
+              // unvouched fields plus fields awaiting an invalidation
+              // re-fetch. Vouched metadata-free fields are NOT pending — no
+              // fetch will run for them.
+              const pendingRequestedFields = getStaleOrMissingRequestedFields(
+                itemKey,
                 loadedFields,
+                rawItemState,
                 fields,
+                partialResources.inferFields,
+                itemsPendingFullInvalidation,
+                getUnresolvedPendingInvalidationFields(itemKey),
               );
 
               if (pendingRequestedFields.length > 0) {
                 loadingFields = pendingRequestedFields;
               }
-            } else if (
-              fields === '*' &&
-              itemFieldInvalidationFields &&
-              itemFieldInvalidationFields.length > 0
-            ) {
-              loadingFields = itemFieldInvalidationFields;
+            } else if (fields === '*') {
+              if (
+                hasFullyLoadedFields(loadedFields) &&
+                itemFieldInvalidationFields &&
+                itemFieldInvalidationFields.length > 0
+              ) {
+                loadingFields = itemFieldInvalidationFields;
+              }
             }
           }
 
@@ -457,6 +494,8 @@ export function useMultipleItems<
     },
     [
       activeOfflineOverlays,
+      getUnresolvedPendingInvalidationFields,
+      itemsPendingFullInvalidation,
       loadFromStateOnly,
       offlineEntitiesByKey,
       partialResources,
@@ -474,15 +513,26 @@ export function useMultipleItems<
           partialResources && Array.isArray(fields) && fields.length > 0
             ? excludeLoadedFields(loadedFields, fields).sort()
             : [];
+        const needsFullFetch =
+          partialResources && fields === '*'
+            ? !snapshotIsFullyLoaded(
+                loadedFields,
+                state.items[itemKey],
+                partialResources.inferFields,
+              ) ||
+              (itemsPendingFullInvalidation.has(itemKey) &&
+                !hasFullyLoadedFields(loadedFields))
+            : false;
 
         return {
           status: itemQuery?.status ?? null,
           refetchOnMount: itemQuery?.refetchOnMount ?? null,
           missingRequestedFieldsKey: JSON.stringify(missingRequestedFields),
+          needsFullFetch,
         };
       });
     },
-    [partialResources, queriesWithId],
+    [itemsPendingFullInvalidation, partialResources, queriesWithId],
   );
 
   const storeState = store.useSelectorRC(resultSelector, {
@@ -512,8 +562,17 @@ export function useMultipleItems<
           const hasAllRequestedFallbackFields =
             !partialResources ||
             query.fields === undefined ||
-            query.fields === '*' ||
-            fallbackItemHasRequestedFields(fallbackItemState, query.fields);
+            (query.fields === '*'
+              ? snapshotIsFullyLoaded(
+                  fallbackItemState?.loadedFields,
+                  fallbackItemState?.item,
+                  partialResources.inferFields,
+                )
+              : fallbackItemHasRequestedFields(
+                  fallbackItemState,
+                  query.fields,
+                  partialResources.inferFields,
+                ));
 
           if (!hasAllRequestedFallbackFields) return result;
 
@@ -743,26 +802,67 @@ export function useMultipleItems<
         // For partial resources, check if all requested fields are loaded
         if (partialResources && !shouldFetch) {
           const loadedFields = store.state.itemLoadedFields[itemKey] ?? [];
+          const item = store.state.items[itemKey];
           const unresolvedPendingInvalidationFields =
             getUnresolvedPendingInvalidationFields(itemKey);
+          // A fully-loaded ('*') item that was fully invalidated has no field
+          // list to enumerate; this marker keeps hooks from trusting the stale
+          // snapshot until the item is fully reloaded ('*' again).
+          const hasUnresolvedFullInvalidation =
+            itemsPendingFullInvalidation.has(itemKey) &&
+            !hasFullyLoadedFields(loadedFields);
           const invalidationPriority =
-            unresolvedPendingInvalidationFields.length > 0
+            unresolvedPendingInvalidationFields.length > 0 ||
+            hasUnresolvedFullInvalidation
               ? itemFieldInvalidationPriorities.get(itemKey)
               : undefined;
 
           if (Array.isArray(fields) && fields.length > 0) {
-            const missingFields = excludeLoadedFields(loadedFields, fields);
+            const affectedInvalidationFields = fields.filter((field) =>
+              unresolvedPendingInvalidationFields.includes(field),
+            );
+            // Per-field stale-or-missing check: `inferFields` keeps vouching
+            // for unaffected fields even while other fields of the item have
+            // unresolved invalidations (stale pending fields are never
+            // vouched). Fields still tracked as loaded can only be stale, not
+            // missing — their refetch is handled by the invalidation path
+            // below (event handler for mounted hooks, mount-once gate for
+            // late-mounting ones), so they are excluded here to avoid
+            // re-scheduling them on every effect run.
+            const staleOrMissingFields = getStaleOrMissingRequestedFields(
+              itemKey,
+              loadedFields,
+              item,
+              fields,
+              partialResources.inferFields,
+              itemsPendingFullInvalidation,
+              unresolvedPendingInvalidationFields,
+            );
+            const missingFields =
+              loadedFields === '*'
+                ? []
+                : staleOrMissingFields.filter(
+                    (field) => !loadedFields.includes(field),
+                  );
             const hasMissingFields = missingFields.length > 0;
             const hasAffectedFieldInvalidation =
-              unresolvedPendingInvalidationFields.length > 0 &&
-              fields.some((field) =>
-                unresolvedPendingInvalidationFields.includes(field),
-              );
+              affectedInvalidationFields.length > 0;
+            // Pending invalidations no longer surface as missing fields for
+            // fully loaded ('*') items, so they must trigger the fetch here for
+            // hooks that mount after the invalidation happened.
+            const shouldFetchForInvalidation =
+              hasAffectedFieldInvalidation &&
+              !ignoreItemsInRefetchOnMount.has(itemKey);
 
-            if (hasMissingFields && !itemFetchIsActive) {
+            if (
+              (hasMissingFields || shouldFetchForInvalidation) &&
+              !itemFetchIsActive
+            ) {
               shouldFetch = true;
               requiredFetch = true;
-              fieldsToFetch = missingFields;
+              fieldsToFetch = Array.from(
+                new Set([...missingFields, ...affectedInvalidationFields]),
+              );
               // Low-priority follow-ups can be skipped while scheduler phase is still fetching.
               // Keep stronger priorities intact; only lift low priority.
               if (fetchType === 'lowPriority') {
@@ -778,22 +878,45 @@ export function useMultipleItems<
             ) {
               fetchType = invalidationPriority;
             }
-          } else if (
-            fields === '*' &&
-            unresolvedPendingInvalidationFields.length > 0 &&
-            !itemFetchIsActive &&
-            !ignoreItemsInRefetchOnMount.has(itemKey)
-          ) {
-            shouldFetch = true;
-            requiredFetch = true;
-            fieldsToFetch = unresolvedPendingInvalidationFields;
+          } else if (fields === '*') {
+            const missingFullItem =
+              !snapshotIsFullyLoaded(
+                loadedFields,
+                item,
+                partialResources.inferFields,
+              ) || hasUnresolvedFullInvalidation;
+            // Invalidation-only refetches (item still complete, some fields
+            // stale) are gated on the mount-once set, mirroring the array-field
+            // branch. A missing full item is not gated, so a hook mounting while
+            // another fetch is in flight still refetches once that fetch settles.
+            const shouldFetchForInvalidation =
+              !missingFullItem &&
+              unresolvedPendingInvalidationFields.length > 0 &&
+              !ignoreItemsInRefetchOnMount.has(itemKey);
 
             if (
-              invalidationPriority &&
-              fetchTypePriority[invalidationPriority] >
-                fetchTypePriority[fetchType]
+              (missingFullItem || shouldFetchForInvalidation) &&
+              !itemFetchIsActive
             ) {
-              fetchType = invalidationPriority;
+              shouldFetch = true;
+              requiredFetch = true;
+              fieldsToFetch = missingFullItem
+                ? '*'
+                : unresolvedPendingInvalidationFields;
+
+              // Low-priority follow-ups can be skipped while the scheduler phase
+              // is still fetching; lift a required full fetch to high priority.
+              if (fetchType === 'lowPriority') {
+                fetchType = 'highPriority';
+              }
+
+              if (
+                invalidationPriority &&
+                fetchTypePriority[invalidationPriority] >
+                  fetchTypePriority[fetchType]
+              ) {
+                fetchType = invalidationPriority;
+              }
             }
           }
         }
@@ -840,6 +963,7 @@ export function useMultipleItems<
     ignoreItemsInRefetchOnMount,
     itemFieldInvalidationPriorities,
     itemPendingInvalidationFields,
+    itemsPendingFullInvalidation,
     loadFromStateOnly,
     partialResources,
     preloadItems,

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -43,12 +43,17 @@ import {
 import {
   excludeLoadedFields,
   fallbackItemHasRequestedFields,
+  getFallbackMissingRequestedFields,
+  getStaleOrMissingRequestedFields,
+  snapshotIsFullyLoaded,
+  snapshotIsFullyLoadedAndFresh,
 } from './itemFieldUtils';
 import type { ListQueryStoreEvents } from './listQueryStore';
 import {
   type DerivedQueryContext,
   type DerivedQueriesConfig,
   type FieldsInput,
+  type ItemLoadedFields,
   type ListQueryOfflineOverlay,
   type ListQueryUseMultipleListQueriesQuery,
   type PartialResourcesConfig,
@@ -144,7 +149,7 @@ export function useMultipleListQueries<
         | {
             item: ItemState | null | undefined;
             itemQuery: TSDFItemQuery<ItemPayload> | null | undefined;
-            loadedFields: string[] | undefined;
+            loadedFields: ItemLoadedFields | undefined;
           }
         | undefined)
     | undefined,
@@ -157,6 +162,7 @@ export function useMultipleListQueries<
   queryInvalidationWasTriggered: Set<string>,
   itemFieldInvalidationPriorities: Map<string, FetchType>,
   itemPendingInvalidationFields: Map<string, string[]>,
+  itemsPendingFullInvalidation: Set<string>,
   globalDisableRefetchOnMount: boolean | undefined,
   partialResources: PartialResourcesConfig<ItemState> | undefined,
   derivedQueries:
@@ -389,6 +395,14 @@ export function useMultipleListQueries<
 
   const getUnresolvedPendingInvalidationFields = useCallback(
     (itemKey: string, state?: State): string[] => {
+      const itemFieldInvalidationFields = state
+        ? state.itemFieldInvalidationFields
+        : store.state.itemFieldInvalidationFields;
+      const stateInvalidationFields = itemFieldInvalidationFields[itemKey];
+      if (stateInvalidationFields && stateInvalidationFields.length > 0) {
+        return stateInvalidationFields;
+      }
+
       const itemLoadedFields = state
         ? state.itemLoadedFields
         : store.state.itemLoadedFields;
@@ -673,46 +687,126 @@ export function useMultipleListQueries<
             },
           );
 
+          // Partial-resource bookkeeping shared by the status override and the
+          // `loadingFields` computation below — computed at most once per query.
+          let staleOrMissingRequestedFields: Set<string> | undefined;
+          let hasAnyIncompleteItem = false;
+          let hasAnyStaleItem = false;
+          const statusCanBeOverridden =
+            status === 'success' || status === 'refetching';
+
+          if (
+            partialResources &&
+            (statusCanBeOverridden || showPartialAsRefetching)
+          ) {
+            if (Array.isArray(fields) && fields.length > 0) {
+              // Union of stale-or-missing requested fields across the query's
+              // items.
+              staleOrMissingRequestedFields = new Set();
+
+              for (const itemKey of effectiveQuery.query.items) {
+                for (const field of getStaleOrMissingRequestedFields(
+                  itemKey,
+                  state.itemLoadedFields[itemKey],
+                  state.items[itemKey],
+                  fields,
+                  partialResources.inferFields,
+                  itemsPendingFullInvalidation,
+                  getUnresolvedPendingInvalidationFields(itemKey, state),
+                )) {
+                  staleOrMissingRequestedFields.add(field);
+                }
+
+                // Stop scanning once no further field could be added — or on
+                // the first hit when the per-field breakdown is not needed.
+                if (
+                  staleOrMissingRequestedFields.size === fields.length ||
+                  (!showPartialAsRefetching &&
+                    staleOrMissingRequestedFields.size > 0)
+                ) {
+                  break;
+                }
+              }
+            } else if (fields === '*') {
+              // "Data absent" (incomplete snapshot) is different from
+              // "complete but stale" (e.g. after a full item invalidation):
+              // only genuinely incomplete items may hide the list behind
+              // `loading` — stale but complete items stay visible while they
+              // refetch. A full item invalidation resets `loadedFields` to
+              // `[]` but leaves the pending-full-invalidation marker, which
+              // proves the item data was complete when invalidated (and is
+              // still present).
+              hasAnyIncompleteItem = effectiveQuery.query.items.some(
+                (itemKey) => {
+                  const item = state.items[itemKey];
+                  if (
+                    snapshotIsFullyLoaded(
+                      state.itemLoadedFields[itemKey],
+                      item,
+                      partialResources.inferFields,
+                    )
+                  ) {
+                    return false;
+                  }
+
+                  return !(
+                    itemsPendingFullInvalidation.has(itemKey) && item != null
+                  );
+                },
+              );
+              hasAnyStaleItem =
+                !hasAnyIncompleteItem &&
+                effectiveQuery.query.items.some(
+                  (itemKey) =>
+                    !snapshotIsFullyLoadedAndFresh(
+                      itemKey,
+                      state.itemLoadedFields[itemKey],
+                      state.items[itemKey],
+                      partialResources.inferFields,
+                      itemsPendingFullInvalidation,
+                    ),
+                );
+            }
+          }
+
           // Override status when partial resources has items with missing fields
           if (
             partialResources &&
             Array.isArray(fields) &&
-            fields.length > 0 &&
-            (status === 'success' || status === 'refetching')
+            statusCanBeOverridden &&
+            staleOrMissingRequestedFields &&
+            staleOrMissingRequestedFields.size > 0
           ) {
-            const someItemMissingFields = effectiveQuery.query.items.some(
-              (itemKey) => {
-                const loadedFields = state.itemLoadedFields[itemKey] ?? [];
-                return fields.some((f) => !loadedFields.includes(f));
-              },
-            );
-            const someItemMissingFieldsInState =
-              effectiveQuery.query.items.some((itemKey) => {
-                const item = state.items[itemKey];
-                if (!item || typeof item !== 'object') return true;
-                const itemRecord =
-                  // WORKAROUND: Partial-resource checks need indexed property access, but ItemState is generic and does not expose a string index signature.
-                  __LEGIT_CAST__<Record<string, unknown>, ItemState>(item);
-                return fields.some(
-                  (f) => !(f in itemRecord) || itemRecord[f] === undefined,
-                );
-              });
+            // Some item genuinely lacks data for a requested field: not
+            // tracked as loaded and not vouched by `inferFields`. Fields may
+            // be logical names, so raw key presence must not be used here —
+            // this must agree with the fetch effect's decision.
+            const someItemMissingFieldDataInState =
+              effectiveQuery.query.items.some(
+                (itemKey) =>
+                  getFallbackMissingRequestedFields(
+                    {
+                      item: state.items[itemKey],
+                      loadedFields: state.itemLoadedFields[itemKey],
+                    },
+                    fields,
+                    partialResources.inferFields,
+                  ).length > 0,
+              );
 
-            if (someItemMissingFields) {
-              if (!hasCachedItemsInState) {
-                status = 'loading';
-              } else if (someItemMissingFieldsInState) {
-                status = showPartialAsRefetching ? 'refetching' : 'loading';
-              } else {
-                // Requested fields are present in cached items; keep stale data
-                // visible and expose a refetching status while metadata catches up.
-                status = 'refetching';
-              }
+            if (!hasCachedItemsInState) {
+              status = 'loading';
+            } else if (someItemMissingFieldDataInState) {
+              status = showPartialAsRefetching ? 'refetching' : 'loading';
+            } else {
+              // Requested fields are present in cached items; keep stale data
+              // visible and expose a refetching status while metadata catches up.
+              status = 'refetching';
             }
           } else if (
             partialResources &&
             fields === '*' &&
-            (status === 'success' || status === 'refetching')
+            statusCanBeOverridden
           ) {
             const hasAnyFieldInvalidation = effectiveQuery.query.items.some(
               (itemKey) => {
@@ -726,35 +820,42 @@ export function useMultipleListQueries<
               },
             );
 
-            if (hasAnyFieldInvalidation) {
+            if (hasAnyIncompleteItem) {
+              if (!hasCachedItemsInState) {
+                status = 'loading';
+              } else {
+                status = showPartialAsRefetching ? 'refetching' : 'loading';
+              }
+            } else if (hasAnyStaleItem || hasAnyFieldInvalidation) {
               status = 'refetching';
             }
           }
 
           if (partialResources && showPartialAsRefetching) {
             if (Array.isArray(fields) && fields.length > 0) {
-              const pendingRequestedFields = fields.filter((field) =>
+              const pendingRequestedFields =
                 status === 'loading' && effectiveQuery.query.items.length === 0
-                  ? true
-                  : effectiveQuery.query.items.some((itemKey) => {
-                      const loadedFields =
-                        state.itemLoadedFields[itemKey] ?? [];
-                      return !loadedFields.includes(field);
-                    }),
-              );
+                  ? [...fields]
+                  : fields.filter(
+                      (field) =>
+                        staleOrMissingRequestedFields?.has(field) ?? false,
+                    );
 
               if (pendingRequestedFields.length > 0) {
                 loadingFields = pendingRequestedFields;
               }
             } else if (fields === '*') {
-              const pendingInvalidationFields = Array.from(
-                new Set(
-                  effectiveQuery.query.items.flatMap(
-                    (itemKey) =>
-                      state.itemFieldInvalidationFields[itemKey] ?? [],
-                  ),
-                ),
-              ).sort();
+              const hasAnyPartialItem = hasAnyIncompleteItem || hasAnyStaleItem;
+              const pendingInvalidationFields = hasAnyPartialItem
+                ? []
+                : Array.from(
+                    new Set(
+                      effectiveQuery.query.items.flatMap(
+                        (itemKey) =>
+                          state.itemFieldInvalidationFields[itemKey] ?? [],
+                      ),
+                    ),
+                  ).sort();
 
               if (pendingInvalidationFields.length > 0) {
                 loadingFields = pendingInvalidationFields;
@@ -803,8 +904,10 @@ export function useMultipleListQueries<
       );
     },
     [
+      getUnresolvedPendingInvalidationFields,
       getVisibleQueryItemKeys,
       isOfflineMode,
+      itemsPendingFullInvalidation,
       offlineEntitiesByKey,
       partialResources,
       queriesWithId,
@@ -846,6 +949,7 @@ export function useMultipleListQueries<
             const requestedFields = Array.isArray(queryConfig.fields)
               ? queryConfig.fields
               : undefined;
+            const requiresFullItems = queryConfig.fields === '*';
             const fallbackItemStatesByKey = new Map<
               string,
               ReturnType<NonNullable<typeof readFallbackItemState>>
@@ -855,15 +959,30 @@ export function useMultipleListQueries<
               const fallbackItemState = readFallbackItemState(itemKey);
               fallbackItemStatesByKey.set(itemKey, fallbackItemState);
 
-              if (
-                requestedFields &&
-                partialResources &&
-                !fallbackItemHasRequestedFields(
-                  fallbackItemState,
-                  requestedFields,
-                )
-              ) {
-                return result;
+              if (partialResources) {
+                // A '*' query must not present a partial fallback snapshot as a
+                // fully-loaded success; require each item to be complete (or
+                // reported complete by `inferFields`).
+                if (requiresFullItems) {
+                  if (
+                    !snapshotIsFullyLoaded(
+                      fallbackItemState?.loadedFields,
+                      fallbackItemState?.item,
+                      partialResources.inferFields,
+                    )
+                  ) {
+                    return result;
+                  }
+                } else if (
+                  requestedFields &&
+                  !fallbackItemHasRequestedFields(
+                    fallbackItemState,
+                    requestedFields,
+                    partialResources.inferFields,
+                  )
+                ) {
+                  return result;
+                }
               }
             }
             const fallbackItems = selectVisibleItems(
@@ -953,9 +1072,14 @@ export function useMultipleListQueries<
             requestedFields && requestedFields.length > 0
               ? effectiveQuery.query.items
                   .flatMap((itemKey) => {
-                    return excludeLoadedFields(
+                    return getStaleOrMissingRequestedFields(
+                      itemKey,
                       state.itemLoadedFields[itemKey],
+                      state.items[itemKey],
                       requestedFields,
+                      partialResources.inferFields,
+                      itemsPendingFullInvalidation,
+                      getUnresolvedPendingInvalidationFields(itemKey, state),
                     );
                   })
                   .filter(
@@ -1006,6 +1130,7 @@ export function useMultipleListQueries<
       [
         getHighestPendingInvalidationPriority,
         getUnresolvedPendingInvalidationFields,
+        itemsPendingFullInvalidation,
         partialResources,
         queriesWithId,
         resolveEffectiveQuery,
@@ -1172,11 +1297,16 @@ export function useMultipleListQueries<
 
           if (Array.isArray(fields) && fields.length > 0) {
             const hasMissingRequestedFields = effectiveQueryState.items.some(
-              (itemKey) => {
-                const loadedFields =
-                  store.state.itemLoadedFields[itemKey] ?? [];
-                return fields.some((field) => !loadedFields.includes(field));
-              },
+              (itemKey) =>
+                getStaleOrMissingRequestedFields(
+                  itemKey,
+                  store.state.itemLoadedFields[itemKey],
+                  store.state.items[itemKey],
+                  fields,
+                  partialResources.inferFields,
+                  itemsPendingFullInvalidation,
+                  getUnresolvedPendingInvalidationFields(itemKey),
+                ).length > 0,
             );
 
             if (hasMissingRequestedFields && !isQueryFetchInFlight) {
@@ -1222,6 +1352,16 @@ export function useMultipleListQueries<
               }
             }
           } else if (fields === '*') {
+            const hasAnyPartialItem = effectiveQueryState.items.some(
+              (itemKey) =>
+                !snapshotIsFullyLoadedAndFresh(
+                  itemKey,
+                  store.state.itemLoadedFields[itemKey],
+                  store.state.items[itemKey],
+                  partialResources.inferFields,
+                  itemsPendingFullInvalidation,
+                ),
+            );
             const hasAnyFieldInvalidation = effectiveQueryState.items.some(
               (itemKey) => {
                 return (
@@ -1230,7 +1370,10 @@ export function useMultipleListQueries<
               },
             );
 
-            if (hasAnyFieldInvalidation && !isQueryFetchInFlight) {
+            if (
+              (hasAnyPartialItem || hasAnyFieldInvalidation) &&
+              !isQueryFetchInFlight
+            ) {
               shouldFetch = true;
               requiredFetch = true;
 
@@ -1301,6 +1444,7 @@ export function useMultipleListQueries<
     automaticRetryState,
     itemFieldInvalidationPriorities,
     itemPendingInvalidationFields,
+    itemsPendingFullInvalidation,
     getHighestPendingInvalidationPriority,
     getUnresolvedPendingInvalidationFields,
     stickyDerivedQueryKeys,

--- a/src/listQueryStore/usePendingOfflineItems.ts
+++ b/src/listQueryStore/usePendingOfflineItems.ts
@@ -13,6 +13,7 @@ import { shouldApplyOfflineOverlay } from '../persistentStorage/offline/entityMe
 import type { InternalGlobalOfflineEntity } from '../persistentStorage/offline/types';
 import { ValidPayload, ValidStoreState } from '../utils/storeShared';
 import type {
+  ItemLoadedFields,
   ListQueryOfflineOverlay,
   TSFDListQueryState,
   TSFDUsePendingOfflineItemsReturn,
@@ -54,7 +55,7 @@ export function usePendingOfflineItems<
         | {
             item: ItemState | null | undefined;
             itemQuery: { payload: ItemPayload } | null | undefined;
-            loadedFields: string[] | undefined;
+            loadedFields: ItemLoadedFields | undefined;
           }
         | undefined)
     | undefined,

--- a/src/persistentStorage/indexedDbAsyncStorageAdapter.ts
+++ b/src/persistentStorage/indexedDbAsyncStorageAdapter.ts
@@ -280,9 +280,7 @@ function mergeCustomMetadata(
 type IndexedDbEntryRecord = {
   a: number;
   d: unknown;
-  f?: string[];
   g?: string;
-  h?: 1;
   i: string;
   m?: Record<string, unknown>;
   o?: 1;
@@ -333,9 +331,7 @@ function toPublicMetadata(
 const INDEXED_DB_ENTRY_RECORD_KEYS = new Set([
   'a',
   'd',
-  'f',
   'g',
-  'h',
   'i',
   'm',
   'o',
@@ -445,7 +441,6 @@ function isValidEntryRecord(record: unknown): boolean {
     return false;
   }
 
-  const loadedFields = recordValue.f;
   return (
     typeof recordValue.i === 'string' &&
     typeof recordValue.a === 'number' &&
@@ -454,11 +449,7 @@ function isValidEntryRecord(record: unknown): boolean {
     (recordValue.z === undefined || typeof recordValue.z === 'number') &&
     (recordValue.m === undefined || isObject(recordValue.m)) &&
     (recordValue.g === undefined || typeof recordValue.g === 'string') &&
-    (recordValue.o === undefined || recordValue.o === 1) &&
-    (loadedFields === undefined ||
-      (loadedFields instanceof Array &&
-        loadedFields.every((value) => typeof value === 'string'))) &&
-    (recordValue.h === undefined || recordValue.h === 1)
+    (recordValue.o === undefined || recordValue.o === 1)
   );
 }
 
@@ -494,7 +485,7 @@ function getStaticPolicyFromScopeRecord(
 function compactEntryValue(
   scope: AsyncStorageNamespaceScope,
   value: unknown,
-): Pick<IndexedDbEntryRecord, 'd' | 'f' | 'h'> {
+): Pick<IndexedDbEntryRecord, 'd'> {
   void scope;
   return { d: value };
 }

--- a/src/persistentStorage/listQueryStorePersistence.ts
+++ b/src/persistentStorage/listQueryStorePersistence.ts
@@ -3,6 +3,7 @@ import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { type __LEGIT_ANY__ } from '@ls-stack/utils/saferTyping';
 import type { Store } from 't-state';
 import type {
+  ItemLoadedFields,
   TSDFItemQuery,
   TSFDListQuery,
   TSFDListQueryState,
@@ -129,7 +130,7 @@ type ManagedQueryEntry = {
 type ManagedQueryEntriesByKey = Map<string, ManagedQueryEntry>;
 type EntryNamespaceMetadata = { h?: true; p?: unknown };
 type ItemEntryNamespaceMetadata = EntryNamespaceMetadata & {
-  f?: string[];
+  f?: ItemLoadedFields;
   g?: unknown;
 };
 
@@ -144,16 +145,22 @@ function toItemState<
 ): {
   item: ItemState;
   itemQuery: TSDFItemQuery<ItemPayload>;
-  loadedFields: string[];
+  loadedFields: ItemLoadedFields | undefined;
 } | null {
   const validated = parsePersistedStoreData(persisted.data, dataSchema);
   if (validated === null) return null;
 
   if (shouldIgnoreItem(persisted.payload)) return null;
 
-  const loadedFields = Array.isArray(persisted.loadedFields)
-    ? Array.from(new Set(persisted.loadedFields)).sort()
-    : Object.keys(validated).sort();
+  // Entries persisted without loaded-field metadata (e.g. client-created items)
+  // keep it absent — `inferFields` governs such snapshots; field metadata is
+  // never fabricated from the snapshot's object keys.
+  const loadedFields =
+    persisted.loadedFields === '*'
+      ? '*'
+      : Array.isArray(persisted.loadedFields)
+        ? Array.from(new Set(persisted.loadedFields)).sort()
+        : undefined;
 
   return {
     item: validated,
@@ -214,7 +221,7 @@ type ListQueryPersistenceSetup<
     | {
         item: ItemState;
         itemQuery: TSDFItemQuery<ItemPayload>;
-        loadedFields: string[];
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined;
   readHydratedQuery(
@@ -322,7 +329,7 @@ export function setupListQueryPersistence<
             {
               data: value.d,
               payload: 'p' in value ? value.p : metadata?.p,
-              ...('lf' in value && Array.isArray(value.lf)
+              ...('lf' in value && (Array.isArray(value.lf) || value.lf === '*')
                 ? { loadedFields: value.lf }
                 : {}),
             },
@@ -340,9 +347,7 @@ export function setupListQueryPersistence<
             {
               data: value,
               payload: metadata.p,
-              ...(Array.isArray(metadata.f)
-                ? { loadedFields: metadata.f }
-                : {}),
+              ...(metadata.f !== undefined ? { loadedFields: metadata.f } : {}),
             },
             config.itemPayloadSchema,
             dataSchema,
@@ -392,7 +397,7 @@ export function setupListQueryPersistence<
     {
       asyncValueCodec: asyncItemStorageValueCodec,
       getManifestMeta: (data) => ({
-        ...(Array.isArray(data.loadedFields) ? { f: data.loadedFields } : {}),
+        ...(data.loadedFields !== undefined ? { f: data.loadedFields } : {}),
         p: data.payload,
       }),
       valueCodec: itemStorageValueCodec,
@@ -563,6 +568,21 @@ export function setupListQueryPersistence<
   const querySizeBytesByKey = new Map<string, number>();
   const hydratedPersistedItemKeys = new Set<string>();
   const hydratedPersistedQueryKeys = new Set<string>();
+  // Remembers in-state entries that lost their persistence slot to the byte
+  // budget, keyed by entry key. Without this memory a budget-evicted entry
+  // would re-enter the next flush as if it were freshly accessed (it has no
+  // persisted metadata anymore) and knock out a different survivor, making
+  // every flush churn remove/re-add writes while the state stays over budget.
+  // The snapshot lets a genuinely refetched entry (changed content) count as
+  // fresh again.
+  const budgetEvictedItemRecency = new Map<
+    string,
+    { lastAccessAt: number; snapshot: string }
+  >();
+  const budgetEvictedQueryRecency = new Map<
+    string,
+    { lastAccessAt: number; snapshot: string }
+  >();
   const syncHydrationItemMissCache = createTimedKeySet();
   const syncHydrationQueryMissCache = createTimedKeySet();
   let knownPersistedItemKeys: Set<string> | null = null;
@@ -1105,12 +1125,51 @@ export function setupListQueryPersistence<
     knownPersistedQueryKeys?.delete(queryKey);
   }
 
+  /**
+   * Resolves the recency an in-state entry without persisted metadata should
+   * compete with in the byte budget. Previously budget-evicted entries keep
+   * their remembered (stale) recency while their content is unchanged, so they
+   * deterministically lose again instead of churning back into storage; a
+   * changed snapshot means the entry was genuinely refetched and counts as
+   * freshly accessed.
+   */
+  function getBudgetEvictedLastAccessAt(
+    memory: Map<string, { lastAccessAt: number; snapshot: string }>,
+    key: string,
+    value: unknown,
+    fallback: number,
+  ): number {
+    const remembered = memory.get(key);
+    if (remembered === undefined) return fallback;
+    if (remembered.snapshot !== JSON.stringify(value)) {
+      memory.delete(key);
+      return fallback;
+    }
+    return remembered.lastAccessAt;
+  }
+
+  /**
+   * Remembers an entry evicted by the byte budget while it is still in state,
+   * so later flushes don't re-persist it as if it were freshly accessed (see
+   * budgetEvictedQueryRecency / budgetEvictedItemRecency).
+   */
+  function rememberBudgetEvictedEntry(
+    memory: Map<string, { lastAccessAt: number; snapshot: string }>,
+    key: string,
+    lastAccessAt: number,
+    snapshot: string | undefined,
+    isInState: boolean,
+  ): void {
+    if (!isInState || snapshot === undefined) return;
+    memory.set(key, { lastAccessAt, snapshot });
+  }
+
   function materializeHydratedItemState(
     itemKey: string,
     itemState: {
       item: ItemState;
       itemQuery: TSDFItemQuery<ItemPayload>;
-      loadedFields: string[];
+      loadedFields: ItemLoadedFields | undefined;
     },
   ): void {
     if (!storeRef) return;
@@ -1119,7 +1178,9 @@ export function setupListQueryPersistence<
     storeRef.produceState((draft) => {
       draft.items[itemKey] = itemState.item;
       draft.itemQueries[itemKey] = itemState.itemQuery;
-      draft.itemLoadedFields[itemKey] = itemState.loadedFields;
+      if (itemState.loadedFields !== undefined) {
+        draft.itemLoadedFields[itemKey] = itemState.loadedFields;
+      }
     });
   }
 
@@ -1141,7 +1202,7 @@ export function setupListQueryPersistence<
     | {
         item: ItemState;
         itemQuery: TSDFItemQuery<ItemPayload>;
-        loadedFields: string[];
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined {
     try {
@@ -1164,7 +1225,7 @@ export function setupListQueryPersistence<
     | {
         item: ItemState;
         itemQuery: TSDFItemQuery<ItemPayload>;
-        loadedFields: string[];
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined {
     const snapshot = itemSnapshotByKey.get(itemKey);
@@ -1184,7 +1245,7 @@ export function setupListQueryPersistence<
     | {
         item: ItemState;
         itemQuery: TSDFItemQuery<ItemPayload>;
-        loadedFields: string[];
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined {
     if (localStorageAdapter === null) return undefined;
@@ -1458,7 +1519,7 @@ export function setupListQueryPersistence<
     | {
         item: ItemState;
         itemQuery: TSDFItemQuery<ItemPayload>;
-        loadedFields: string[];
+        loadedFields: ItemLoadedFields | undefined;
       }
     | undefined {
     if (localStorageAdapter !== null) {
@@ -1529,12 +1590,10 @@ export function setupListQueryPersistence<
     if (!storeRef) return false;
     const existingItemQuery = storeRef.state.itemQueries[itemKey];
     const existingItem = storeRef.state.items[itemKey];
-    const existingLoadedFields = storeRef.state.itemLoadedFields[itemKey];
-    if (
-      existingItemQuery !== undefined &&
-      existingItem !== undefined &&
-      existingLoadedFields !== undefined
-    ) {
+    // `itemLoadedFields` is optional metadata (absent for items persisted
+    // without it, where `inferFields` governs), so state presence is judged by
+    // the item and its query alone.
+    if (existingItemQuery !== undefined && existingItem !== undefined) {
       return existingItemQuery !== null;
     }
     if (existingItemQuery === null) return false;
@@ -1579,12 +1638,7 @@ export function setupListQueryPersistence<
     for (const itemKey of [...new Set(itemKeys)]) {
       const existingItemQuery = storeRef.state.itemQueries[itemKey];
       const existingItem = storeRef.state.items[itemKey];
-      const existingLoadedFields = storeRef.state.itemLoadedFields[itemKey];
-      if (
-        existingItemQuery !== undefined &&
-        existingItem !== undefined &&
-        existingLoadedFields !== undefined
-      ) {
+      if (existingItemQuery !== undefined && existingItem !== undefined) {
         resultsByKey.set(itemKey, Promise.resolve(existingItemQuery !== null));
         continue;
       }
@@ -1934,8 +1988,16 @@ export function setupListQueryPersistence<
           .map(({ queryKey }) => removeLocalStorageQueryEntry(queryKey)),
       );
 
-      for (const { queryKey } of filteredEntries) {
+      for (const { queryKey, lastAccessAt } of filteredEntries) {
         if (!keptQueryKeys.has(queryKey)) {
+          rememberBudgetEvictedEntry(
+            budgetEvictedQueryRecency,
+            queryKey,
+            lastAccessAt,
+            querySnapshotByKey.get(queryKey),
+            storeRef !== null &&
+              Object.hasOwn(storeRef.state.queries, queryKey),
+          );
           forgetPersistedQuery(queryKey);
         }
       }
@@ -2009,6 +2071,13 @@ export function setupListQueryPersistence<
     for (const entry of validEntries) {
       const { queryKey } = entry;
       if (!keptQueryKeys.has(queryKey)) {
+        rememberBudgetEvictedEntry(
+          budgetEvictedQueryRecency,
+          queryKey,
+          entry.lastAccessAt,
+          querySnapshotByKey.get(queryKey),
+          storeRef !== null && Object.hasOwn(storeRef.state.queries, queryKey),
+        );
         forgetPersistedQuery(queryKey);
       }
     }
@@ -2119,8 +2188,15 @@ export function setupListQueryPersistence<
             return itemNamespace.remove(itemKey);
           }),
       );
-      for (const { itemKey } of persistedItemEntries) {
+      for (const { itemKey, lastAccessAt } of persistedItemEntries) {
         if (!keptItemKeys.has(itemKey)) {
+          rememberBudgetEvictedEntry(
+            budgetEvictedItemRecency,
+            itemKey,
+            lastAccessAt,
+            itemSnapshotByKey.get(itemKey),
+            storeRef !== null && storeRef.state.items[itemKey] != null,
+          );
           forgetPersistedItem(itemKey);
         }
       }
@@ -2249,8 +2325,15 @@ export function setupListQueryPersistence<
         .filter(({ itemKey }) => !keptItemKeys.has(itemKey))
         .map(({ itemKey }) => itemNamespace.remove(itemKey)),
     );
-    for (const { itemKey } of persistedItemEntries) {
+    for (const { itemKey, lastAccessAt } of persistedItemEntries) {
       if (!keptItemKeys.has(itemKey)) {
+        rememberBudgetEvictedEntry(
+          budgetEvictedItemRecency,
+          itemKey,
+          lastAccessAt,
+          itemSnapshotByKey.get(itemKey),
+          storeRef !== null && storeRef.state.items[itemKey] != null,
+        );
         forgetPersistedItem(itemKey);
       }
     }
@@ -2398,13 +2481,29 @@ export function setupListQueryPersistence<
           persistedQueryItemKeys.add(itemKey);
         }
 
-        nextQueryKeys.add(queryKey);
         const nextValue = {
           payload: query.payload,
           items: limitedQuery.itemKeys,
           hasMore: limitedQuery.hasMore,
         };
         const nextSnapshot = JSON.stringify(nextValue);
+
+        if (!previousKnownLocalQueryKeys.has(queryKey)) {
+          const evictedRecency = budgetEvictedQueryRecency.get(queryKey);
+          if (evictedRecency !== undefined) {
+            if (evictedRecency.snapshot === nextSnapshot) {
+              // This query lost its storage slot to the byte budget and its
+              // content hasn't changed since: keep it out of storage instead
+              // of churning it back in (a re-save would look freshly accessed
+              // and knock out a fresher survivor in the next maintenance).
+              continue;
+            }
+            // Content changed since the eviction: treat it as fresh again.
+            budgetEvictedQueryRecency.delete(queryKey);
+          }
+        }
+
+        nextQueryKeys.add(queryKey);
         if (
           querySnapshotByKey.get(queryKey) === nextSnapshot &&
           previousKnownLocalQueryKeys.has(queryKey)
@@ -2439,6 +2538,7 @@ export function setupListQueryPersistence<
       }
 
       for (const [itemKey, item] of itemEntries) {
+        const hasItemInState = Object.hasOwn(state.items, itemKey);
         const hasItemQueryInState = Object.hasOwn(state.itemQueries, itemKey);
         const hasLoadedFieldsInState = Object.hasOwn(
           state.itemLoadedFields,
@@ -2451,7 +2551,12 @@ export function setupListQueryPersistence<
         const itemQuery = hasItemQueryInState
           ? state.itemQueries[itemKey]
           : hydratedItem?.itemQuery;
-        const loadedFields = hasLoadedFieldsInState
+        // For in-state items loadedFields must come exclusively from state: a
+        // missing state entry is a deliberate "no metadata, inferFields
+        // governs" marker (e.g. after a mutation rollback) and must not be
+        // resurrected from the previously persisted snapshot. The hydrated
+        // fallback only applies to items that are not in state at all.
+        const loadedFields = hasItemInState
           ? state.itemLoadedFields[itemKey]
           : hydratedItem?.loadedFields;
 
@@ -2496,6 +2601,23 @@ export function setupListQueryPersistence<
           loadedFields,
         };
         const nextSnapshot = JSON.stringify(nextValue);
+
+        if (!previousKnownLocalItemKeys.has(itemKey)) {
+          const evictedRecency = budgetEvictedItemRecency.get(itemKey);
+          if (evictedRecency !== undefined) {
+            if (evictedRecency.snapshot === nextSnapshot) {
+              // This item lost its storage slot to the byte budget and its
+              // content hasn't changed since: keep it out of storage instead
+              // of churning it back in (a re-save would look freshly accessed
+              // and knock out a fresher survivor in the next maintenance).
+              nextItemKeys.delete(itemKey);
+              continue;
+            }
+            // Content changed since the eviction: treat it as fresh again.
+            budgetEvictedItemRecency.delete(itemKey);
+          }
+        }
+
         if (
           itemSnapshotByKey.get(itemKey) === nextSnapshot &&
           previousKnownLocalItemKeys.has(itemKey)
@@ -2537,6 +2659,25 @@ export function setupListQueryPersistence<
         tasks.push(itemNamespace.remove(itemKey));
         forgetPersistedItem(itemKey);
         removedItemKeys.add(itemKey);
+      }
+
+      // Removing persisted entries may have freed budget room, so let
+      // previously budget-evicted entries compete for a slot again on the
+      // next flush + maintenance pass.
+      if (removedQueryKeys.size > 0) budgetEvictedQueryRecency.clear();
+      if (removedItemKeys.size > 0) budgetEvictedItemRecency.clear();
+
+      // Drop eviction memory for entries that left the state entirely; they
+      // are no longer candidates for persistence.
+      for (const queryKey of budgetEvictedQueryRecency.keys()) {
+        if (!Object.hasOwn(state.queries, queryKey)) {
+          budgetEvictedQueryRecency.delete(queryKey);
+        }
+      }
+      for (const itemKey of budgetEvictedItemRecency.keys()) {
+        if (state.items[itemKey] == null) {
+          budgetEvictedItemRecency.delete(itemKey);
+        }
       }
 
       await Promise.all(tasks);
@@ -2711,17 +2852,34 @@ export function setupListQueryPersistence<
       });
     }
 
+    const inStateQueryLastAccessAt = new Map<string, number>();
     for (const [queryKey, queryData] of finalQueryDataByKey) {
+      const existingMetadata = metadataByKey.get(queryKey);
+      // In-state queries compete for the byte budget with their real persisted
+      // recency (like items do); only genuinely new queries count as accessed
+      // now. Otherwise every in-state query would tie at commitTimestamp and a
+      // freshly fetched query could lose its slot to stale ones. Previously
+      // budget-evicted queries keep their remembered recency so they don't
+      // churn back in as if they were fresh.
+      const lastAccessAt =
+        existingMetadata?.lastAccessAt ??
+        getBudgetEvictedLastAccessAt(
+          budgetEvictedQueryRecency,
+          queryKey,
+          queryData,
+          commitTimestamp,
+        );
+      inStateQueryLastAccessAt.set(queryKey, lastAccessAt);
       const sizeBytes = estimateAsyncQueryEntrySizeBytes({
-        currentCustomMetadata: metadataByKey.get(queryKey)?.customMetadata,
-        lastAccessAt: commitTimestamp,
+        currentCustomMetadata: existingMetadata?.customMetadata,
+        lastAccessAt,
         protectedKeysSnapshotSet: protectedRefs,
         queryKey,
         value: queryData,
       });
       finalQuerySizeBytesByKey.set(queryKey, sizeBytes);
       candidateEntries.push({
-        lastAccessAt: commitTimestamp,
+        lastAccessAt,
         offlineProtected:
           protectedQueryKeys.has(queryKey) ||
           protectedRefs?.has(
@@ -2757,6 +2915,16 @@ export function setupListQueryPersistence<
     finalPersistedQueryKeys.clear();
     for (const queryKey of keptQueryKeys) {
       finalPersistedQueryKeys.add(queryKey);
+      budgetEvictedQueryRecency.delete(queryKey);
+    }
+
+    // Drop eviction memory for queries that are no longer in state — they no
+    // longer compete for the budget (evicted-this-flush keys are still in
+    // finalQueryDataByKey here, so their memory is preserved).
+    for (const queryKey of budgetEvictedQueryRecency.keys()) {
+      if (!finalQueryDataByKey.has(queryKey)) {
+        budgetEvictedQueryRecency.delete(queryKey);
+      }
     }
 
     const evictedQueryKeys: string[] = [];
@@ -2766,6 +2934,16 @@ export function setupListQueryPersistence<
       }
     }
     for (const queryKey of evictedQueryKeys) {
+      const queryData = finalQueryDataByKey.get(queryKey);
+      if (queryData !== undefined) {
+        // Remember the recency this in-state query competed (and lost) with,
+        // so later flushes don't treat it as freshly accessed.
+        budgetEvictedQueryRecency.set(queryKey, {
+          lastAccessAt:
+            inStateQueryLastAccessAt.get(queryKey) ?? commitTimestamp,
+          snapshot: JSON.stringify(queryData),
+        });
+      }
       finalQueryDataByKey.delete(queryKey);
     }
 
@@ -2786,6 +2964,7 @@ export function setupListQueryPersistence<
     const finalPersistedItemKeys = new Set(previousKnownLocalItemKeys);
 
     for (const [itemKey, item] of itemEntries) {
+      const hasItemInState = Object.hasOwn(state.items, itemKey);
       const hasItemQueryInState = Object.hasOwn(state.itemQueries, itemKey);
       const hasLoadedFieldsInState = Object.hasOwn(
         state.itemLoadedFields,
@@ -2798,7 +2977,12 @@ export function setupListQueryPersistence<
       const itemQuery = hasItemQueryInState
         ? state.itemQueries[itemKey]
         : hydratedItem?.itemQuery;
-      const loadedFields = hasLoadedFieldsInState
+      // For in-state items loadedFields must come exclusively from state: a
+      // missing state entry is a deliberate "no metadata, inferFields
+      // governs" marker (e.g. after a mutation rollback) and must not be
+      // resurrected from the previously persisted snapshot. The hydrated
+      // fallback only applies to items that are not in state at all.
+      const loadedFields = hasItemInState
         ? state.itemLoadedFields[itemKey]
         : hydratedItem?.loadedFields;
 
@@ -2830,7 +3014,7 @@ export function setupListQueryPersistence<
       };
       finalItemDataByKey.set(itemKey, {
         metadata: {
-          ...(Array.isArray(loadedFields) ? { f: loadedFields } : {}),
+          ...(loadedFields !== undefined ? { f: loadedFields } : {}),
           p: itemQuery.payload,
           ...(getItemDerivedGroup
             ? { g: getItemDerivedGroup(item, itemQuery.payload) }
@@ -2886,12 +3070,25 @@ export function setupListQueryPersistence<
       });
     }
 
+    const inStateItemLastAccessAt = new Map<string, number>();
     for (const [itemKey, entry] of finalItemDataByKey) {
       const existingMetadata = itemMetadataByKey.get(itemKey);
+      // Same recency rules as queries: previously budget-evicted in-state
+      // items keep their remembered recency instead of counting as freshly
+      // accessed, so they don't churn back into storage on every flush.
+      const lastAccessAt =
+        existingMetadata?.lastAccessAt ??
+        getBudgetEvictedLastAccessAt(
+          budgetEvictedItemRecency,
+          itemKey,
+          entry.value,
+          itemCommitTimestamp,
+        );
+      inStateItemLastAccessAt.set(itemKey, lastAccessAt);
       const sizeBytes = estimateAsyncItemEntrySizeBytes({
         currentCustomMetadata: existingMetadata?.customMetadata,
         itemKey,
-        lastAccessAt: existingMetadata?.lastAccessAt ?? itemCommitTimestamp,
+        lastAccessAt,
         nextCustomMetadata: entry.metadata,
         protectedKeysSnapshotSet: protectedRefs,
         value: entry.value,
@@ -2899,7 +3096,7 @@ export function setupListQueryPersistence<
       finalItemSizeBytesByKey.set(itemKey, sizeBytes);
       itemCandidateEntries.push({
         itemKey,
-        lastAccessAt: existingMetadata?.lastAccessAt ?? itemCommitTimestamp,
+        lastAccessAt,
         offlineProtected:
           protectedItemKeys.has(itemKey) ||
           protectedRefs?.has(
@@ -2934,6 +3131,15 @@ export function setupListQueryPersistence<
     finalPersistedItemKeys.clear();
     for (const itemKey of keptItemKeys) {
       finalPersistedItemKeys.add(itemKey);
+      budgetEvictedItemRecency.delete(itemKey);
+    }
+
+    // Drop eviction memory for items that are no longer in state (see the
+    // matching query sweep above).
+    for (const itemKey of budgetEvictedItemRecency.keys()) {
+      if (!finalItemDataByKey.has(itemKey)) {
+        budgetEvictedItemRecency.delete(itemKey);
+      }
     }
 
     const evictedItemKeys: string[] = [];
@@ -2943,6 +3149,14 @@ export function setupListQueryPersistence<
       }
     }
     for (const itemKey of evictedItemKeys) {
+      const entry = finalItemDataByKey.get(itemKey);
+      if (entry !== undefined) {
+        budgetEvictedItemRecency.set(itemKey, {
+          lastAccessAt:
+            inStateItemLastAccessAt.get(itemKey) ?? itemCommitTimestamp,
+          snapshot: JSON.stringify(entry.value),
+        });
+      }
       finalItemDataByKey.delete(itemKey);
     }
 
@@ -3163,6 +3377,8 @@ export function setupListQueryPersistence<
     querySnapshotByKey.clear();
     itemSizeBytesByKey.clear();
     querySizeBytesByKey.clear();
+    budgetEvictedItemRecency.clear();
+    budgetEvictedQueryRecency.clear();
     hydratedPersistedItemKeys.clear();
     hydratedPersistedQueryKeys.clear();
     syncHydrationItemMissCache.clearAll();

--- a/src/persistentStorage/parsePersistedData.ts
+++ b/src/persistentStorage/parsePersistedData.ts
@@ -3,10 +3,13 @@ import {
   rc_boolean,
   rc_object,
   rc_parse,
+  rc_literals,
   rc_string,
+  rc_union,
   rc_unknown,
   type RcType,
 } from 'runcheck';
+import type { ItemLoadedFields } from '../listQueryStore/types';
 import type { ValidPayload } from '../utils/storeShared';
 import type {
   ConvertedPersistentStorageDataSchema,
@@ -25,7 +28,7 @@ const persistedCollectionItemDataSchema = rc_object({
 const persistedListQueryItemDataSchema = rc_object({
   data: rc_unknown,
   payload: rc_unknown,
-  loadedFields: rc_array(rc_string).optional(),
+  loadedFields: rc_union(rc_array(rc_string), rc_literals('*')).optional(),
 });
 
 const persistedListQueryDataSchema = rc_object({
@@ -208,7 +211,7 @@ export function parsePersistedCollectionItemData<
 export type ParsedTypedPersistedListQueryItemData<
   ItemPayload extends ValidPayload,
   TData,
-> = { data: TData; payload: ItemPayload; loadedFields?: string[] };
+> = { data: TData; payload: ItemPayload; loadedFields?: ItemLoadedFields };
 
 export type ParsedPersistedListQueryItemData<ItemPayload extends ValidPayload> =
   ParsedTypedPersistedListQueryItemData<ItemPayload, unknown>;

--- a/src/persistentStorage/types.ts
+++ b/src/persistentStorage/types.ts
@@ -2,6 +2,7 @@ import type { __LEGIT_ANY__ } from '@ls-stack/utils/saferTyping';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { type RcType } from 'runcheck';
 import type { TSDFDebugLogger } from '../debug';
+import type { ItemLoadedFields } from '../listQueryStore/types';
 import type { ValidPayload, ValidStoreState } from '../utils/storeShared';
 import type {
   AnyOfflineOperationDefinition,
@@ -620,8 +621,12 @@ export type PersistedListQueryItemData<State> = {
   data: State;
   /** Payload stored to validate and rehydrate item queries. */
   payload: unknown;
-  /** Optional list of selected fields that were loaded from the query result. */
-  loadedFields?: string[];
+  /**
+   * Loaded-fields metadata for the item: a list of selected fields that were
+   * loaded, or `'*'` when the item is fully loaded. Absent when the item has
+   * no loaded-fields metadata (`inferFields` governs such snapshots).
+   */
+  loadedFields?: ItemLoadedFields;
 };
 
 /** Shape of a single persisted list query entry. */

--- a/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
+++ b/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
@@ -1116,6 +1116,7 @@ test('list query partial-resources remote snapshots clear satisfied local invali
     });
     const full = envB.apiStore.useItem('users||1', {
       returnRefetchingStatus: true,
+      showPartialAsRefetching: true,
       disableRefetches: true,
       fields: '*',
     });
@@ -1128,8 +1129,9 @@ test('list query partial-resources remote snapshots clear satisfied local invali
   });
   await advanceTime(0);
 
-  // Before tab A refetches, unaffected hooks should stay readable and the full
-  // hook should continue exposing the cached object instead of dropping to loading.
+  // Before tab A refetches, unaffected field hooks should stay readable. The
+  // full hook should keep cached data visible, but cannot claim success from a
+  // field-list cache entry.
   expect(pick(envBHooks.result.current.name, ['status', 'data']))
     .toMatchInlineSnapshot(`
       data: { name: 'Alice' }
@@ -1143,7 +1145,7 @@ test('list query partial-resources remote snapshots clear satisfied local invali
   expect(pick(envBHooks.result.current.full, ['status', 'data']))
     .toMatchInlineSnapshot(`
       data: { age: 30, name: 'Alice' }
-      status: 'success'
+      status: 'refetching'
     `);
 
   envA.serverTable.setItem('users||1', { id: 1, name: 'Alice', age: 31 });
@@ -1174,7 +1176,7 @@ test('list query partial-resources remote snapshots clear satisfied local invali
   expect(pick(envBHooks.result.current.full, ['status', 'data']))
     .toMatchInlineSnapshot(`
       data: { age: 31, name: 'Alice' }
-      status: 'success'
+      status: 'refetching'
     `);
   expect(envB.timelineString).toMatchInlineSnapshot(`
     "
@@ -1186,6 +1188,25 @@ test('list query partial-resources remote snapshots clear satisfied local invali
     .     | 31       | Alice:31  | Alice     | [age-hook, full-hook] ui-changed
     "
   `);
+
+  void envA.apiStore.scheduleItemFetch('highPriority', 'users||1', {
+    fields: '*',
+  });
+  await flushAllTimers();
+
+  // A real full-resource sibling snapshot is still allowed to satisfy the full
+  // hook and records the full-loaded sentinel.
+  expect(envB.store.state.itemLoadedFields[itemKey]).toMatchInlineSnapshot(
+    `"*"`,
+  );
+  expect(countFetchHistoryEntries(envB.serverTable.fetchHistory, 'fetch')).toBe(
+    1,
+  );
+  expect(pick(envBHooks.result.current.full, ['status', 'data']))
+    .toMatchInlineSnapshot(`
+      data: { age: 31, id: 1, name: 'Alice' }
+      status: 'success'
+    `);
 });
 
 // review below this
@@ -1734,4 +1755,89 @@ test('item deletion on one tab cleans up partial-resource field metadata on sibl
     envB.store.state.itemFieldInvalidationFields[itemKeyB],
   ).toBeUndefined();
   expect(envB.store.state.queries[queryKeyB]?.items).not.toContain(itemKeyB);
+});
+
+test('a mutation snapshot sent while the sender is fully invalidated does not erase sibling field metadata', async () => {
+  const { envA, envB } = createEnvs({
+    storeId: 'list-query-partial-full-invalidation-mutation-snapshot',
+    data: { users: [{ id: 1, name: 'Alice', age: 30 }] },
+    focusedTab: 'a',
+  });
+
+  // Both tabs fully load the item ('*').
+  renderHook(() => {
+    const item = envA.apiStore.useItem('users||1', {
+      returnRefetchingStatus: true,
+      fields: '*',
+    });
+
+    envA.trackItemUI('full-hook', getTrackedUserSummary(item.data));
+    return item;
+  });
+  await flushAllTimers();
+
+  const envBHook = renderHook(() => {
+    const item = envB.apiStore.useItem('users||1', {
+      returnRefetchingStatus: true,
+      fields: '*',
+    });
+
+    envB.trackItemUI('full-hook', getTrackedUserSummary(item.data));
+    envB.trackItemUI('full-hook-status', item.status);
+    return item;
+  });
+  await flushAllTimers();
+
+  const itemKeyB = envB.getStoreItemKeyFromRaw('users||1');
+  expect(envB.store.state.itemLoadedFields[itemKeyB]).toBe('*');
+  const envBFetchCountBeforeInvalidation = countFetchHistoryEntries(
+    envB.serverTable.fetchHistory,
+    'fetch',
+  );
+  expect(envBFetchCountBeforeInvalidation).toBe(1);
+  envB.clearTimeline();
+
+  // Tab A fully invalidates the item (local only — invalidations are not
+  // broadcast). Its local `itemLoadedFields` is reset to `[]` while its
+  // mounted hook refetches.
+  act(() => {
+    envA.apiStore.invalidateItem('users||1');
+  });
+  // The '*' refetch is now in flight on tab A (800ms). Before it lands, tab A
+  // performs a client mutation, whose optimistic + confirmed item snapshots
+  // are published while tab A's loaded-fields metadata is still `[]`.
+  await advanceTime(100);
+  const mutationPromise = envA.performClientItemUpdateAction(
+    'users||1',
+    { age: 31 },
+    { withOptimisticUpdate: true },
+  );
+  await flushAllTimers();
+  await mutationPromise;
+  // Let any snapshot published at mutation settlement reach tab B as well.
+  await flushAllTimers();
+
+  // Tab B's own '*' metadata must survive those snapshots: the sender's `[]`
+  // vouches for nothing but says nothing about what the receiver has loaded.
+  // Previously the `[]` on the wire erased tab B's metadata, blanking the
+  // mounted '*' hook to loading and scheduling a duplicate fetch.
+  expect(envB.store.state.itemLoadedFields[itemKeyB]).toBe('*');
+  expect(countFetchHistoryEntries(envB.serverTable.fetchHistory, 'fetch')).toBe(
+    envBFetchCountBeforeInvalidation,
+  );
+  expect(pick(envBHook.result.current, ['status', 'data']))
+    .toMatchInlineSnapshot(`
+      data: { age: 31, id: 1, name: 'Alice' }
+      status: 'success'
+    `);
+  // The timeline shows tab B only consumes incoming snapshots — the status
+  // never leaves success and no local fetch is started.
+  expect(envB.timelineString).toMatchInlineSnapshot(`
+    "
+    time  | full-hook | full-hook-status |
+    4.62s | Alice:30  | success          | -- timeline-cleared
+    4.72s | Alice:30  | success          | [users||1] <optimistic-item-snapshot-received (value: {"id":1,"name":"Alice","age":31})
+    .     | Alice:31  | success          | [full-hook] ui-changed
+    "
+  `);
 });

--- a/tests/browser-tabs/browser-tabs-test-helpers.ts
+++ b/tests/browser-tabs/browser-tabs-test-helpers.ts
@@ -188,6 +188,10 @@ export const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 export function getPublisherTabIds(

--- a/tests/hooks/list-query-pending-offline-items.test.tsx
+++ b/tests/hooks/list-query-pending-offline-items.test.tsx
@@ -348,6 +348,9 @@ test('usePendingOfflineItems can opt resolution-required visible items back in',
   });
   await flushAllTimers();
 
+  // The opt-in hook shows the item's in-memory optimistic value ('Ada
+  // conflict'), not the persisted base snapshot ('Ada') — a storage preload
+  // must never clobber newer in-memory state with the persisted copy.
   expect(hook.result.current).toMatchInlineSnapshot(`
     defaultPending:
       deletedItems: []
@@ -355,7 +358,7 @@ test('usePendingOfflineItems can opt resolution-required visible items back in',
 
     includeResolutionRequired:
       deletedItems: []
-      items: ['Ada']
+      items: ['Ada conflict']
   `);
 });
 

--- a/tests/list-query-features/list-query-derived-queries.test.tsx
+++ b/tests/list-query-features/list-query-derived-queries.test.tsx
@@ -50,6 +50,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 const rowSchema = __LEGIT_CAST__<PersistentStorageSchema<Row>, unknown>(

--- a/tests/list-query-features/list-query-partial-resources-2.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-2.test.ts
@@ -35,6 +35,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 const initialServerData: Tables = {

--- a/tests/list-query-features/list-query-partial-resources-3.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-3.test.ts
@@ -40,6 +40,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 const initialServerData: Tables = {

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -1,0 +1,965 @@
+import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
+import { createLoggerStore } from '@ls-stack/utils/testUtils';
+import '@testing-library/react/dont-cleanup-after-each';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import type { ItemLoadedFields } from '../../src/listQueryStore/types';
+import type { PartialResourcesConfig } from '../../src/listQueryStore/types';
+import {
+  createListQueryStoreTestEnv,
+  type Row,
+  type Tables,
+} from '../mocks/listQueryStoreTestEnv';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import { advanceTime, flushAllTimers, range } from '../utils/genericTestUtils';
+
+const mergeAndSelect = {
+  mergeItems: (prev: Row | undefined, fetched: Row) => {
+    if (!prev) return fetched;
+    return { ...prev, ...fetched };
+  },
+  selectFields: (fields: readonly string[], item: Row) => {
+    const result: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (field in item) {
+        result[field] = item[field];
+      }
+    }
+    return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
+  },
+} satisfies Pick<PartialResourcesConfig<Row>, 'mergeItems' | 'selectFields'>;
+
+const ALL_FIELDS = ['id', 'name', 'address', 'age', 'country'] as const;
+
+/** `inferFields` that reports the concrete list of defined fields (never `'*'`). */
+const listInferFieldsConfig: PartialResourcesConfig<Row> = {
+  ...mergeAndSelect,
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
+};
+
+/**
+ * `inferFields` that returns the `'*'` sentinel once every field is present —
+ * the shape the docs describe for manually inserted / offline / persisted rows.
+ */
+const starInferFieldsConfig: PartialResourcesConfig<Row> = {
+  ...mergeAndSelect,
+  inferFields: (item): ItemLoadedFields => {
+    const isComplete = ALL_FIELDS.every((field) => item[field] !== undefined);
+    if (isComplete) return '*';
+    return Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field);
+  },
+};
+
+const initialServerData: Tables = {
+  users: range(1, 5).map((id) => ({
+    id,
+    name: `User ${id}`,
+    address: `Address ${id}`,
+    age: id * 10,
+    country: `Country ${id}`,
+  })),
+};
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+beforeEach(() => {
+  vi.setSystemTime(TEST_INITIAL_TIME);
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+});
+
+afterAll(() => {
+  cleanup();
+});
+
+describe('partial resources: full invalidation of a fully-loaded item', () => {
+  // Finding 1 (P1): a full `invalidateItem` on a `'*'`-loaded item must keep
+  // *every* mounted field hook obligated to refetch. Only one hook actually
+  // schedules the refetch (deduplicated via the shared invalidation trigger
+  // set); the rest rely on the durable full-invalidation marker so they don't
+  // keep trusting the now-stale snapshot via `inferFields`.
+  test('all mounted field hooks refetch their own fields after a full invalidation', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // Fully load the item ('*') without keeping a '*' hook mounted, so the
+    // refetch obligation can only be satisfied by the array-field hooks below.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await preload;
+
+    // Two independent hooks each read a different field from the '*' snapshot.
+    const { result } = renderHook(() => {
+      const nameHook = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['name'],
+      });
+      const addressHook = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      });
+
+      return { name: nameHook, address: addressHook };
+    });
+
+    await flushAllTimers();
+
+    // Both hooks see the loaded data as success (no fetch needed yet).
+    expect(result.current.name.status).toBe('success');
+    expect(result.current.address.status).toBe('success');
+
+    // Server data changes for both fields, then the whole item is invalidated.
+    env.serverTable.updateItem('users||1', {
+      name: 'Renamed User 1',
+      address: 'Relocated Address 1',
+    });
+
+    act(() => {
+      env.apiStore.invalidateItem('users||1');
+    });
+
+    await flushAllTimers();
+
+    // Both hooks must end up with the fresh server values. Previously the
+    // address hook kept the stale 'Address 1' because the full-invalidation
+    // obligation was dropped once the name hook's partial refetch resolved.
+    expect(result.current.name.data?.name).toBe('Renamed User 1');
+    expect(result.current.address.data?.address).toBe('Relocated Address 1');
+    expect(result.current.name.status).toBe('success');
+    expect(result.current.address.status).toBe('success');
+
+    // Exactly one preload ('*') plus a single coalesced refetch covering both
+    // mounted hooks' fields — no duplicate requests and no over-broad ('*')
+    // refetch.
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload: { itemId: 'users||1' }
+        - _type: 'item'
+          payload:
+            fields: ['address', 'name']
+            itemId: 'users||1'
+      `);
+  });
+
+  // Finding: `invalidateItem` derived the invalidation baseline only from
+  // `itemLoadedFields`. A client-created (metadata-free) item vouched as
+  // complete by `inferFields` recorded NO durable staleness marker, so after
+  // one partial refetch consumed `refetchOnMount`, other field hooks kept
+  // trusting the stale snapshot via `inferFields` forever.
+  test('field hooks refetch after a full invalidation of a client-created (metadata-free) item', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: starInferFieldsConfig,
+    });
+
+    // A complete item is inserted directly into state (e.g. created on the
+    // client). It has no `itemLoadedFields` metadata — `inferFields` reports it
+    // as complete ('*').
+    act(() => {
+      env.apiStore.addItemToState('users||1', {
+        id: 1,
+        name: 'User 1',
+        address: 'Address 1',
+        age: 10,
+        country: 'Country 1',
+      });
+    });
+
+    // Two independent hooks each read a different field; both trust the
+    // inferred-complete snapshot, so no fetch happens.
+    const { result } = renderHook(() => {
+      const nameHook = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['name'],
+      });
+      const addressHook = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      });
+
+      return { name: nameHook, address: addressHook };
+    });
+
+    await flushAllTimers();
+
+    expect(result.current.name.status).toBe('success');
+    expect(result.current.address.status).toBe('success');
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(
+      `[]`,
+    );
+
+    // Server data changes for both fields, then the whole item is invalidated.
+    env.serverTable.updateItem('users||1', {
+      name: 'Renamed User 1',
+      address: 'Relocated Address 1',
+    });
+
+    act(() => {
+      env.apiStore.invalidateItem('users||1');
+    });
+
+    await flushAllTimers();
+
+    // Both hooks must end up with the fresh server values. Previously only the
+    // name hook refetched (via `refetchOnMount`); the address hook kept the
+    // stale 'Address 1' because no durable full-invalidation marker existed for
+    // the metadata-free item, letting `inferFields` vouch for the stale field.
+    expect(result.current.name.data?.name).toBe('Renamed User 1');
+    expect(result.current.address.data?.address).toBe('Relocated Address 1');
+    expect(result.current.name.status).toBe('success');
+    expect(result.current.address.status).toBe('success');
+
+    // Each refetch requested only its own field — no duplicate or full fetches.
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['name']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload:
+            fields: ['address']
+            itemId: 'users||1'
+      `);
+  });
+
+  // Finding 3 (P2): resolving a fetch while a per-field invalidation was still
+  // unresolved *replaced* the item's pending invalidation fields with only the
+  // per-field ones, silently dropping the fields still owed from an earlier
+  // full invalidation. Hooks for the dropped fields then trusted the stale
+  // snapshot via `inferFields` and never refetched.
+  test('a per-field invalidation does not erase the refetch obligation of an earlier full invalidation', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // Load name + address, then leave the item unmounted so the invalidations
+    // below are only satisfied by later mounts.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: ['name', 'address'],
+    });
+    await flushAllTimers();
+    await preload;
+
+    // Server data changes, then: a FULL invalidation (owes name + address)
+    // followed by a per-field invalidation of 'age'.
+    env.serverTable.updateItem('users||1', {
+      name: 'Renamed User 1',
+      address: 'Relocated Address 1',
+    });
+
+    act(() => {
+      env.apiStore.invalidateItem('users||1');
+      env.apiStore.invalidateQueryAndItems({
+        itemPayload: 'users||1',
+        queryPayload: false,
+        fields: ['age'],
+      });
+    });
+
+    // A name hook mounts and refetches; resolving it prunes the invalidation
+    // tracking while the 'age' per-field invalidation is still unresolved —
+    // this is where the 'address' obligation used to be dropped.
+    const nameHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['name'],
+      }),
+    );
+    await flushAllTimers();
+    expect(nameHook.result.current.data?.name).toBe('Renamed User 1');
+    nameHook.unmount();
+
+    // An age hook mounts and resolves the per-field invalidation.
+    const ageHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['age'],
+      }),
+    );
+    await flushAllTimers();
+    expect(ageHook.result.current.status).toBe('success');
+    ageHook.unmount();
+
+    // The address field is still owed from the full invalidation: a mounting
+    // address hook must refetch it instead of trusting the stale snapshot.
+    const addressHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      }),
+    );
+    await flushAllTimers();
+
+    expect(addressHook.result.current.status).toBe('success');
+    // Previously stayed 'Address 1' (stale) with no refetch.
+    expect(addressHook.result.current.data?.address).toBe(
+      'Relocated Address 1',
+    );
+    addressHook.unmount();
+
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['name', 'address']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload:
+            fields: ['name']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload:
+            fields: ['age']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload:
+            fields: ['address']
+            itemId: 'users||1'
+      `);
+  });
+});
+
+describe('partial resources: status and fetch decisions agree on inferFields', () => {
+  // Finding 1 (P1): the result selector decided "is this field available?"
+  // by checking raw object keys, while the fetch effect trusted
+  // `inferFields`. When fields are logical names (per docs, fields do NOT
+  // need to be raw item keys), the two disagreed: the hook was stuck on
+  // `loading` forever while no fetch was ever scheduled.
+  test('a logical (non-key) field vouched by inferFields resolves to success without any fetch', async () => {
+    // Fields are logical names resolved by the API — `inferFields` vouches for
+    // complete client-created rows, and `selectFields` exposes the row as-is.
+    const logicalFieldsConfig: PartialResourcesConfig<Row> = {
+      mergeItems: mergeAndSelect.mergeItems,
+      selectFields: (_fields, item) => item,
+      inferFields: () => '*',
+    };
+
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: logicalFieldsConfig,
+    });
+
+    // Client-created item without loaded-fields metadata.
+    act(() => {
+      env.apiStore.addItemToState('users||1', {
+        id: 1,
+        name: 'User 1',
+        address: 'Address 1',
+        age: 10,
+        country: 'Country 1',
+      });
+    });
+
+    const renders = createLoggerStore();
+
+    // 'contactInfo' is a logical field — it is not a raw key of the item, but
+    // `inferFields` vouches the snapshot is complete, so it is covered.
+    renderHook(() => {
+      const { status, data } = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['contactInfo'],
+      });
+
+      renders.add({ status, name: data?.name });
+    });
+
+    await flushAllTimers();
+
+    // Previously: stuck on `loading` forever (status selector saw the raw key
+    // missing) while the fetch effect (trusting inferFields) never fetched.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: User 1
+      "
+    `);
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(
+      `[]`,
+    );
+  });
+
+  // Mirror of the same disagreement: a raw key being present must not show
+  // unvouched placeholder data as `success` when `inferFields` says the field
+  // was never actually loaded — the fetch effect refetches it, so the status
+  // must be `loading` (data hidden) until the fetch resolves.
+  test('a present-but-unvouched field shows loading and fetches instead of exposing placeholder data', async () => {
+    // Only id/name are trustworthy on locally created rows; other keys may
+    // hold placeholder values that were never loaded from the server.
+    const placeholderAwareConfig: PartialResourcesConfig<Row> = {
+      ...mergeAndSelect,
+      inferFields: () => ['id', 'name'],
+    };
+
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: placeholderAwareConfig,
+    });
+
+    // Client-created row with a placeholder address key present.
+    act(() => {
+      env.apiStore.addItemToState('users||1', {
+        id: 1,
+        name: 'User 1',
+        address: 'Draft address',
+      });
+    });
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const { status, data } = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      });
+
+      renders.add({ status, address: data?.address ?? null });
+    });
+
+    await flushAllTimers();
+
+    // Previously the placeholder was exposed as `success` (raw key present)
+    // before the refetch resolved. Now the unvouched field is treated as
+    // missing: loading (data hidden) until the real value arrives.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ address: null
+      -> status: success ⋅ address: Address 1
+      "
+    `);
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['address']
+            itemId: 'users||1'
+      `);
+  });
+});
+
+describe('partial resources: unresolved invalidations only affect their own fields', () => {
+  // Finding 10 (P3): while ANY per-field invalidation was unresolved, the
+  // fetch effect stopped trusting `inferFields` for ALL fields of the item —
+  // hooks for unaffected, vouched fields spuriously refetched them.
+  test('a hook for an unaffected vouched field does not refetch while another field is pending invalidation', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: starInferFieldsConfig,
+    });
+
+    // Client-created complete item — no loaded-fields metadata, vouched by
+    // `inferFields`.
+    act(() => {
+      env.apiStore.addItemToState('users||1', {
+        id: 1,
+        name: 'User 1',
+        address: 'Address 1',
+        age: 10,
+        country: 'Country 1',
+      });
+    });
+
+    // Only 'age' becomes stale (no hooks mounted yet).
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        itemPayload: 'users||1',
+        queryPayload: false,
+        fields: ['age'],
+      });
+    });
+
+    // Hooks for unaffected fields mount. 'name' and 'address' are vouched by
+    // `inferFields` and NOT affected by the pending 'age' invalidation — they
+    // must resolve from state without any fetch. Previously the unresolved
+    // 'age' invalidation disabled `inferFields` for every field, causing
+    // spurious refetches of both.
+    const nameHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['name'],
+      }),
+    );
+    await flushAllTimers();
+    expect(nameHook.result.current.status).toBe('success');
+    nameHook.unmount();
+
+    const addressHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      }),
+    );
+    await flushAllTimers();
+    expect(addressHook.result.current.status).toBe('success');
+    addressHook.unmount();
+
+    // The pending 'age' invalidation is still owed: an age hook must refetch.
+    const ageHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['age'],
+      }),
+    );
+    await flushAllTimers();
+    expect(ageHook.result.current.status).toBe('success');
+    ageHook.unmount();
+
+    // Only the invalidated 'age' field was ever fetched.
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['age']
+            itemId: 'users||1'
+      `);
+  });
+});
+
+describe('partial resources: invalidating an item of a mounted fields:"*" list query', () => {
+  // Finding 4 (P2): `invalidateItem` on any item of a mounted `fields: '*'`
+  // list query blanked the whole list to `loading` with `items: []`, because
+  // the status selector treated "complete but stale" the same as "data
+  // absent". Stale-but-complete items must stay visible as `refetching`.
+  test('the list keeps its items visible as refetching instead of blanking to loading', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const { status, items } = env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: '*', returnRefetchingStatus: true },
+      );
+
+      renders.add({
+        status,
+        itemsCount: items.length,
+        firstName: items[0]?.name ?? null,
+      });
+    });
+
+    await flushAllTimers();
+    renders.addMark('invalidate item 1');
+
+    // Server data changes, then one item of the list is fully invalidated.
+    env.serverTable.updateItem('users||1', { name: 'Renamed User 1' });
+
+    act(() => {
+      env.apiStore.invalidateItem('users||1');
+    });
+
+    await flushAllTimers();
+
+    // The loaded list must never blank out: it stays visible with a
+    // `refetching` status while the stale item refetches, then settles with
+    // the fresh value. Previously the list flipped to `loading` with 0 items.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ itemsCount: 0 ⋅ firstName: null
+      -> status: success ⋅ itemsCount: 5 ⋅ firstName: User 1
+
+      >>> invalidate item 1
+
+      -> status: refetching ⋅ itemsCount: 5 ⋅ firstName: User 1
+      -> status: success ⋅ itemsCount: 5 ⋅ firstName: Renamed User 1
+      "
+    `);
+  });
+});
+
+describe('partial resources: imperative getters with ignoreStaleState honor pending invalidations', () => {
+  // Finding 5 (P2): `getItemFromStateOrFetch` / `getQueryFromStateOrFetch`
+  // with `ignoreStaleState: true` (= "require fresh data") only consulted the
+  // state-level per-field invalidation record. A FULL invalidation deletes
+  // that record and tracks the obligation in the pending-full-invalidation
+  // marker instead — which the getters ignored, so they returned stale cached
+  // data as if it were fresh.
+
+  /** Fully loads item 1 ('*'), refetches only 'name' after a full invalidation,
+   * leaving 'address' stale while the full-invalidation marker is unresolved. */
+  async function setupStaleAddressAfterFullInvalidation(options?: {
+    preloadQuery?: boolean;
+  }) {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: starInferFieldsConfig,
+    });
+
+    if (options?.preloadQuery) {
+      // Load the list query first so a cached query exists when the
+      // invalidation happens.
+      const queryPreload = env.apiStore.getQueryFromStateOrFetch(
+        { tableId: 'users' },
+        { fields: '*' },
+      );
+      await flushAllTimers();
+      await queryPreload;
+    }
+
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A mounted name hook resolves the invalidation refetch for 'name' only.
+    const nameHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['name'],
+      }),
+    );
+    await flushAllTimers();
+
+    env.serverTable.updateItem('users||1', {
+      name: 'Renamed User 1',
+      address: 'Relocated Address 1',
+    });
+
+    act(() => {
+      env.apiStore.invalidateItem('users||1');
+    });
+    await flushAllTimers();
+
+    // Sanity: only 'name' was refetched — 'address' in state is still stale.
+    expect(nameHook.result.current.data?.name).toBe('Renamed User 1');
+    nameHook.unmount();
+
+    return env;
+  }
+
+  test('getItemFromStateOrFetch refetches stale fields instead of returning them from cache', async () => {
+    const env = await setupStaleAddressAfterFullInvalidation();
+    env.serverTable.clearFetchHistory();
+
+    // Require-fresh read of the still-stale 'address' field: must hit the
+    // server, not the cache.
+    const addressResultPromise = env.apiStore.getItemFromStateOrFetch(
+      'users||1',
+      { fields: ['address'], ignoreStaleState: true },
+    );
+    await flushAllTimers();
+    const addressResult = await addressResultPromise;
+    expect(addressResult.ok ? addressResult.value.address : null).toBe(
+      'Relocated Address 1',
+    );
+
+    // Require-fresh read of the full item while the full-invalidation marker
+    // is still unresolved: must trigger a full refetch.
+    const fullResultPromise = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+      ignoreStaleState: true,
+    });
+    await flushAllTimers();
+    const fullResult = await fullResultPromise;
+    expect(fullResult.ok ? fullResult.value.address : null).toBe(
+      'Relocated Address 1',
+    );
+
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['address']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload: { itemId: 'users||1' }
+      `);
+  });
+
+  test('getQueryFromStateOrFetch refetches when an item has stale fields from a full invalidation', async () => {
+    const env = await setupStaleAddressAfterFullInvalidation({
+      preloadQuery: true,
+    });
+    env.serverTable.clearFetchHistory();
+
+    // Require-fresh query read of the stale 'address' field: item 1 still has
+    // an unresolved full invalidation, so the query must refetch.
+    const queryResultPromise = env.apiStore.getQueryFromStateOrFetch(
+      { tableId: 'users' },
+      { fields: ['address'], ignoreStaleState: true },
+    );
+    await flushAllTimers();
+    const queryResult = await queryResultPromise;
+    expect(
+      queryResult.ok ? queryResult.value.items[0]?.data.address : null,
+    ).toBe('Relocated Address 1');
+
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['address']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+  });
+});
+
+describe('partial resources: mounting a fields:"*" hook during an in-flight fetch', () => {
+  // Finding 2 (P1): a `fields: '*'` hook that mounts while another fetch for the
+  // same item is already in flight must still refetch the full item once that
+  // fetch settles, instead of getting stuck on `loading` forever because the
+  // mount-once guard swallowed its only fetch opportunity.
+  test('the full-item hook recovers to success after the in-flight partial fetch settles', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // Start a partial fetch and leave it in flight (fetch duration is 800ms).
+    const { result, rerender } = renderHook(
+      ({ mountFullHook }: { mountFullHook: boolean }) => {
+        const partialHook = env.apiStore.useItem('users||1', {
+          returnRefetchingStatus: true,
+          fields: ['name'],
+        });
+
+        const fullHook = env.apiStore.useItem(
+          mountFullHook ? 'users||1' : false,
+          { returnRefetchingStatus: true, fields: '*' },
+        );
+
+        return { partial: partialHook, full: fullHook };
+      },
+      { initialProps: { mountFullHook: false } },
+    );
+
+    // Let the partial fetch start but not finish.
+    await advanceTime(400);
+    expect(result.current.partial.status).toBe('loading');
+
+    // Mount the full-item hook while the partial fetch is still active.
+    act(() => {
+      rerender({ mountFullHook: true });
+    });
+
+    await flushAllTimers();
+
+    // The full-item hook must reach success with the complete item, not stay
+    // stuck on loading with null data.
+    expect(result.current.full.status).toBe('success');
+    expect(result.current.full.data).toMatchInlineSnapshot(`
+      address: 'Address 1'
+      age: 10
+      country: 'Country 1'
+      id: 1
+      name: 'User 1'
+    `);
+
+    // The full-item fetch ('*') was issued once the in-flight partial fetch for
+    // 'name' settled — not swallowed by the mount-once guard.
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['name']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload: { itemId: 'users||1' }
+      `);
+  });
+});
+
+describe('partial resources: client-created items inside list queries', () => {
+  // Finding 6 (P3): the query-hook array-fields paths must consult `inferFields`
+  // like the item-hook paths do. A client-created item appended to a query has
+  // no `itemLoadedFields` metadata, but its data already contains the requested
+  // fields — the mounted query hook must not schedule a spurious list refetch
+  // (which would drop the client-created item, since the server doesn't know it).
+  test('appending a complete client-created item to a loaded query does not trigger a refetch', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    const renders = createLoggerStore();
+
+    // A partial list query is loaded and stays mounted.
+    renderHook(() => {
+      const { status, items } = env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name'], returnRefetchingStatus: true },
+      );
+
+      renders.add({ status, ids: items.map((item) => item.id).join(',') });
+    });
+
+    await flushAllTimers();
+    renders.addMark('item created on client');
+
+    // The client creates a new item (not on the server yet) and appends it to
+    // the query — e.g. an optimistic create. `addItemToState` sets no
+    // `itemLoadedFields`, so only `inferFields` can vouch for its data.
+    act(() => {
+      env.apiStore.addItemToState(
+        'users||6',
+        {
+          id: 6,
+          name: 'User 6',
+          address: 'Address 6',
+          age: 60,
+          country: 'Country 6',
+        },
+        {
+          addItemToQueries: { queries: { tableId: 'users' }, appendTo: 'end' },
+        },
+      );
+    });
+
+    await flushAllTimers();
+
+    // The new item shows up in the query, and no refetch is triggered:
+    // `inferFields` confirms the item data already has the requested fields.
+    // Previously the metadata-free item counted as "missing requested fields",
+    // scheduling a required list refetch that removed the client-created item.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ ids: ''
+      -> status: success ⋅ ids: 1,2,3,4,5
+
+      >>> item created on client
+
+      -> status: success ⋅ ids: 1,2,3,4,5,6
+      "
+    `);
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['id', 'name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+  });
+});
+
+describe('partial resources: per-field invalidation on a fully loaded ("*") item', () => {
+  // Finding 8 (P3): `getStaleOrMissingRequestedFields` early-returned `[]` for
+  // '*'-loaded items before consulting the pending invalidation fields, so an
+  // array-fields list hook over a '*' item never surfaced the immediate
+  // `refetching` status override nor `loadingFields` while an invalidated
+  // requested field was being refetched.
+  test('array-fields list hook reports refetching and loadingFields while an invalidated field refetches', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // Load the list without field selection so every item is tracked as fully
+    // loaded ('*').
+    const preload = env.apiStore.getQueryFromStateOrFetch(
+      { tableId: 'users' },
+      { fields: '*' },
+    );
+    await flushAllTimers();
+    await preload;
+
+    const renders = createLoggerStore();
+
+    // Array-fields hook over the '*'-loaded items; no fetch is needed yet.
+    renderHook(() => {
+      const { status, items, loadingFields } = env.apiStore.useListQuery(
+        { tableId: 'users' },
+        {
+          fields: ['name'],
+          returnRefetchingStatus: true,
+          showPartialAsRefetching: true,
+        },
+      );
+
+      renders.add({
+        status,
+        loadingFields: loadingFields ?? null,
+        firstName: items[0]?.name,
+      });
+    });
+
+    await flushAllTimers();
+    renders.addMark('invalidate name field');
+
+    // Server data changes, then the (still '*'-loaded) item has the requested
+    // 'name' field invalidated.
+    env.serverTable.updateItem('users||1', { name: 'Renamed User 1' });
+
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        itemPayload: 'users||1',
+        queryPayload: false,
+        fields: ['name'],
+      });
+    });
+
+    await flushAllTimers();
+
+    // The hook must expose the refetch window: status flips to `refetching`
+    // with `loadingFields: [name]` as soon as the field is invalidated (the
+    // item stays '*'-loaded, so only the pending invalidation reveals it), and
+    // resolves with the fresh value. Previously the whole window was invisible
+    // (status stayed success-shaped with no loadingFields).
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ loadingFields: null ⋅ firstName: User 1
+
+      >>> invalidate name field
+
+      -> status: refetching ⋅ loadingFields: [name] ⋅ firstName: User 1
+      -> status: success ⋅ loadingFields: null ⋅ firstName: Renamed User 1
+      "
+    `);
+  });
+});
+
+describe('partial resources: inferFields reporting a complete snapshot', () => {
+  // Finding 3 (P2): when `inferFields` reports `'*'` for a snapshot that carries
+  // no field metadata (e.g. a manually inserted item), a `fields: '*'` hook must
+  // treat it as fully loaded and render success without an extra fetch.
+  test('a fields:"*" hook trusts a manually inserted complete item without refetching', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: starInferFieldsConfig,
+    });
+
+    // Insert a complete item directly into state. `addItemToState` does not set
+    // `itemLoadedFields`, so the snapshot is only "complete" via `inferFields`.
+    act(() => {
+      env.apiStore.addItemToState('users||1', {
+        id: 1,
+        name: 'User 1',
+        address: 'Address 1',
+        age: 10,
+        country: 'Country 1',
+      });
+    });
+
+    const { result } = renderHook(() => {
+      return env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: '*',
+      });
+    });
+
+    await flushAllTimers();
+
+    // The hook trusts the inferred-complete snapshot: success, no server fetch.
+    expect(result.current.status).toBe('success');
+    expect(result.current.data?.name).toBe('User 1');
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(
+      `[]`,
+    );
+  });
+});

--- a/tests/list-query-features/list-query-partial-resources-show-partial-status.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-show-partial-status.test.ts
@@ -34,6 +34,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 const initialServerData: Tables = {

--- a/tests/list-query-features/list-query-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-partial-resources.test.ts
@@ -41,6 +41,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 const initialServerData: Tables = {
@@ -164,6 +168,124 @@ describe('useItem with partial resources', () => {
     ).toMatchInlineSnapshot(`[]`);
   });
 
+  test('getItemFromStateOrFetch with fields "*" fetches when cached item is only partially loaded', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: partialResourcesConfig,
+    });
+
+    // Start from the realistic list-card case: the query cached only the
+    // columns needed by the list UI.
+    const partialListPromise = env.apiStore.getQueryFromStateOrFetch(
+      { tableId: 'users' },
+      { fields: ['id', 'name'] },
+    );
+    await flushAllTimers();
+    await partialListPromise;
+
+    const fullItemPromise = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+
+    const fullItem = await fullItemPromise;
+
+    expect(fullItem.ok ? fullItem.value : null).toMatchInlineSnapshot(`
+      address: 'Address 1'
+      age: 10
+      country: 'Country 1'
+      id: 1
+      name: 'User 1'
+    `);
+    expect(env.serverTable.getRequestHistory('all', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['id', 'name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+        - _type: 'item'
+          payload: { itemId: 'users||1' }
+      `);
+  });
+
+  test('addItemToState item fields inferred by partial resources satisfy matching partial item hooks without refetching', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: partialResourcesConfig,
+    });
+
+    // The partial resource config owns field inference for snapshots that do
+    // not have loaded-field metadata, so write sites do not duplicate it.
+    act(() => {
+      env.apiStore.addItemToState('users||20', {
+        id: 20,
+        name: 'Created User',
+      });
+    });
+    env.serverTable.clearFetchHistory();
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const result = env.apiStore.useItem('users||20', {
+        returnRefetchingStatus: true,
+        fields: ['id', 'name'],
+      });
+
+      renders.add(pick(result, ['status', 'data', 'error']));
+    });
+
+    await flushAllTimers();
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ data: {id:20, name:Created User} ⋅ error: null
+      "
+    `);
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(
+      `[]`,
+    );
+  });
+
+  test('fallback field inference uses partial resource config instead of cached object keys', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: {
+        ...partialResourcesConfig,
+        inferFields: () => ['id'],
+      },
+    });
+
+    // The item object has a `name`, but the config says only `id` can be
+    // inferred from metadata-free fallback snapshots. Requesting `name` must
+    // therefore fetch instead of trusting a shallow object-key check.
+    act(() => {
+      env.apiStore.addItemToState('users||1', { id: 1, name: 'Cached Name' });
+    });
+    env.serverTable.clearFetchHistory();
+
+    const hook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        fields: ['name'],
+        returnRefetchingStatus: true,
+      }),
+    );
+
+    await flushAllTimers();
+
+    expect(pick(hook.result.current, ['status', 'data', 'error']))
+      .toMatchInlineSnapshot(`
+        data: { name: 'User 1' }
+        error: null
+        status: 'success'
+      `);
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['name']
+            itemId: 'users||1'
+      `);
+  });
+
   test('getItemFromStateOrFetch refetches a stale requested field when stale state is ignored', async () => {
     const env = createListQueryStoreTestEnv(initialServerData, {
       partialResources: partialResourcesConfig,
@@ -273,6 +395,51 @@ describe('useItem with partial resources', () => {
       - _type: 'item'
         payload: { itemId: 'users||1' }
         time: '10ms -> 810ms | duration: 800ms'
+    `);
+  });
+
+  test('fields "*" refetches full item when cached item is only partially loaded', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: partialResourcesConfig,
+    });
+
+    const partialListPromise = env.apiStore.awaitListQueryFetch(
+      { tableId: 'users' },
+      { fields: ['id', 'name'] },
+    );
+    await flushAllTimers();
+    await partialListPromise;
+    env.serverTable.fetchHistory.length = 0;
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const result = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        showPartialAsRefetching: true,
+        fields: '*',
+      });
+
+      renders.add(pick(result, ['status', 'data', 'error']));
+    });
+
+    await flushAllTimers();
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: refetching ⋅ data: {id:1, name:User 1} ⋅ error: null
+      ┌─
+      ⋅ status: success
+      ⋅ data: {id:1, name:User 1, address:Address 1, age:10, country:Country 1}
+      ⋅ error: null
+      └─
+      "
+    `);
+
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(`
+      - _type: 'item'
+        payload: { itemId: 'users||1' }
+        time: '820ms -> 1.62s | duration: 800ms'
     `);
   });
 
@@ -563,6 +730,49 @@ describe('useListQuery with partial resources', () => {
     ).toMatchInlineSnapshot(`[]`);
   });
 
+  test('getQueryFromStateOrFetch with fields "*" fetches when cached query items are only partially loaded', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: partialResourcesConfig,
+    });
+
+    const partialQueryPromise = env.apiStore.getQueryFromStateOrFetch(
+      { tableId: 'users' },
+      { fields: ['id', 'name'] },
+    );
+    await flushAllTimers();
+    await partialQueryPromise;
+
+    const fullQueryPromise = env.apiStore.getQueryFromStateOrFetch(
+      { tableId: 'users' },
+      { fields: '*' },
+    );
+    await flushAllTimers();
+
+    const fullQuery = await fullQueryPromise;
+
+    expect(fullQuery.ok ? fullQuery.value.items[0]?.data : null)
+      .toMatchInlineSnapshot(`
+        address: 'Address 1'
+        age: 10
+        country: 'Country 1'
+        id: 1
+        name: 'User 1'
+      `);
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['id', 'name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+        - _type: 'list'
+          payload:
+            fields: '*'
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+  });
+
   test('getQueryFromStateOrFetch refetches a stale requested field when stale state is ignored', async () => {
     const env = createListQueryStoreTestEnv(initialServerData, {
       partialResources: partialResourcesConfig,
@@ -678,6 +888,57 @@ describe('useListQuery with partial resources', () => {
           pos: { limit: 50, offset: 0 }
         returned_items: 5
         time: '10ms -> 810ms | duration: 800ms'
+    `);
+  });
+
+  test('fields "*" refetches full list when cached query items are only partially loaded', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: partialResourcesConfig,
+    });
+
+    const partialListPromise = env.apiStore.awaitListQueryFetch(
+      { tableId: 'users' },
+      { fields: ['id', 'name'] },
+    );
+    await flushAllTimers();
+    await partialListPromise;
+    env.serverTable.fetchHistory.length = 0;
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const result = env.apiStore.useListQuery(
+        { tableId: 'users' },
+        {
+          returnRefetchingStatus: true,
+          showPartialAsRefetching: true,
+          fields: '*',
+        },
+      );
+
+      renders.add(pick(result, ['status', 'items', 'error']));
+    });
+
+    await flushAllTimers();
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: refetching ⋅ items: [{id:1, name:User 1}, …(4 more)] ⋅ error: null
+      ┌─
+      ⋅ status: success
+      ⋅ items: [{id:1, name:User 1, address:Address 1, age:10, country:Country 1}, …(4 more)]
+      ⋅ error: null
+      └─
+      "
+    `);
+
+    expect(env.serverTable.getRequestHistory('list')).toMatchInlineSnapshot(`
+      - _type: 'list'
+        payload:
+          fields: '*'
+          pos: { limit: 50, offset: 0 }
+        returned_items: 5
+        time: '820ms -> 1.62s | duration: 800ms'
     `);
   });
 
@@ -1169,6 +1430,63 @@ describe('invalidateQueryAndItems with fields', () => {
     `);
   });
 
+  test('per-field invalidation of a fully loaded item: hook mounting after the invalidation refetches the invalidated fields', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: partialResourcesConfig,
+    });
+
+    // fully load the item, marking it as '*' loaded
+    const fullFetch = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await fullFetch;
+
+    // field-scoped invalidation while NO hook is mounted
+    env.serverTable.updateItem('users||1', { address: 'Updated Address 1' });
+
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        itemPayload: 'users||1',
+        queryPayload: false,
+        fields: ['address'],
+      });
+    });
+
+    await flushAllTimers();
+
+    const hookRenders = createLoggerStore();
+
+    renderHook(() => {
+      const result = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['id', 'address'],
+      });
+      hookRenders.add(pick(result, ['status', 'data']));
+    });
+
+    await flushAllTimers();
+
+    expect(hookRenders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ data: {id:1, address:Address 1}
+      -> status: refetching ⋅ data: {id:1, address:Address 1}
+      -> status: success ⋅ data: {id:1, address:Updated Address 1}
+      "
+    `);
+
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(`
+      - _type: 'item'
+        payload: { itemId: 'users||1' }
+        time: '10ms -> 810ms | duration: 800ms'
+      - _type: 'item'
+        payload:
+          fields: ['address']
+          itemId: 'users||1'
+        time: '820ms -> 1.62s | duration: 800ms'
+    `);
+  });
+
   test('per-field invalidation keeps the highest emitted priority for mounted full-resource hooks', async () => {
     const env = createListQueryStoreTestEnv(initialServerData, {
       partialResources: partialResourcesConfig,
@@ -1634,10 +1952,9 @@ describe('await* preload with partial resources', () => {
 
     await flushAllTimers();
 
-    expect(env.store.state.itemLoadedFields[storeItemKey])
-      .toMatchInlineSnapshot(`
-        ['address', 'age', 'country', 'id', 'name']
-      `);
+    expect(
+      env.store.state.itemLoadedFields[storeItemKey],
+    ).toMatchInlineSnapshot(`"*"`);
 
     expect(renders.changesSnapshot).toMatchInlineSnapshot(`
       "
@@ -1651,6 +1968,75 @@ describe('await* preload with partial resources', () => {
         payload: { itemId: 'users||1' }
         time: '10ms -> 810ms | duration: 800ms'
     `);
+  });
+
+  test('full fetch satisfies later nested logical fields without object-key refetches', async () => {
+    type NestedRow = Row & { values: Record<string, string> };
+
+    const nestedPartialResources: PartialResourcesConfig<NestedRow> = {
+      mergeItems: (prev, fetched) => {
+        if (!prev) return fetched;
+        return {
+          ...prev,
+          ...fetched,
+          values: { ...prev.values, ...fetched.values },
+        };
+      },
+      selectFields: (fields, item) => {
+        return __LEGIT_CAST__<NestedRow, Row>({
+          id: item.id,
+          name: item.name,
+          values: Object.fromEntries(
+            fields
+              .filter((field) => field in item.values)
+              .map((field) => [field, item.values[field]]),
+          ),
+        });
+      },
+      inferFields: (item) => Object.keys(item.values),
+    };
+    const env = createListQueryStoreTestEnv<NestedRow>(
+      {
+        users: [
+          {
+            id: 1,
+            name: 'User 1',
+            values: { favoriteColor: 'Blue', title: 'Manager' },
+          },
+        ],
+      },
+      { partialResources: nestedPartialResources },
+    );
+
+    const preloadPromise = env.apiStore.awaitItemFetch('users||1', {
+      fields: '*',
+    });
+
+    await flushAllTimers();
+    await preloadPromise;
+    env.serverTable.fetchHistory.length = 0;
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const result = env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['favoriteColor'],
+      });
+
+      renders.add(pick(result, ['status', 'data']));
+    });
+
+    await flushAllTimers();
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ data: {id:1, name:User 1, values:{favoriteColor:Blue}}
+      "
+    `);
+    expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(
+      `[]`,
+    );
   });
 
   test('awaitListQueryFetch with fields "*" satisfies later list hook without refetch', async () => {

--- a/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-size-coalescing-partial-resources.test.ts
@@ -31,6 +31,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 
 beforeAll(() => {
@@ -164,7 +168,7 @@ describe('query coalescing with partial resources', () => {
 
     const itemKey = env.getStoreItemKeyFromRaw('table1||1');
     expect(env.store.state.itemLoadedFields[itemKey]).toMatchInlineSnapshot(
-      `['address', 'country', 'id', 'name']`,
+      `"*"`,
     );
   });
 

--- a/tests/mocks/mockLocalStorageStore.ts
+++ b/tests/mocks/mockLocalStorageStore.ts
@@ -1,3 +1,4 @@
+import type { ItemLoadedFields } from '../../src/listQueryStore/types';
 import {
   createLocalStoragePersistentTestStore,
   type PersistentTestStoreScope,
@@ -18,7 +19,7 @@ type MockLocalStorageInitialScope = {
       tableId: string;
       id: number | string;
       data: unknown;
-      loadedFields?: string[];
+      loadedFields?: ItemLoadedFields;
       timestamp?: number;
       version?: number;
     }>;

--- a/tests/offline/offline-overlays.test.tsx
+++ b/tests/offline/offline-overlays.test.tsx
@@ -962,18 +962,18 @@ describe('list-query overlays', () => {
       0     | Ada          | no      | [item-name, pending] ui-initialized
       10ms  | Ada          | no      | 🔴 [users||1] >fetch-started
       810ms | Ada          | no      | 🔴 [users||1] <fetch-finished (value: {"id":1,"name":"Ada"})
-      2s    | Ada          | no      | [users||1] scheduled-fetch-triggered
-      2.01s | Ada          | no      | 🟠 [users||1] >fetch-started
-      2.81s | Ada          | no      | 🟠 [users||1] <fetch-finished (value: {"id":1,"name":"Ada"})
-      3.81s | Ada          | no      | -- queue an optimistic item edit while offline
+      3.81s | Ada          | no      | [users||1] scheduled-fetch-triggered
+      3.82s | Ada          | no      | 🟠 [users||1] >fetch-started
+      4.62s | Ada          | no      | 🟠 [users||1] <fetch-finished (value: {"id":1,"name":"Ada"})
+      5.62s | Ada          | no      | -- queue an optimistic item edit while offline
       .     | Ada pending  | yes     | [item-name, pending] ui-changed
       .     | Ada pending  | yes     | offline:patchUserName queued
       .     | Ada pending  | yes     | -- reconnect — direct item refetch must not restore stale value
       .     | Ada pending  | yes     | [users||1] scheduled-fetch-triggered
       .     | Ada pending  | yes     | offline:patchUserName replay-started
-      3.82s | Ada pending  | yes     | 🟡 [users||1] >fetch-started
-      4.62s | Ada pending  | yes     | 🟡 [users||1] <fetch-finished (value: {"id":1,"name":"Ada"})
-      5.81s | Ada pending  | yes     | -- replay settles — item shows replayed value
+      5.63s | Ada pending  | yes     | 🟡 [users||1] >fetch-started
+      6.43s | Ada pending  | yes     | 🟡 [users||1] <fetch-finished (value: {"id":1,"name":"Ada"})
+      7.62s | Ada pending  | yes     | -- replay settles — item shows replayed value
       .     | Ada pending  | yes     | [users||1] server-data-changed (value: {"name":"Ada replayed"})
       .     | Ada pending  | yes     | offline:patchUserName replay-finished
       .     | Ada replayed | no      | [item-name, pending] ui-changed

--- a/tests/offline/offline-reads.test.tsx
+++ b/tests/offline/offline-reads.test.tsx
@@ -52,6 +52,7 @@ const partialUserResourcesConfig: PartialResourcesConfig<PartialUserRow> = {
     }
     return __LEGIT_CAST__<PartialUserRow, Record<string, unknown>>(result);
   },
+  inferFields: (item) => Object.keys(item),
 };
 
 let network = createOfflineNetworkMock();

--- a/tests/offline/offline-storage.test.tsx
+++ b/tests/offline/offline-storage.test.tsx
@@ -77,6 +77,7 @@ const partialResourcesConfig: PartialResourcesConfig<OfflineStorageUserRow> = {
       result,
     );
   },
+  inferFields: (item) => Object.keys(item),
 };
 
 function createOfflineDocumentEnv({

--- a/tests/persistent-storage/async-storage-efficiency/list-query.test.ts
+++ b/tests/persistent-storage/async-storage-efficiency/list-query.test.ts
@@ -502,8 +502,6 @@ describe('async storage efficiency: list-query', () => {
              |    └ (query data, <{tableId:"fourth"}>)
       .      | 👁️ #8 file-open-or-create 🆕 tsdf/sess1/lq-coalesced-query-maintenance/li.h~1322690187.p.json
              |    └ (item data, <"fourth||2>)
-      3.662s | ✍️ #5 tsdf/sess1/lq-coalesced-query-maintenance/li.h~4006559409.p.json
-             |    └ (item data, <"third||1>) | 0.04 kb -> 0.04 kb ⚠️ UNCHANGED
       3.663s | ✍️ #7 tsdf/sess1/lq-coalesced-query-maintenance/lq.h~3370518832.p.json
              |    └ (query data, <{tableId:"fourth"}>) | 0.00 kb -> 0.03 kb
       .      | ✍️ #8 tsdf/sess1/lq-coalesced-query-maintenance/li.h~1322690187.p.json
@@ -511,7 +509,7 @@ describe('async storage efficiency: list-query', () => {
       3.667s | ✍️ #2 tsdf/sess1/lq-coalesced-query-maintenance/lq._i.r.json
              |    └ (queries index) | 0.33 kb -> 0.33 kb
       .      | ✍️ #1 tsdf/sess1/lq-coalesced-query-maintenance/li._i.r.json
-             |    └ (items index) | 0.12 kb -> 0.29 kb
+             |    └ (items index) | 0.12 kb -> 0.23 kb
       3.669s | end
       "
     `);
@@ -652,11 +650,7 @@ describe('async storage efficiency: list-query', () => {
       getParsedOpfsFileData('tsdf/sess1/lq-query-becomes-empty/li._i.r.json'),
     ).toMatchInlineSnapshot(`
       e:
-        "users||1:
-          a: 1735689600000
-          f: ['age', 'email', 'id', 'name']
-          p: 'users||1'
-          z: 95
+        "users||1: { a: 1735689600000, p: 'users||1', z: 63 }
     `);
     expect(
       getParsedOpfsFileData(
@@ -787,7 +781,7 @@ describe('async storage efficiency: list-query', () => {
       maxItemBytes: sumPersistedEntryBytes(
         getAsyncListItemEntrySizeBytes(rawItemPayload('standalone', 1), {
           id: 1,
-          name: 'Expired oldest',
+          name: 'Expired recent',
         }),
         getAsyncListItemEntrySizeBytes(rawItemPayload('admins', 4), {
           id: 4,
@@ -806,7 +800,7 @@ describe('async storage efficiency: list-query', () => {
     // Persist two standalone items that will later look expired to the cleanup pass.
     env.apiStore.addItemToState(rawItemPayload('standalone', 1), {
       id: 1,
-      name: 'Expired oldest',
+      name: 'Expired recent',
     });
     await advanceTime(1100);
     await flushAllTimers();
@@ -814,18 +808,24 @@ describe('async storage efficiency: list-query', () => {
     await advanceTime(100);
     env.apiStore.addItemToState(rawItemPayload('standalone', 2), {
       id: 2,
-      name: 'Expired newer',
+      name: 'Expired older',
     });
     await advanceTime(1100);
     await flushAllTimers();
 
-    // Persist one query-backed item before introducing a second query-backed item.
+    // Persist one query-backed item before introducing a second query-backed
+    // item. This flush already overflows maxItemBytes, so the least recently
+    // persisted item (standalone||1) loses its storage slot here while staying
+    // loaded in memory.
     env.scheduleFetch('highPriority', usersQuery);
     await flushAllTimers();
     await advanceTime(1100);
     await flushAllTimers();
 
-    // Backdate the standalone entries so the later maxItemBytes cleanup sees them as stale persisted candidates.
+    // Backdate the standalone entries so the later maxItemBytes cleanup sees
+    // them as stale candidates (standalone||1 is already out of storage, so its
+    // backdate only touches leftover metadata). The timestamps are distinct so
+    // the recency ordering stays deterministic.
     mockAdapter.setMetadata(
       listQueryScope.listQuery.itemStorageKey('standalone', 1),
       {
@@ -841,7 +841,7 @@ describe('async storage efficiency: list-query', () => {
         ...mockAdapter.readMetadata(
           listQueryScope.listQuery.itemStorageKey('standalone', 2),
         ),
-        lastAccessAt: expiredTimestamp,
+        lastAccessAt: expiredTimestamp - 60 * 60 * 1000,
       },
     );
 
@@ -854,9 +854,13 @@ describe('async storage efficiency: list-query', () => {
     await flushAllTimers();
     const operationsBreakdown = readCapture.finish().timelineString;
 
+    // The budget keeps the two most recently accessed items: the freshly
+    // fetched admins||4 and the query-backed users||3. The stale standalone||2
+    // is removed, and the previously budget-evicted standalone||1 is not
+    // resurrected as if it were freshly accessed.
     expect(
       listQueryScope.listQuery.listStoredItemKeys().sort(),
-    ).toMatchInlineSnapshot(`['"admins||4', '"standalone||2']`);
+    ).toMatchInlineSnapshot(`['"admins||4', '"users||3']`);
     expect(
       getParsedOpfsFileData(
         'tsdf/sess1/lq-expired-during-max-items/li._i.r.json',
@@ -864,7 +868,7 @@ describe('async storage efficiency: list-query', () => {
     ).toMatchInlineSnapshot(`
       e:
         "admins||4: { a: 1735689619212, p: 'admins||4', z: 76 }
-        "standalone||2: { a: 1735689619212, p: 'standalone||2', z: 70 }
+        "users||3: { a: 1735689616251, p: 'users||3', z: 68 }
 
       s: { b: 147 }
     `);
@@ -888,35 +892,29 @@ describe('async storage efficiency: list-query', () => {
       time   |
       1.85s  | 👁️ #1 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/lq.h~2316387135.p.json
              |    └ (query data)
-      .      | 🗑️ #2 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~2775221404.p.json
-             |    └ (item data, <"standalone||1>)
-      .      | 🗑️ #3 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~3224064498.p.json
-             |    └ (item data, <"users||3>)
-      .      | 👁️ #4 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~3111345837.p.json
-             |    └ (item data)
-      .      | 👁️ #5 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
+      .      | 🗑️ #2 ✅ tsdf/sess1/lq-expired-during-max-items/li.h~3111345837.p.json
+             |    └ (item data, <"standalone||2>)
+      .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
              |    └ (item data)
       1.853s | ✍️ #1 tsdf/sess1/lq-expired-during-max-items/lq.h~2316387135.p.json
              |    └ (query data) | 0.00 kb -> 0.03 kb
-      .      | ✍️ #4 tsdf/sess1/lq-expired-during-max-items/li.h~3111345837.p.json
-             |    └ (item data) | 0.00 kb -> 0.06 kb
-      .      | ✍️ #5 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
+      .      | ✍️ #3 tsdf/sess1/lq-expired-during-max-items/li.h~2792428996.p.json
              |    └ (item data) | 0.00 kb -> 0.08 kb
-      1.857s | ✍️ #6 tsdf/sess1/lq-expired-during-max-items/lq._i.r.json
+      1.857s | ✍️ #4 tsdf/sess1/lq-expired-during-max-items/lq._i.r.json
              |    └ (queries index) | 0.16 kb -> 0.30 kb
-      .      | ✍️ #7 tsdf/sess1/lq-expired-during-max-items/li._i.r.json
-             |    └ (items index) | 0.28 kb -> 0.28 kb
+      .      | ✍️ #5 tsdf/sess1/lq-expired-during-max-items/li._i.r.json
+             |    └ (items index) | 0.28 kb -> 0.26 kb
       1.859s | end
       "
     `);
 
     expect(getOpfsDirTree(mockAdapter)).toMatchInlineSnapshot(`
-      "tsdf (1.13 kb)
-      ├ sess1 (1.06 kb)
-      │ └ lq-expired-during-max-items (1.05 kb)
-      │   ├ li._i.r.json (0.30 kb)
+      "tsdf (1.12 kb)
+      ├ sess1 (1.05 kb)
+      │ └ lq-expired-during-max-items (1.04 kb)
+      │   ├ li._i.r.json (0.28 kb)
       │   ├ li.h~2792428996.p.json (0.12 kb)
-      │   ├ li.h~3111345837.p.json (0.10 kb)
+      │   ├ li.h~3224064498.p.json (0.11 kb)
       │   ├ lq._i.r.json (0.33 kb)
       │   ├ lq.h~2316387135.p.json (0.07 kb)
       │   └ lq.h~2902406637.p.json (0.07 kb)
@@ -1192,12 +1190,10 @@ describe('async storage efficiency: list-query', () => {
              |    └ (query data, <{tableId:"users"}>) | 0.05 kb -> 0.03 kb
       .      | ✍️ #3 tsdf/sess1/lq-delete-flow/lq.h~1805955701.p.json
              |    └ (query data, <{filters:[{field:"name",op:"eq",value:"Alice"}],tableId:"users"}>) | 0.03 kb -> 0.00 kb
-      .      | ✍️ #4 tsdf/sess1/lq-delete-flow/li.h~1937155452.p.json
-             |    └ (item data, <"users||2>) | 0.04 kb -> 0.04 kb ⚠️ UNCHANGED
+      1.043s | ✍️ #4 tsdf/sess1/lq-delete-flow/li._i.r.json
+             |    └ (items index) | 0.23 kb -> 0.12 kb
       1.046s | ✍️ #5 tsdf/sess1/lq-delete-flow/lq._i.r.json
              |    └ (queries index) | 0.51 kb -> 0.51 kb
-      .      | ✍️ #6 tsdf/sess1/lq-delete-flow/li._i.r.json
-             |    └ (items index) | 0.23 kb -> 0.18 kb
       1.048s | end
       "
     `);
@@ -1567,7 +1563,7 @@ describe('async storage efficiency: list-query', () => {
       1.852s | ✍️ #1 tsdf/sess1/lq-query-invalidation-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.05 kb
       1.856s | ✍️ #2 tsdf/sess1/lq-query-invalidation-flow/li._i.r.json
-             |    └ (items index) | 0.18 kb -> 0.18 kb
+             |    └ (items index) | 0.12 kb -> 0.12 kb
       1.858s | end
       "
     `);
@@ -1654,7 +1650,7 @@ describe('async storage efficiency: list-query', () => {
       1.852s | ✍️ #1 tsdf/sess1/lq-coalesced-invalidations/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.06 kb
       1.856s | ✍️ #2 tsdf/sess1/lq-coalesced-invalidations/li._i.r.json
-             |    └ (items index) | 0.18 kb -> 0.18 kb
+             |    └ (items index) | 0.12 kb -> 0.12 kb
       1.858s | end
       "
     `);
@@ -1721,17 +1717,8 @@ describe('async storage efficiency: list-query', () => {
       getParsedOpfsFileData('tsdf/sess1/lq-offline-marker-flow/li._i.r.json'),
     ).toMatchInlineSnapshot(`
       e:
-        "users||1:
-          a: 1735689600000
-          f: ['age', 'email', 'id', 'name']
-          o: '✅'
-          p: 'users||1'
-          z: 94
-        "users||2:
-          a: 1735689613968
-          f: ['age', 'email', 'id', 'name']
-          p: 'users||2'
-          z: 95
+        "users||1: { a: 1735689600000, o: '✅', p: 'users||1', z: 62 }
+        "users||2: { a: 1735689613968, p: 'users||2', z: 63 }
     `);
     expect(
       getParsedOpfsFileData(
@@ -1998,7 +1985,7 @@ describe('async storage efficiency: list-query', () => {
       1.853s | ✍️ #2 tsdf/sess1/lq-item-invalidation-flow/li.h~228010772.p.json
              |    └ (item data, <"users||1>) | 0.06 kb -> 0.05 kb
       1.857s | ✍️ #3 tsdf/sess1/lq-item-invalidation-flow/li._i.r.json
-             |    └ (items index) | 0.18 kb -> 0.18 kb
+             |    └ (items index) | 0.12 kb -> 0.12 kb
       1.859s | end
       "
     `);
@@ -2250,11 +2237,7 @@ describe('async storage efficiency: list-query', () => {
     expect(getParsedOpfsFileData('tsdf/sess1/lq-mutation-flow/li._i.r.json'))
       .toMatchInlineSnapshot(`
         e:
-          "users||1:
-            a: 1735689600000
-            f: ['age', 'email', 'id', 'name']
-            p: 'users||1'
-            z: 95
+          "users||1: { a: 1735689600000, p: 'users||1', z: 63 }
       `);
     expect(mutationOperations).toMatchInlineSnapshot(`
       "
@@ -2387,11 +2370,14 @@ describe('async storage efficiency: list-query', () => {
           name: 'Project 1',
         }),
       ),
+      // All three queries fit the query budget — the byte pressure that forces
+      // an eviction during the tasks flush comes from maxItemBytes alone.
       maxQueryBytes: sumPersistedEntryBytes(
         getAsyncListQueryEntrySizeBytes(usersQuery, [storeItemKey('users', 1)]),
         getAsyncListQueryEntrySizeBytes(projectsQuery, [
           storeItemKey('projects', 1),
         ]),
+        getAsyncListQueryEntrySizeBytes(tasksQuery, [storeItemKey('tasks', 1)]),
       ),
       serverData: {
         users: [{ id: 1, name: 'User 1' }],
@@ -2422,18 +2408,277 @@ describe('async storage efficiency: list-query', () => {
     expect(readCapture.finish().timelineString).toMatchInlineSnapshot(`
       "
       time   |
-      1.85s  | 🗑️ #1 ✅ tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~2924752681.p.json
-             |    └ (item data, <"projects||1>)
-      .      | 👁️ #2 file-open-or-create 🆕 tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~228010772.p.json
+      1.85s  | 👁️ #1 file-open-or-create 🆕 tsdf/sess1/list-query-opfs-eviction-efficiency/lq.h~4263007875.p.json
+             |    └ (query data)
+      .      | 🗑️ #2 ✅ tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~228010772.p.json
+             |    └ (item data, <"users||1>)
+      .      | 👁️ #3 file-open-or-create 🆕 tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~1128283337.p.json
              |    └ (item data)
-      1.853s | ✍️ #2 tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~228010772.p.json
+      1.853s | ✍️ #1 tsdf/sess1/list-query-opfs-eviction-efficiency/lq.h~4263007875.p.json
+             |    └ (query data) | 0.00 kb -> 0.03 kb
+      .      | ✍️ #3 tsdf/sess1/list-query-opfs-eviction-efficiency/li.h~1128283337.p.json
              |    └ (item data) | 0.00 kb -> 0.05 kb
-      1.857s | ✍️ #3 tsdf/sess1/list-query-opfs-eviction-efficiency/li._i.r.json
-             |    └ (items index) | 0.16 kb -> 0.15 kb
+      1.857s | ✍️ #4 tsdf/sess1/list-query-opfs-eviction-efficiency/lq._i.r.json
+             |    └ (queries index) | 0.34 kb -> 0.48 kb
+      .      | ✍️ #5 tsdf/sess1/list-query-opfs-eviction-efficiency/li._i.r.json
+             |    └ (items index) | 0.27 kb -> 0.27 kb
       1.859s | end
       "
     `);
     expect(mockAdapter.payloadGetRequests).toMatchInlineSnapshot(`[]`);
     expect(mockAdapter.payloadGetManyRequests).toMatchInlineSnapshot(`[]`);
+  });
+
+  test('a newly fetched query evicts the least recently used in-state query when the query budget is full', async () => {
+    const storeName = 'lq-query-budget-recency';
+    const sessionKey = 'sess1';
+    const usersQuery = { tableId: 'users' };
+    const projectsQuery = { tableId: 'projects' };
+    const tasksQuery = { tableId: 'tasks' };
+    const mockAdapter = createOpfsPersistentStorageTestStore();
+    const listQueryScope = mockAdapter.scope(storeName, sessionKey);
+    const env = createListQueryEnv({
+      storeName,
+      sessionKey,
+      // The budget fits exactly two persisted queries, so fetching a third
+      // must evict one even though all three stay loaded in memory.
+      maxQueryBytes: sumPersistedEntryBytes(
+        getAsyncListQueryEntrySizeBytes(projectsQuery, [
+          storeItemKey('projects', 1),
+        ]),
+        getAsyncListQueryEntrySizeBytes(tasksQuery, [storeItemKey('tasks', 1)]),
+      ),
+      serverData: {
+        users: [{ id: 1, name: 'User 1' }],
+        projects: [{ id: 1, name: 'Project 1' }],
+        tasks: [{ id: 1, name: 'Task 1' }],
+      },
+    });
+
+    await settleStartupBackgroundScan(mockAdapter);
+
+    // Fetch and persist users, then projects, with a real time gap so their
+    // persisted lastAccessAt timestamps differ (users is the oldest).
+    env.scheduleFetch('highPriority', usersQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.scheduleFetch('highPriority', projectsQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(listQueryScope.listQuery.listStoredQueryKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['{tableId:"projects"}', '{tableId:"users"}']
+      `);
+
+    // Fetching tasks overflows the query budget. The new query must win a
+    // persistence slot: unchanged in-state queries compete with their real
+    // persisted recency, so the least recently persisted one (users) is
+    // evicted — the fresh fetch is never silently dropped.
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(listQueryScope.listQuery.listStoredQueryKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['{tableId:"projects"}', '{tableId:"tasks"}']
+      `);
+    // The evicted query's item is dropped with it — its only reference was
+    // the users query, which is no longer persisted.
+    expect(listQueryScope.listQuery.listStoredItemKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['"projects||1', '"tasks||1']
+      `);
+  });
+
+  test('a budget-evicted in-state query stays evicted across later flushes instead of churning back into storage', async () => {
+    const storeName = 'lq-query-budget-stability';
+    const sessionKey = 'sess1';
+    const usersQuery = { tableId: 'users' };
+    const projectsQuery = { tableId: 'projects' };
+    const tasksQuery = { tableId: 'tasks' };
+    const mockAdapter = createOpfsPersistentStorageTestStore();
+    const listQueryScope = mockAdapter.scope(storeName, sessionKey);
+    const env = createListQueryEnv({
+      storeName,
+      sessionKey,
+      // The budget fits exactly two persisted queries, so keeping three
+      // loaded in memory forces one of them out of persistence.
+      maxQueryBytes: sumPersistedEntryBytes(
+        getAsyncListQueryEntrySizeBytes(projectsQuery, [
+          storeItemKey('projects', 1),
+        ]),
+        getAsyncListQueryEntrySizeBytes(tasksQuery, [storeItemKey('tasks', 1)]),
+      ),
+      serverData: {
+        users: [{ id: 1, name: 'User 1' }],
+        projects: [{ id: 1, name: 'Project 1' }],
+        tasks: [{ id: 1, name: 'Task 1' }],
+      },
+    });
+
+    await settleStartupBackgroundScan(mockAdapter);
+
+    // Fetch three queries with real time gaps so persisted recency is
+    // unambiguous: users is the oldest, tasks the newest.
+    env.scheduleFetch('highPriority', usersQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.scheduleFetch('highPriority', projectsQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    // The third fetch overflowed the budget and evicted the least recently
+    // persisted query (users) even though it is still loaded in memory.
+    expect(listQueryScope.listQuery.listStoredQueryKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['{tableId:"projects"}', '{tableId:"tasks"}']
+      `);
+
+    // Trigger more flushes with a state change that does not alter any
+    // persisted query content: refetching tasks yields identical data. The
+    // evicted users query must not re-enter storage as if it were freshly
+    // accessed and knock out a different survivor — that would make every
+    // flush churn remove/re-add writes while the state stays over budget.
+    const churnCapture =
+      startOpfsPersistentStorageOperationCapture(mockAdapter);
+
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(listQueryScope.listQuery.listStoredQueryKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['{tableId:"projects"}', '{tableId:"tasks"}']
+      `);
+
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(listQueryScope.listQuery.listStoredQueryKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['{tableId:"projects"}', '{tableId:"tasks"}']
+      `);
+
+    // The two follow-up flushes must not have produced any query entry
+    // removals or re-writes — the persisted set is already stable.
+    expect(churnCapture.finish().timelineString).toMatchInlineSnapshot(
+      `"empty"`,
+    );
+  });
+
+  test('a budget-evicted in-state item stays evicted across later flushes instead of churning back into storage', async () => {
+    const storeName = 'lq-item-budget-stability';
+    const sessionKey = 'sess1';
+    const mockAdapter = createOpfsPersistentStorageTestStore();
+    const listQueryScope = mockAdapter.scope(storeName, sessionKey);
+    const env = createListQueryEnv({
+      storeName,
+      sessionKey,
+      // The budget fits exactly two persisted standalone items, so keeping
+      // three loaded in memory forces one of them out of persistence.
+      maxItemBytes: sumPersistedEntryBytes(
+        getAsyncListItemEntrySizeBytes(rawItemPayload('users', 2), {
+          id: 2,
+          name: 'User 2',
+        }),
+        getAsyncListItemEntrySizeBytes(rawItemPayload('users', 3), {
+          id: 3,
+          name: 'User 3',
+        }),
+      ),
+      serverData: {
+        users: [
+          { id: 1, name: 'User 1' },
+          { id: 2, name: 'User 2' },
+          { id: 3, name: 'User 3' },
+        ],
+      },
+    });
+
+    await settleStartupBackgroundScan(mockAdapter);
+
+    // Fetch three standalone items with real time gaps so persisted recency
+    // is unambiguous: users||1 is the oldest, users||3 the newest.
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 1));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 2));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 3));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    // The third fetch overflowed the budget and evicted the least recently
+    // persisted item (users||1) even though it is still loaded in memory.
+    expect(listQueryScope.listQuery.listStoredItemKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['"users||2', '"users||3']
+      `);
+
+    // Trigger more flushes with a state change that does not alter any
+    // persisted item content: refetching users||3 yields identical data. The
+    // evicted users||1 item must not re-enter storage as if it were freshly
+    // accessed and knock out a different survivor.
+    const churnCapture =
+      startOpfsPersistentStorageOperationCapture(mockAdapter);
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 3));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(listQueryScope.listQuery.listStoredItemKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['"users||2', '"users||3']
+      `);
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 3));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(listQueryScope.listQuery.listStoredItemKeys().sort())
+      .toMatchInlineSnapshot(`
+        ['"users||2', '"users||3']
+      `);
+
+    // The two follow-up flushes must not have produced any item entry
+    // removals or re-writes — the persisted set is already stable. The only
+    // captured operations are failed opens of the queries index (this test
+    // never persists a query, so the file does not exist): read-only probes,
+    // no writes and no removals.
+    expect(churnCapture.finish().timelineString).toMatchInlineSnapshot(`
+      "
+      time   |
+      1.81s  | 👁️ #1 file-open ❌ tsdf/sess1/lq-item-budget-stability/lq._i.r.json
+             |    └ (queries index)
+             ·
+      4.721s | 👁️ #1 file-open ❌ tsdf/sess1/lq-item-budget-stability/lq._i.r.json
+             |    └ (queries index)
+      4.722s | end
+      "
+    `);
   });
 });

--- a/tests/persistent-storage/indexeddb-async-storage-efficiency/list-query.test.ts
+++ b/tests/persistent-storage/indexeddb-async-storage-efficiency/list-query.test.ts
@@ -1,3 +1,4 @@
+import { createLoggerStore } from '@ls-stack/utils/testUtils';
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
 import { describe, expect, test } from 'vitest';
@@ -19,6 +20,7 @@ import {
   flushInvalidationPersistence,
   getAsyncListItemEntrySizeBytes,
   getAsyncListQueryEntrySizeBytes,
+  partialResourcesConfig,
   rawItemPayload,
   resolveAfterIndexedDbStorage,
   setProtectedKeysSnapshot,
@@ -664,10 +666,7 @@ describe('indexeddb async storage efficiency: list-query', () => {
       }),
     ).toMatchInlineSnapshot(`
       entries:
-        "users||1:
-          a: 1735689600000
-          f: ['age', 'email', 'id', 'name']
-          p: 'users||1'
+        "users||1: { a: 1735689600000, p: 'users||1' }
     `);
     expect(
       await readListQueryItemPayloadSnapshot({
@@ -794,7 +793,7 @@ describe('indexeddb async storage efficiency: list-query', () => {
       maxItemBytes: sumPersistedEntryBytes(
         getAsyncListItemEntrySizeBytes(rawItemPayload('standalone', 1), {
           id: 1,
-          name: 'Expired oldest',
+          name: 'Expired recent',
         }),
         getAsyncListItemEntrySizeBytes(rawItemPayload('admins', 4), {
           id: 4,
@@ -813,7 +812,7 @@ describe('indexeddb async storage efficiency: list-query', () => {
     // Persist two standalone items that will later look expired to the cleanup pass.
     env.apiStore.addItemToState(rawItemPayload('standalone', 1), {
       id: 1,
-      name: 'Expired oldest',
+      name: 'Expired recent',
     });
     await advanceTime(1100);
     await settleIndexedDbStorage();
@@ -821,18 +820,24 @@ describe('indexeddb async storage efficiency: list-query', () => {
     await advanceTime(100);
     env.apiStore.addItemToState(rawItemPayload('standalone', 2), {
       id: 2,
-      name: 'Expired newer',
+      name: 'Expired older',
     });
     await advanceTime(1100);
     await settleIndexedDbStorage();
 
-    // Persist one query-backed item before introducing a second query-backed item.
+    // Persist one query-backed item before introducing a second query-backed
+    // item. This flush already overflows the item budget, so the least recently
+    // persisted item (standalone||1) loses its storage slot here while staying
+    // loaded in memory.
     env.scheduleFetch('highPriority', usersQuery);
     await settleIndexedDbStorage();
     await advanceTime(1100);
     await settleIndexedDbStorage();
 
-    // Backdate the standalone entries so the later maxItems cleanup sees them as stale persisted candidates.
+    // Backdate the standalone entries so the later maxItems cleanup sees them
+    // as stale candidates (standalone||1 is already out of storage, so its
+    // backdate only touches leftover metadata). The timestamps are distinct so
+    // the recency ordering stays deterministic.
     mockAdapter.setMetadata(
       listQueryScope.listQuery.itemStorageKey('standalone', 1),
       {
@@ -848,7 +853,7 @@ describe('indexeddb async storage efficiency: list-query', () => {
         ...(await mockAdapter.readMetadata(
           listQueryScope.listQuery.itemStorageKey('standalone', 2),
         )),
-        lastAccessAt: expiredTimestamp,
+        lastAccessAt: expiredTimestamp - 60 * 60 * 1000,
       },
     );
     await settleIndexedDbStorage();
@@ -863,9 +868,13 @@ describe('indexeddb async storage efficiency: list-query', () => {
     await settleIndexedDbStorage();
     const operationsBreakdown = readCapture.finish().timelineString;
 
+    // The budget keeps the two most recently accessed items: the freshly
+    // fetched admins||4 and the query-backed users||3. The stale standalone||2
+    // is removed, and the previously budget-evicted standalone||1 is not
+    // resurrected as if it were freshly accessed.
     expect(
       (await listQueryScope.listQuery.listStoredItemKeys()).sort(),
-    ).toMatchInlineSnapshot(`['"admins||4', '"standalone||2']`);
+    ).toMatchInlineSnapshot(`['"admins||4', '"users||3']`);
     expect(
       await readListQueryItemNamespaceSnapshot({
         mockAdapter,
@@ -874,8 +883,8 @@ describe('indexeddb async storage efficiency: list-query', () => {
       }),
     ).toMatchInlineSnapshot(`
       entries:
-        "admins||4: { a: 1735689619227, p: 'admins||4' }
-        "standalone||2: { a: 1735689619227, p: 'standalone||2' }
+        "admins||4: { a: 1735689619226, p: 'admins||4' }
+        "users||3: { a: 1735689616210, p: 'users||3' }
 
       staticPolicy: { b: 147 }
     `);
@@ -888,10 +897,10 @@ describe('indexeddb async storage efficiency: list-query', () => {
     ).toMatchInlineSnapshot(`
       entries:
         {tableId:"admins"}:
-          a: 1735689619181
+          a: 1735689619180
           p: { tableId: 'admins' }
         {tableId:"users"}:
-          a: 1735689616163
+          a: 1735689616164
           p: { tableId: 'users' }
     `);
     expect(
@@ -913,9 +922,9 @@ describe('indexeddb async storage efficiency: list-query', () => {
     expect(operationsBreakdown).toMatchInlineSnapshot(`
       ""
       1.812s | 🔎 entries.byScopeLastAccessAt scope=["sess1","lq-expired-during-max-items","listQuery.query"] order=lru-desc -> ["{tableId:\\"users\\"}"]
-      1.816s | 🔎 entries.byScopeLastAccessAt scope=["sess1","lq-expired-during-max-items","listQuery.item"] order=lru-desc -> ["\\"users||3", "\\"standalone||1"]
+      1.816s | 🔎 entries.byScopeLastAccessAt scope=["sess1","lq-expired-during-max-items","listQuery.item"] order=lru-desc -> ["\\"users||3", "\\"standalone||2"]
       1.862s | ✍️ tx(entries, namespacePolicies).commit scope=["sess1","lq-expired-during-max-items","listQuery.query"] put=["{tableId:\\"admins\\"}"] delete=[] touch=[] static-policy
-      1.914s | ✍️ tx(entries, namespacePolicies).commit scope=["sess1","lq-expired-during-max-items","listQuery.item"] put=["\\"admins||4", "\\"standalone||2"] delete=["\\"standalone||1", "\\"users||3"] touch=[] static-policy
+      1.91s | ✍️ tx(entries, namespacePolicies).commit scope=["sess1","lq-expired-during-max-items","listQuery.item"] put=["\\"admins||4"] delete=["\\"standalone||2"] touch=[] static-policy
       ""
     `);
 
@@ -942,7 +951,7 @@ describe('indexeddb async storage efficiency: list-query', () => {
             rows:
               - key: ['["sess1","lq-expired-during-max-items","li"]', '"admins||4']
                 value: 'JSON object | 0.3 kb'
-              - key: ['["sess1","lq-expired-during-max-items","li"]', '"standalone||2']
+              - key: ['["sess1","lq-expired-during-max-items","li"]', '"users||3']
                 value: 'JSON object | 0.3 kb'
               - key: ['["sess1","lq-expired-during-max-items","lq"]', '{tableId:"admins"}']
                 value: 'JSON object | 0.3 kb'
@@ -1497,6 +1506,122 @@ describe('indexeddb async storage efficiency: list-query', () => {
     );
   });
 
+  test("round-trip persistence preserves the fully-loaded ('*') marker for cached items", async () => {
+    const storeName = 'lq-full-star-roundtrip';
+    const sessionKey = 'sess1';
+    const itemPayload = rawItemPayload('users', 1);
+    const mockAdapter = createIndexedDbPersistentStorageTestStore();
+
+    // Writer session: fetch the complete item so the fully-loaded ('*') marker
+    // must be persisted alongside the item data.
+    const writerEnv = createListQueryEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Cached', age: 31, email: 'cached@site.test' }],
+      },
+    });
+
+    await settleStartupBackgroundScan(mockAdapter);
+
+    writerEnv.apiStore.scheduleItemFetch('highPriority', itemPayload, {
+      fields: '*',
+    });
+
+    await settleIndexedDbStorage();
+    await advanceTime(1100);
+    await settleIndexedDbStorage();
+
+    // The persisted manifest metadata must carry `f: '*'`; if the adapter
+    // rejected the marker the entry would be silently dropped on read.
+    expect(
+      await readListQueryItemNamespaceSnapshot({
+        mockAdapter,
+        sessionKey,
+        storeName,
+      }),
+    ).toMatchInlineSnapshot(`
+      entries:
+        "users||1: { a: 1735689613862, f: '*', p: 'users||1' }
+    `);
+    expect(
+      await readListQueryItemPayloadSnapshot({
+        id: 1,
+        mockAdapter,
+        sessionKey,
+        storeName,
+        tableId: 'users',
+      }),
+    ).toMatchInlineSnapshot(`
+      age: 31
+      email: 'cached@site.test'
+      id: 1
+      name: 'Cached'
+    `);
+
+    // Reader session: same storage, but the server now has newer data so we
+    // can tell hydrated data ('Cached') apart from fetched data ('Fresh').
+    const readerEnv = createListQueryEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Fresh', age: 32, email: 'fresh@site.test' }],
+      },
+    });
+
+    // Hydrate the cached snapshot into the reader before any hook subscribes.
+    expect(
+      await resolveAfterIndexedDbStorage(
+        readerEnv.apiStore.preloadItemFromStorage(itemPayload),
+        mockAdapter,
+      ),
+    ).toMatchInlineSnapshot(`- { payload: 'users||1', preloaded: '✅' }`);
+
+    // Hydration restored the fully-loaded marker, so a `fields: '*'` read is
+    // satisfiable from the cached snapshot.
+    expect(
+      readerEnv.store.state.itemLoadedFields[storeItemKey('users', 1)],
+    ).toBe('*');
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const { data, status } = readerEnv.apiStore.useItem(itemPayload, {
+        fields: '*',
+        returnRefetchingStatus: true,
+      });
+      renders.add({ status, name: data?.name ?? null });
+    });
+
+    await settleIndexedDbStorage();
+
+    // The hook renders success with the hydrated data right away and only
+    // transitions through a background revalidation, never a blocking load.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: Cached
+      -> status: refetching ⋅ name: Cached
+      -> status: success ⋅ name: Fresh
+      "
+    `);
+
+    // The only network request is the low-priority revalidation of the
+    // hydrated item, not a fields-driven fetch of missing data.
+    expect(
+      readerEnv.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`
+      - _type: 'item'
+        payload: { itemId: 'users||1' }
+    `);
+
+    // The marker survives the revalidation.
+    expect(
+      readerEnv.store.state.itemLoadedFields[storeItemKey('users', 1)],
+    ).toBe('*');
+  });
+
   test('useListQuery invalidation snapshots the full query persistence timeline through the refetch save', async () => {
     const storeName = 'lq-query-invalidation-flow';
     const sessionKey = 'sess1';
@@ -1719,12 +1844,8 @@ describe('indexeddb async storage efficiency: list-query', () => {
       }),
     ).toMatchInlineSnapshot(`
       entries:
-        "users||1:
-          a: 1735689600000
-          f: ['age', 'email', 'id', 'name']
-          o: '✅'
-          p: 'users||1'
-        "users||2: { a: 1735689617878, p: 'users||2' }
+        "users||1: { a: 1735689600000, o: '✅', p: 'users||1' }
+        "users||2: { a: 1735689617832, p: 'users||2' }
     `);
     expect(
       await readListQueryItemPayloadSnapshot({
@@ -2189,10 +2310,7 @@ describe('indexeddb async storage efficiency: list-query', () => {
       }),
     ).toMatchInlineSnapshot(`
       entries:
-        "users||1:
-          a: 1735689600000
-          f: ['age', 'email', 'id', 'name']
-          p: 'users||1'
+        "users||1: { a: 1735689600000, p: 'users||1' }
     `);
     expect(mutationOperations).toContain(
       'commit scope=["sess1","lq-mutation-flow","listQuery.item"] put=["\\"users||1"] delete=[] touch=[] static-policy',
@@ -2311,23 +2429,14 @@ describe('indexeddb async storage efficiency: list-query', () => {
           }),
         ),
       ),
-      maxQueryBytes: Math.max(
-        sumPersistedEntryBytes(
-          getAsyncListQueryEntrySizeBytes(usersQuery, [
-            storeItemKey('users', 1),
-          ]),
-          getAsyncListQueryEntrySizeBytes(projectsQuery, [
-            storeItemKey('projects', 1),
-          ]),
-        ),
-        sumPersistedEntryBytes(
-          getAsyncListQueryEntrySizeBytes(projectsQuery, [
-            storeItemKey('projects', 1),
-          ]),
-          getAsyncListQueryEntrySizeBytes(tasksQuery, [
-            storeItemKey('tasks', 1),
-          ]),
-        ),
+      // All three queries fit the query budget — the byte pressure that forces
+      // an eviction during the tasks flush comes from maxItemBytes alone.
+      maxQueryBytes: sumPersistedEntryBytes(
+        getAsyncListQueryEntrySizeBytes(usersQuery, [storeItemKey('users', 1)]),
+        getAsyncListQueryEntrySizeBytes(projectsQuery, [
+          storeItemKey('projects', 1),
+        ]),
+        getAsyncListQueryEntrySizeBytes(tasksQuery, [storeItemKey('tasks', 1)]),
       ),
       serverData: {
         users: [{ id: 1, name: 'User 1' }],

--- a/tests/persistent-storage/indexeddb-async-storage-efficiency/shared.ts
+++ b/tests/persistent-storage/indexeddb-async-storage-efficiency/shared.ts
@@ -3,7 +3,10 @@ import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { act, cleanup, renderHook } from '@testing-library/react';
 import { rc_number, rc_object, rc_string } from 'runcheck';
 import { afterEach, beforeAll, beforeEach, vi } from 'vitest';
-import type { OffsetPaginationConfig } from '../../../src/listQueryStore/types';
+import type {
+  OffsetPaginationConfig,
+  PartialResourcesConfig,
+} from '../../../src/listQueryStore/types';
 import { serializeProtectedRef } from '../../../src/persistentStorage/asyncStorageAdapter';
 import { DOCUMENT_PERSISTED_ENTRY_KEY } from '../../../src/persistentStorage/documentEntryKey';
 import { __resetSessionOfflineCoordinatorRegistryForTests } from '../../../src/persistentStorage/offline/sessionCoordinator';
@@ -460,6 +463,26 @@ export function storeItemKey(tableId: string, id: number): string {
   return getCompositeKey(rawItemPayload(tableId, id));
 }
 
+export const partialResourcesConfig: PartialResourcesConfig<Row> = {
+  mergeItems: (prev, fetched) => {
+    if (!prev) return fetched;
+    return { ...prev, ...fetched };
+  },
+  selectFields: (fields, item) => {
+    const result: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (field in item) {
+        result[field] = item[field];
+      }
+    }
+    return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
+  },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
+};
+
 export function createListQueryEnv(options: {
   defaultQuerySize?: number;
   maxItemBytes?: number;
@@ -468,6 +491,7 @@ export function createListQueryEnv(options: {
   maxQueries?: number;
   maxQuerySize?: number;
   offsetPagination?: OffsetPaginationConfig;
+  partialResources?: PartialResourcesConfig<Row>;
   pinnedItems?: string[];
   pinnedQueries?: Array<{ tableId: string }>;
   serverData?: Tables<Row>;
@@ -481,6 +505,7 @@ export function createListQueryEnv(options: {
     getSessionKey: () => options.sessionKey ?? 'session1',
     id: options.storeName,
     offsetPagination: options.offsetPagination,
+    partialResources: options.partialResources,
     persistentStorage: {
       adapter: mockAdapter.adapter,
       itemPayloadSchema: rc_string,

--- a/tests/persistent-storage/list-query-store-persistence.opfs.test.ts
+++ b/tests/persistent-storage/list-query-store-persistence.opfs.test.ts
@@ -543,6 +543,115 @@ describe('opfs: list query store persistence', () => {
     ).toMatchInlineSnapshot(`['id', 'name']`);
   });
 
+  test("round-trip persistence preserves the fully-loaded ('*') marker for cached items", async () => {
+    const storeName = 'lq-opfs-full-star-roundtrip';
+    const sessionKey = 'sess1';
+    const itemPayload = 'users||1';
+    const { listQueryScope } = createListQueryOpfsTestStore({
+      storeName,
+      sessionKey,
+    });
+
+    const writerEnv = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Cached', age: 31, email: 'cached@site.test' }],
+      },
+    });
+
+    writerEnv.apiStore.scheduleItemFetch('highPriority', itemPayload, {
+      fields: '*',
+    });
+
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    const itemIndex = __LEGIT_CAST__<
+      { e: Record<string, { f?: unknown; p?: unknown }> },
+      unknown
+    >(getParsedOpfsFileData(`tsdf/${sessionKey}/${storeName}/li._i.r.json`));
+    const itemMetadata = itemIndex.e[listQueryScope.itemKey('users', 1)];
+    expect({ f: itemMetadata?.f, p: itemMetadata?.p }).toMatchInlineSnapshot(`
+        f: '*'
+        p: 'users||1'
+      `);
+    expect(
+      getParsedOpfsFileData(
+        `tsdf/${sessionKey}/${storeName}/li.<${listQueryScope.itemKey('users', 1)}>.p.json`,
+      ),
+    ).toMatchInlineSnapshot(`
+      age: 31
+      email: 'cached@site.test'
+      id: 1
+      name: 'Cached'
+    `);
+
+    const readerEnv = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Fresh', age: 32, email: 'fresh@site.test' }],
+      },
+    });
+
+    const preloadPromise =
+      readerEnv.apiStore.preloadItemFromStorage(itemPayload);
+    await expect(resolveAfterAllTimers(preloadPromise)).resolves
+      .toMatchInlineSnapshot(`
+      - { payload: 'users||1', preloaded: '✅' }
+    `);
+
+    expect(
+      readerEnv.store.state.itemLoadedFields[
+        listQueryScope.itemKey('users', 1)
+      ],
+    ).toBe('*');
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const { data, status } = readerEnv.apiStore.useItem(itemPayload, {
+        fields: '*',
+        returnRefetchingStatus: true,
+      });
+
+      renders.add({ status, name: data?.name ?? null });
+    });
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: Cached
+      "
+    `);
+    expect(readerEnv.serverTable.numOfFinishedFetches).toBe(0);
+
+    await flushAllTimers();
+
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: Cached
+      ⋅⋅⋅
+      -> status: refetching ⋅ name: Cached
+      -> status: success ⋅ name: Fresh
+      "
+    `);
+    expect(
+      readerEnv.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload: { itemId: 'users||1' }
+      `);
+    expect(
+      readerEnv.store.state.itemLoadedFields[
+        listQueryScope.itemKey('users', 1)
+      ],
+    ).toBe('*');
+  });
+
   test('partial-resource persistence stores each item with its own loaded fields', async () => {
     const storeName = 'lq-opfs-partial-multiple-item-fields';
     const sessionKey = 'sess1';

--- a/tests/persistent-storage/list-query-store-persistence.opfs.test.ts
+++ b/tests/persistent-storage/list-query-store-persistence.opfs.test.ts
@@ -76,6 +76,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 const fullLoadedFields = ['age', 'email', 'id', 'name'];
 
@@ -1818,12 +1822,13 @@ describe('opfs: list query store persistence', () => {
     `);
 
     // Drop the in-memory item without touching the persisted copy so the next
-    // preload must go back to storage.
+    // preload must go back to storage. Item keys are the serialized payload, so
+    // the string payload 'users||1' is stored under the key '"users||1'.
     act(() => {
       env.store.produceState((draft) => {
-        delete draft.items['users||1'];
-        delete draft.itemQueries['users||1'];
-        delete draft.itemLoadedFields['users||1'];
+        delete draft.items['"users||1'];
+        delete draft.itemQueries['"users||1'];
+        delete draft.itemLoadedFields['"users||1'];
       });
     });
 

--- a/tests/persistent-storage/list-query-store-persistence.test.ts
+++ b/tests/persistent-storage/list-query-store-persistence.test.ts
@@ -2,6 +2,7 @@ import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { createLoggerStore } from '@ls-stack/utils/testUtils';
 import { renderHook } from '@testing-library/react';
+import { act } from 'react';
 import { rc_number, rc_object, rc_string } from 'runcheck';
 import {
   afterEach,
@@ -59,6 +60,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 const fullLoadedFields = ['age', 'email', 'id', 'name'];
 const persistentStore = createLocalStoragePersistentTestStore();
@@ -718,7 +723,6 @@ describe('localStorage: list query store persistence', () => {
         .listQuery.readItemEntry<Row>('users', 1).data,
     ).toMatchInlineSnapshot(`
       data: { id: 1, name: 'Cached' }
-      loadedFields: ['age', 'email', 'id', 'name']
       payload: 'users||1'
     `);
   });
@@ -777,6 +781,187 @@ describe('localStorage: list query store persistence', () => {
       .toMatchInlineSnapshot(`
         ['id', 'name']
       `);
+  });
+
+  test("round-trip persistence preserves the fully-loaded ('*') marker for cached items", async () => {
+    const itemPayload = rawItemPayload('users', 1);
+    const storeName = 'lq-full-star-roundtrip';
+    const sessionKey = 'sess1';
+
+    const writerEnv = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Cached', age: 31, email: 'cached@site.test' }],
+      },
+    });
+
+    // The writer fetches the complete item; the persisted snapshot must carry
+    // the fully-loaded marker (`lf: '*'`) instead of an enumerated field list.
+    writerEnv.apiStore.scheduleItemFetch('highPriority', itemPayload, {
+      fields: '*',
+    });
+
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(
+      getParsedLocalStorageValue(
+        itemStorageKey(storeName, sessionKey, 'users', 1),
+      ),
+    ).toMatchInlineSnapshot(`
+      d: { age: 31, email: 'cached@site.test', id: 1, name: 'Cached' }
+      lf: '*'
+      p: 'users||1'
+    `);
+
+    const readerEnv = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Fresh', age: 32, email: 'fresh@site.test' }],
+      },
+    });
+
+    const renders = createLoggerStore();
+
+    // A full ('*') read must be satisfiable straight from hydration: the first
+    // render is already a success, which only happens when the restored marker
+    // is '*' — a fabricated field list would not vouch for a complete item.
+    renderHook(() => {
+      const { data, status } = readerEnv.apiStore.useItem(itemPayload, {
+        fields: '*',
+        returnRefetchingStatus: true,
+      });
+
+      renders.add({ status, name: data?.name ?? null });
+    });
+
+    // Assert the synchronous hydration result before flushing the mount effect.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: Cached
+      "
+    `);
+    expect(readerEnv.serverTable.numOfFinishedFetches).toBe(0);
+    expect(
+      readerEnv.store.state.itemLoadedFields[storeItemKey('users', 1)],
+    ).toBe('*');
+
+    await flushAllTimers();
+
+    // The hydrated snapshot only revalidates (a single low-priority refetch of
+    // the complete item), it never blocks the UI behind a loading state.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: Cached
+      ⋅⋅⋅
+      -> status: refetching ⋅ name: Cached
+      -> status: success ⋅ name: Fresh
+      "
+    `);
+    expect(
+      readerEnv.serverTable.getRequestHistory('item', { includeTime: false }),
+    ).toMatchInlineSnapshot(`
+      - _type: 'item'
+        payload: { itemId: 'users||1' }
+    `);
+    expect(
+      readerEnv.store.state.itemLoadedFields[storeItemKey('users', 1)],
+    ).toBe('*');
+  });
+
+  test('a failed mutation rollback does not resurrect stale loadedFields into the persisted snapshot', async () => {
+    const itemPayload = rawItemPayload('users', 1);
+    const storeName = 'lq-rollback-loaded-fields';
+    const sessionKey = 'sess1';
+
+    const env = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: { users: [{ id: 1, name: 'Server' }] },
+    });
+
+    // A manually added item has no loadedFields metadata entry — for such
+    // items `inferFields` governs the staleness baseline, so the persisted
+    // snapshot must carry no `lf` field either.
+    act(() => {
+      env.apiStore.addItemToState(itemPayload, { id: 1, name: 'Client draft' });
+    });
+    await advanceTime(1100);
+    expect(
+      getParsedLocalStorageValue(
+        itemStorageKey(storeName, sessionKey, 'users', 1),
+      ),
+    ).toMatchInlineSnapshot(`
+      d: { id: 1, name: 'Client draft' }
+      p: 'users||1'
+    `);
+
+    // Start a slow save that will ultimately fail. The rollback snapshot is
+    // captured now, while the item is still metadata-free.
+    let rejectMutation: (error: Error) => void = () => {};
+    let mutationResult!: Promise<unknown>;
+    act(() => {
+      mutationResult = env.apiStore.performMutation(itemPayload, {
+        optimisticUpdate: () => {
+          env.apiStore.updateItemState(itemPayload, (draft) => {
+            draft.name = 'Optimistic';
+          });
+        },
+        mutation: () =>
+          new Promise((_resolve, reject) => {
+            rejectMutation = reject;
+          }),
+      });
+    });
+
+    // While the save is in flight the item gets invalidated (e.g. by a
+    // real-time event). On a partial-resources store this clears the loaded
+    // fields to `[]`, and the refetch it schedules is deferred until the
+    // mutation settles. Make that deferred refetch fail so no fresh fetch
+    // metadata masks what the rollback leaves behind.
+    env.serverTable.setNextFetchError(itemPayload, 'refetch offline');
+    act(() => {
+      env.apiStore.invalidateItem(itemPayload);
+    });
+
+    // A regular flush runs mid-mutation and persists the transient `lf: []`.
+    await advanceTime(1100);
+    expect(
+      getParsedLocalStorageValue(
+        itemStorageKey(storeName, sessionKey, 'users', 1),
+      ),
+    ).toMatchInlineSnapshot(`
+      d: { id: 1, name: 'Optimistic' }
+      lf: []
+      p: 'users||1'
+    `);
+
+    // The save fails: the rollback restores the metadata-free baseline,
+    // deleting the state loadedFields entry while the item stays in state.
+    rejectMutation(new Error('save failed'));
+    await act(async () => {
+      await mutationResult;
+    });
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    // The follow-up flush must persist the item without `lf` again. The state
+    // deliberately has no metadata anymore, so the stale mid-mutation `lf`
+    // must not be resurrected from the previously persisted snapshot.
+    expect(
+      getParsedLocalStorageValue(
+        itemStorageKey(storeName, sessionKey, 'users', 1),
+      ),
+    ).toMatchInlineSnapshot(`
+      d: { id: 1, name: 'Client draft' }
+      p: 'users||1'
+    `);
   });
 
   test('partial-resource persistence stores each item with its own loaded fields', async () => {
@@ -1014,6 +1199,145 @@ describe('localStorage: list query store persistence', () => {
     expect(readerEnv.store.state.itemLoadedFields[storeItemKey('users', 1)])
       .toMatchInlineSnapshot(`
         ['age', 'email', 'id', 'name']
+      `);
+  });
+
+  test('a hydrated fields:"*" hook does not report success from a partial persisted snapshot', async () => {
+    const itemPayload = rawItemPayload('users', 1);
+    const storeName = 'lq-item-partial-full-hook';
+    const sessionKey = 'sess1';
+
+    // Persisted entry only holds a partial field set (id/name). This config's
+    // inferFields never returns '*', so the fallback snapshot is genuinely
+    // incomplete — a fields:'*' hook must not trust it.
+    persistentStore
+      .scope(storeName, sessionKey)
+      .listQuery.seedItem(
+        'users',
+        1,
+        { id: 1, name: 'Cached' },
+        { loadedFields: ['id', 'name'] },
+      );
+
+    const env = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Fresh', age: 21, email: 'fresh@site.test' }],
+      },
+    });
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const { data, status } = env.apiStore.useItem(itemPayload, {
+        fields: '*',
+        returnRefetchingStatus: true,
+      });
+
+      renders.add({
+        status,
+        name: data?.name ?? null,
+        age: data?.age ?? null,
+        email: data?.email ?? null,
+      });
+    });
+
+    await flushAllTimers();
+
+    // The fields:'*' hook must revalidate: it may not surface `success` from the
+    // partial persisted fallback (which lacks age/email). Previously the
+    // fallback render treated any fields:'*' request as satisfied.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: loading ⋅ name: null ⋅ age: null ⋅ email: null
+      -> status: success ⋅ name: Fresh ⋅ age: 21 ⋅ email: fresh@site.test
+      "
+    `);
+
+    // A full-item fetch is issued to complete the missing fields.
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload: { itemId: 'users||1' }
+      `);
+  });
+
+  test('hydrating an item persisted without loadedFields metadata does not fabricate metadata from object keys', async () => {
+    const itemPayload = rawItemPayload('users', 1);
+    const storeName = 'lq-item-metadata-free-hydration';
+    const sessionKey = 'sess1';
+
+    // A client-created item is persisted. `addItemToState` sets no
+    // `itemLoadedFields`, so the persisted entry carries no `lf` metadata —
+    // `inferFields` is the designed authority for such snapshots.
+    const writerEnv = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+    });
+
+    // No hooks are mounted on the writer env; no act() wrapper needed.
+    writerEnv.apiStore.addItemToState(itemPayload, {
+      id: 1,
+      name: 'Created',
+      email: 'created@site.test',
+    });
+
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    // The persisted entry has no `lf` key.
+    expect(
+      getParsedLocalStorageValue(
+        itemStorageKey(storeName, sessionKey, 'users', 1),
+      ),
+    ).toMatchInlineSnapshot(`
+      d: { email: 'created@site.test', id: 1, name: 'Created' }
+      p: 'users||1'
+    `);
+
+    const readerEnv = createEnv({
+      storeName,
+      sessionKey,
+      partialResources: partialResourcesConfig,
+      serverData: {
+        users: [{ id: 1, name: 'Fresh', email: 'fresh@site.test' }],
+      },
+    });
+
+    const renders = createLoggerStore();
+
+    renderHook(() => {
+      const { data, status } = readerEnv.apiStore.useItem(itemPayload, {
+        fields: ['id', 'name'],
+        returnRefetchingStatus: true,
+      });
+
+      renders.add({ status, name: data?.name ?? null });
+    });
+
+    await flushAllTimers();
+
+    // Cached data is visible immediately and the mount revalidation refreshes
+    // the requested fields.
+    expect(renders.changesSnapshot).toMatchInlineSnapshot(`
+      "
+      -> status: success ⋅ name: Created
+      -> status: refetching ⋅ name: Created
+      -> status: success ⋅ name: Fresh
+      "
+    `);
+
+    // Only the fields actually fetched become loaded-field metadata. Previously
+    // hydration fabricated `['email', 'id', 'name']` from the snapshot's object
+    // keys — the shallow inference the partial-resources design forbids — and
+    // the never-fetched email was falsely marked as loaded/fresh.
+    expect(readerEnv.store.state.itemLoadedFields[storeItemKey('users', 1)])
+      .toMatchInlineSnapshot(`
+        ['id', 'name']
       `);
   });
 

--- a/tests/persistent-storage/persistence-with-tabs-sync.test.ts
+++ b/tests/persistent-storage/persistence-with-tabs-sync.test.ts
@@ -45,6 +45,10 @@ const partialResourcesConfig: PartialResourcesConfig<Row> = {
     }
     return __LEGIT_CAST__<Row, Record<string, unknown>>(result);
   },
+  inferFields: (item) =>
+    Object.entries(item)
+      .filter(([, value]) => value !== undefined)
+      .map(([field]) => field),
 };
 const persistentStore = createLocalStoragePersistentTestStore();
 

--- a/tests/persistent-storage/sync-storage-efficiency/list-query.test.ts
+++ b/tests/persistent-storage/sync-storage-efficiency/list-query.test.ts
@@ -432,17 +432,15 @@ describe('sync storage efficiency: list-query', () => {
             |    └ (query data, <{tableId:"fourth"}>)
       .     | ✍️ #4 ❌->✅ tsdf.sess1.lq-coalesced-query-maintenance.lq.{tableId:"fourth"}
             |    └ (query data, <{tableId:"fourth"}>) | ❌ -> 0.13 kb
-      .     | ✍️ #3 ✅->✅ tsdf.sess1.lq-coalesced-query-maintenance.li."third||1
-            |    └ (item data, <"third||1>) | 0.09 kb -> 0.15 kb
       .     | 📖 #2 ✅ tsdf._m.r.n:sess1.lq-coalesced-query-maintenance.li.m
             |    └ (items index) | 0.12 kb
       .     | ✍️ #5 ❌->✅ tsdf.sess1.lq-coalesced-query-maintenance.li."fourth||2
             |    └ (item data, <"fourth||2>) | ❌ -> 0.09 kb
       .     | ✍️ #2 ✅->✅ tsdf._m.r.n:sess1.lq-coalesced-query-maintenance.li.m
-            |    └ (items index) | 0.12 kb -> 0.29 kb
+            |    └ (items index) | 0.12 kb -> 0.23 kb
             ·
       3.81s | 📖 #2 ✅ tsdf._m.r.n:sess1.lq-coalesced-query-maintenance.li.m
-            |    └ (items index) | 0.29 kb
+            |    └ (items index) | 0.23 kb
       .     | 🔑[0] #6 ✅ tsdf.sess1.lq-coalesced-query-maintenance.lq.{tableId:"first"}
             |    └ (query data, <{tableId:"first"}>)
       .     | 🔑[1] #7 ✅ tsdf.sess1.lq-coalesced-query-maintenance.lq.{tableId:"second"}
@@ -587,11 +585,7 @@ describe('sync storage efficiency: list-query', () => {
     expect(getParsedLocalStorageValue(itemManifestKey)).toMatchInlineSnapshot(
       `
         e:
-          "users||1:
-            a: 1735689613910
-            f: ['age', 'email', 'id', 'name']
-            p: 'users||1'
-            z: 83
+          "users||1: { a: 1735689614100, p: 'users||1', z: 50 }
       `,
     );
     expect(
@@ -609,7 +603,6 @@ describe('sync storage efficiency: list-query', () => {
       ),
     ).toMatchInlineSnapshot(`
       d: { id: 1, name: 'Cached user' }
-      lf: ['age', 'email', 'id', 'name']
       p: 'users||1'
     `);
     expect(refetchOperations).toMatchInlineSnapshot(`
@@ -952,10 +945,8 @@ describe('sync storage efficiency: list-query', () => {
            |    └ (item data, <"users||1>)
       .    | 📖 #4 ✅ tsdf._m.r.n:sess1.lq-delete-flow.li.m
            |    └ (items index) | 0.23 kb
-      .    | ✍️ #5 ✅->✅ tsdf.sess1.lq-delete-flow.li."users||2
-           |    └ (item data, <"users||2>) | 0.08 kb -> 0.15 kb
       .    | ✍️ #4 ✅->✅ tsdf._m.r.n:sess1.lq-delete-flow.li.m
-           |    └ (items index) | 0.23 kb -> 0.18 kb
+           |    └ (items index) | 0.23 kb -> 0.12 kb
       "
     `);
   });
@@ -1248,11 +1239,11 @@ describe('sync storage efficiency: list-query', () => {
       "
       time  |
       1.81s | ✍️ #1 ✅->✅ tsdf.sess1.lq-query-invalidation-flow.li."users||1
-            |    └ (item data, <"users||1>) | 0.16 kb -> 0.16 kb
+            |    └ (item data, <"users||1>) | 0.10 kb -> 0.10 kb
       .     | 📖 #2 ✅ tsdf._m.r.n:sess1.lq-query-invalidation-flow.li.m
-            |    └ (items index) | 0.18 kb
+            |    └ (items index) | 0.12 kb
       .     | ✍️ #2 ✅->✅ tsdf._m.r.n:sess1.lq-query-invalidation-flow.li.m
-            |    └ (items index) | 0.18 kb -> 0.18 kb
+            |    └ (items index) | 0.12 kb -> 0.12 kb
       "
     `);
   });
@@ -1334,11 +1325,11 @@ describe('sync storage efficiency: list-query', () => {
       "
       time  |
       1.81s | ✍️ #1 ✅->✅ tsdf.sess1.lq-coalesced-invalidations.li."users||1
-            |    └ (item data, <"users||1>) | 0.16 kb -> 0.16 kb
+            |    └ (item data, <"users||1>) | 0.10 kb -> 0.10 kb
       .     | 📖 #2 ✅ tsdf._m.r.n:sess1.lq-coalesced-invalidations.li.m
-            |    └ (items index) | 0.18 kb
+            |    └ (items index) | 0.12 kb
       .     | ✍️ #2 ✅->✅ tsdf._m.r.n:sess1.lq-coalesced-invalidations.li.m
-            |    └ (items index) | 0.18 kb -> 0.18 kb
+            |    └ (items index) | 0.12 kb -> 0.12 kb
       "
     `);
   });
@@ -1440,23 +1431,13 @@ describe('sync storage efficiency: list-query', () => {
         `tsdf.${sessionKey}.${storeName}.li.`,
       )?.meta,
     ).toMatchInlineSnapshot(`
-      f: ['age', 'email', 'id', 'name']
       o: '✅'
       p: 'users||1'
     `);
     expect(getParsedLocalStorageValue(itemManifestKey)).toMatchInlineSnapshot(`
       e:
-        "users||1:
-          a: 1735689613910
-          f: ['age', 'email', 'id', 'name']
-          o: '✅'
-          p: 'users||1'
-          z: 82
-        "users||2:
-          a: 1735689615910
-          f: ['age', 'email', 'id', 'name']
-          p: 'users||2'
-          z: 83
+        "users||1: { a: 1735689613910, o: '✅', p: 'users||1', z: 49 }
+        "users||2: { a: 1735689613910, p: 'users||2', z: 50 }
     `);
     expect(getParsedLocalStorageValue(queryStorageKey)).toMatchInlineSnapshot(`
       a: 1735689613910
@@ -1648,11 +1629,11 @@ describe('sync storage efficiency: list-query', () => {
       "
       time  |
       1.81s | ✍️ #1 ✅->✅ tsdf.sess1.lq-item-invalidation-flow.li."users||1
-            |    └ (item data, <"users||1>) | 0.16 kb -> 0.16 kb
+            |    └ (item data, <"users||1>) | 0.10 kb -> 0.10 kb
       .     | 📖 #2 ✅ tsdf._m.r.n:sess1.lq-item-invalidation-flow.li.m
-            |    └ (items index) | 0.18 kb
+            |    └ (items index) | 0.12 kb
       .     | ✍️ #2 ✅->✅ tsdf._m.r.n:sess1.lq-item-invalidation-flow.li.m
-            |    └ (items index) | 0.18 kb -> 0.18 kb
+            |    └ (items index) | 0.12 kb -> 0.12 kb
       "
     `);
   });
@@ -1734,9 +1715,6 @@ describe('sync storage efficiency: list-query', () => {
       0     | 📖 #1 ❌ tsdf._m.r.n:sess1.lq-item-remount-no-cache.li.m
             |    └ (items index)
       10ms  | 📖 #1 ❌ tsdf._m.r.n:sess1.lq-item-remount-no-cache.li.m
-            |    └ (items index)
-            ·
-      810ms | 📖 #1 ❌ tsdf._m.r.n:sess1.lq-item-remount-no-cache.li.m
             |    └ (items index)
             ·
       1.81s | 📖 #1 ❌ tsdf._m.r.n:sess1.lq-item-remount-no-cache.li.m
@@ -1915,12 +1893,167 @@ describe('sync storage efficiency: list-query', () => {
       "
       time |
       1s   | ✍️ #1 ✅->✅ tsdf.sess1.lq-mutation-flow.li."users||1
-           |    └ (item data, <"users||1>) | 0.16 kb -> 0.16 kb
+           |    └ (item data, <"users||1>) | 0.10 kb -> 0.10 kb
       .    | 📖 #2 ✅ tsdf._m.r.n:sess1.lq-mutation-flow.li.m
-           |    └ (items index) | 0.18 kb
+           |    └ (items index) | 0.12 kb
       .    | ✍️ #2 ✅->✅ tsdf._m.r.n:sess1.lq-mutation-flow.li.m
-           |    └ (items index) | 0.18 kb -> 0.18 kb
+           |    └ (items index) | 0.12 kb -> 0.12 kb
       "
     `);
+  });
+
+  test('a budget-evicted in-state query stays evicted across later flushes instead of churning back into storage', async () => {
+    const usersQuery = { tableId: 'users' };
+    const projectsQuery = { tableId: 'projects' };
+    const tasksQuery = { tableId: 'tasks' };
+    const storeName = 'lq-query-budget-stability';
+    const sessionKey = 'sess1';
+    const env = createListQueryEnv({
+      storeName,
+      sessionKey,
+      // The budget fits exactly two persisted queries, so keeping three
+      // loaded in memory forces one of them out of persistence.
+      maxQueryBytes: sumPersistedEntryBytes(
+        getLocalListQueryEntrySizeBytes(projectsQuery, [
+          storeItemKey('projects', 1),
+        ]),
+        getLocalListQueryEntrySizeBytes(tasksQuery, [storeItemKey('tasks', 1)]),
+      ),
+      serverData: {
+        users: [{ id: 1, name: 'User 1' }],
+        projects: [{ id: 1, name: 'Project 1' }],
+        tasks: [{ id: 1, name: 'Task 1' }],
+      },
+    });
+
+    await settleStartupBackgroundScan();
+
+    // Fetch three queries with real time gaps so persisted recency is
+    // unambiguous: users is the oldest, tasks the newest.
+    env.scheduleFetch('highPriority', usersQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.scheduleFetch('highPriority', projectsQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+    await waitForScheduledCleanup();
+
+    // The third fetch overflowed the budget and the scheduled cleanup evicted
+    // the least recently persisted query (users) even though it is still
+    // loaded in memory.
+    expect(
+      listStoredKeys(`tsdf.${sessionKey}.${storeName}.lq.`),
+    ).toMatchInlineSnapshot(`['{tableId:"projects"}', '{tableId:"tasks"}']`);
+
+    // Trigger more flushes with a state change that does not alter any
+    // persisted query content: refetching tasks yields identical data. The
+    // evicted users query must not re-enter storage as if it were freshly
+    // accessed and knock out a different survivor.
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+    await waitForScheduledCleanup();
+
+    expect(
+      listStoredKeys(`tsdf.${sessionKey}.${storeName}.lq.`),
+    ).toMatchInlineSnapshot(`['{tableId:"projects"}', '{tableId:"tasks"}']`);
+
+    env.scheduleFetch('highPriority', tasksQuery);
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+    await waitForScheduledCleanup();
+
+    expect(
+      listStoredKeys(`tsdf.${sessionKey}.${storeName}.lq.`),
+    ).toMatchInlineSnapshot(`['{tableId:"projects"}', '{tableId:"tasks"}']`);
+  });
+
+  test('a budget-evicted in-state item stays evicted across later flushes instead of churning back into storage', async () => {
+    const storeName = 'lq-item-budget-stability';
+    const sessionKey = 'sess1';
+    const env = createListQueryEnv({
+      storeName,
+      sessionKey,
+      // The budget fits exactly two persisted items, so keeping three loaded
+      // in memory forces one of them out of persistence.
+      maxItemBytes: sumPersistedEntryBytes(
+        getLocalListItemEntrySizeBytes(rawItemPayload('users', 2), {
+          id: 2,
+          name: 'User 2',
+        }),
+        getLocalListItemEntrySizeBytes(rawItemPayload('users', 3), {
+          id: 3,
+          name: 'User 3',
+        }),
+      ),
+      serverData: {
+        users: [
+          { id: 1, name: 'User 1' },
+          { id: 2, name: 'User 2' },
+          { id: 3, name: 'User 3' },
+        ],
+      },
+    });
+
+    await settleStartupBackgroundScan();
+
+    // Fetch three standalone items with real time gaps so persisted recency
+    // is unambiguous: users||1 is the oldest, users||3 the newest.
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 1));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 2));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 3));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+    await waitForScheduledCleanup();
+
+    // The third fetch overflowed the budget and the scheduled cleanup evicted
+    // the least recently persisted item (users||1) even though it is still
+    // loaded in memory.
+    expect(
+      listStoredKeys(`tsdf.${sessionKey}.${storeName}.li.`),
+    ).toMatchInlineSnapshot(`['"users||2', '"users||3']`);
+
+    // Trigger more flushes with a state change that does not alter any
+    // persisted item content: refetching users||3 yields identical data. The
+    // evicted users||1 item must not re-enter storage as if it were freshly
+    // accessed and knock out a different survivor.
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 3));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+    await waitForScheduledCleanup();
+
+    expect(
+      listStoredKeys(`tsdf.${sessionKey}.${storeName}.li.`),
+    ).toMatchInlineSnapshot(`['"users||2', '"users||3']`);
+
+    env.apiStore.scheduleItemFetch('highPriority', rawItemPayload('users', 3));
+    await flushAllTimers();
+    await advanceTime(1100);
+    await flushAllTimers();
+    await waitForScheduledCleanup();
+
+    expect(
+      listStoredKeys(`tsdf.${sessionKey}.${storeName}.li.`),
+    ).toMatchInlineSnapshot(`['"users||2', '"users||3']`);
   });
 });

--- a/tests/utils/indexedDbPersistentStorageTestStore.ts
+++ b/tests/utils/indexedDbPersistentStorageTestStore.ts
@@ -667,9 +667,12 @@ function normalizeLogicalPayload(
       return {
         data: record !== null && 'd' in record ? record.d : value,
         payload: metadata.customMetadata.p,
-        ...(Array.isArray(metadata.customMetadata.f)
+        ...(Array.isArray(metadata.customMetadata.f) ||
+        metadata.customMetadata.f === '*'
           ? { loadedFields: metadata.customMetadata.f }
-          : record !== null && 'lf' in record && Array.isArray(record.lf)
+          : record !== null &&
+              'lf' in record &&
+              (Array.isArray(record.lf) || record.lf === '*')
             ? { loadedFields: record.lf }
             : {}),
       };

--- a/tests/utils/indexedDbPersistentStorageTestStore.ts
+++ b/tests/utils/indexedDbPersistentStorageTestStore.ts
@@ -2,6 +2,7 @@ import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { safeJsonParse } from '@ls-stack/utils/safeJson';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
 import { vi } from 'vitest';
+import type { ItemLoadedFields } from '../../src/listQueryStore/types';
 import { estimateManagedAsyncStorageEntrySizeBytes } from '../../src/persistentStorage/asyncStorageAdapter';
 import {
   encodePersistedAsyncNamespaceKind,
@@ -38,7 +39,7 @@ type IndexedDbNamespacePolicyRecord = {
 type StorageSeedOptions = { timestamp?: number; version?: number };
 
 type ListQuerySeedItemOptions = StorageSeedOptions & {
-  loadedFields?: string[];
+  loadedFields?: ItemLoadedFields;
 };
 
 type ListQueryItemRef = string | { tableId: string; id: number | string };
@@ -202,24 +203,11 @@ function isValidEntryRecord(value: unknown): boolean {
   const record = getRecord(value);
   if (record === null) return false;
 
-  const allowedKeys = new Set([
-    'a',
-    'd',
-    'f',
-    'g',
-    'h',
-    'i',
-    'm',
-    'o',
-    'p',
-    'v',
-    'z',
-  ]);
+  const allowedKeys = new Set(['a', 'd', 'g', 'i', 'm', 'o', 'p', 'v', 'z']);
   if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
     return false;
   }
 
-  const loadedFields = record.f;
   return (
     typeof record.i === 'string' &&
     typeof record.a === 'number' &&
@@ -228,11 +216,7 @@ function isValidEntryRecord(value: unknown): boolean {
     (record.z === undefined || typeof record.z === 'number') &&
     (record.m === undefined || getRecord(record.m) !== null) &&
     (record.g === undefined || typeof record.g === 'string') &&
-    (record.o === undefined || record.o === 1) &&
-    (loadedFields === undefined ||
-      (loadedFields instanceof Array &&
-        loadedFields.every((entry) => typeof entry === 'string'))) &&
-    (record.h === undefined || record.h === 1)
+    (record.o === undefined || record.o === 1)
   );
 }
 
@@ -407,9 +391,7 @@ function mergeCustomMetadata(fields: {
 type IndexedDbEntryRecord = {
   a: number;
   d: unknown;
-  f?: string[];
   g?: string;
-  h?: 1;
   i: string;
   m?: Record<string, unknown>;
   o?: 1;
@@ -421,7 +403,7 @@ type IndexedDbEntryRecord = {
 function compactEntryValue(
   scope: AsyncStorageNamespaceScope,
   value: unknown,
-): Pick<IndexedDbEntryRecord, 'd' | 'f' | 'h'> {
+): Pick<IndexedDbEntryRecord, 'd'> {
   const record = getRecord(value);
 
   switch (scope.kind) {
@@ -467,9 +449,9 @@ function buildCustomMetadata(
           : typeof record.p === 'string'
             ? { p: record.p }
             : {}),
-        ...(Array.isArray(record.loadedFields)
+        ...(Array.isArray(record.loadedFields) || record.loadedFields === '*'
           ? { f: record.loadedFields }
-          : Array.isArray(record.lf)
+          : Array.isArray(record.lf) || record.lf === '*'
             ? { f: record.lf }
             : {}),
       };

--- a/tests/utils/opfsPersistentStorageTestStore.ts
+++ b/tests/utils/opfsPersistentStorageTestStore.ts
@@ -1,6 +1,7 @@
 import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { safeJsonParse } from '@ls-stack/utils/safeJson';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
+import type { ItemLoadedFields } from '../../src/listQueryStore/types';
 import {
   ASYNC_NAMESPACE_INDEX_RECORD_KEY,
   getPayloadRecordKey,
@@ -87,7 +88,7 @@ function getLogicalStorageKey(
 type StorageSeedOptions = { timestamp?: number; version?: number };
 
 type ListQuerySeedItemOptions = StorageSeedOptions & {
-  loadedFields?: string[];
+  loadedFields?: ItemLoadedFields;
 };
 
 type ListQueryItemRef = string | { tableId: string; id: number | string };

--- a/tests/utils/opfsPersistentStorageTestStore.ts
+++ b/tests/utils/opfsPersistentStorageTestStore.ts
@@ -200,9 +200,9 @@ function buildCustomMetadata(
           : typeof record.p === 'string'
             ? { p: record.p }
             : {}),
-        ...(Array.isArray(record.loadedFields)
+        ...(Array.isArray(record.loadedFields) || record.loadedFields === '*'
           ? { f: record.loadedFields }
-          : Array.isArray(record.lf)
+          : Array.isArray(record.lf) || record.lf === '*'
             ? { f: record.lf }
             : {}),
       };
@@ -416,9 +416,12 @@ function normalizeLogicalPayload(
         ? {
             data: record !== null && 'd' in record ? record.d : value,
             payload: metadata.customMetadata.p,
-            ...(Array.isArray(metadata.customMetadata.f)
+            ...(Array.isArray(metadata.customMetadata.f) ||
+            metadata.customMetadata.f === '*'
               ? { loadedFields: metadata.customMetadata.f }
-              : record !== null && 'lf' in record && Array.isArray(record.lf)
+              : record !== null &&
+                  'lf' in record &&
+                  (Array.isArray(record.lf) || record.lf === '*')
                 ? { loadedFields: record.lf }
                 : {}),
           }

--- a/tests/utils/persistentStorageTestStore.ts
+++ b/tests/utils/persistentStorageTestStore.ts
@@ -1,6 +1,7 @@
 import { getCompositeKey } from '@ls-stack/utils/getCompositeKey';
 import { safeJsonParse } from '@ls-stack/utils/safeJson';
 import { __LEGIT_CAST__ } from '@ls-stack/utils/saferTyping';
+import type { ItemLoadedFields } from '../../src/listQueryStore/types';
 import {
   createCompactListQueryLocalStorageEntry,
   parseCompactListQueryLocalStorageEntry,
@@ -29,7 +30,7 @@ const utf8Encoder = new TextEncoder();
 type StorageSeedOptions = { timestamp?: number; version?: number };
 
 type ListQuerySeedItemOptions = StorageSeedOptions & {
-  loadedFields?: string[];
+  loadedFields?: ItemLoadedFields;
 };
 
 type ListQueryItemRef = string | { tableId: string; id: number | string };

--- a/tests/utils/persistentStorageTestStore.ts
+++ b/tests/utils/persistentStorageTestStore.ts
@@ -89,6 +89,12 @@ function getStoredValueSizeBytes(
   return raw === null ? undefined : utf8Encoder.encode(raw).byteLength;
 }
 
+function getLoadedFields(value: unknown): ItemLoadedFields | undefined {
+  return value === '*' || Array.isArray(value)
+    ? __LEGIT_CAST__<ItemLoadedFields, unknown>(value)
+    : undefined;
+}
+
 export type PersistentTestStoreScope = {
   document: {
     storageKey: () => string;
@@ -499,12 +505,8 @@ function createPersistentTestStore(
                   ? {
                       data: __LEGIT_CAST__<T, unknown>(v.d),
                       payload: __LEGIT_CAST__<string, unknown>(v.p),
-                      ...('lf' in v && Array.isArray(v.lf)
-                        ? {
-                            loadedFields: __LEGIT_CAST__<string[], unknown>(
-                              v.lf,
-                            ),
-                          }
+                      ...('lf' in v && getLoadedFields(v.lf) !== undefined
+                        ? { loadedFields: getLoadedFields(v.lf) }
                         : {}),
                     }
                   : null,
@@ -534,12 +536,8 @@ function createPersistentTestStore(
                     ? {
                         data: __LEGIT_CAST__<T, unknown>(v.d),
                         payload: __LEGIT_CAST__<string, unknown>(v.p),
-                        ...('lf' in v && Array.isArray(v.lf)
-                          ? {
-                              loadedFields: __LEGIT_CAST__<string[], unknown>(
-                                v.lf,
-                              ),
-                            }
+                        ...('lf' in v && getLoadedFields(v.lf) !== undefined
+                          ? { loadedFields: getLoadedFields(v.lf) }
                           : {}),
                       }
                     : null,


### PR DESCRIPTION
## Summary

This PR fixes several partial-resource and persistence bugs by introducing `inferFields` for metadata-free item snapshots and a `'*'` sentinel for fully loaded items. It also tightens invalidation tracking, improves stale-data handling across hooks and imperative reads, and preserves persistence behavior under storage budget pressure.
### Changes

- Add `inferFields` to partial-resources configs and use it when loaded-field metadata is missing.
- Introduce `ItemLoadedFields` with support for the `'*'` fully-loaded sentinel.
- Fix fetch and hook status logic so full and partial reads agree on what data is available.
- Track full-item invalidations separately so stale `'*'` snapshots do not get trusted or lost.
- Preserve metadata-free snapshots through persistence, browser-tab sync, and offline flows.
- Reduce storage churn by remembering budget-evicted entries and keeping them out of later flushes.
- Update playground docs and skill guidance to describe the new partial-resource contract.
- Expand regression coverage for full invalidation, logical fields, persistence round-trips, and storage efficiency.

### Testing Notes

Verify partial-resource hooks with both array fields and `fields: '*'` in these cases: fully loaded items, client-created/offline items without loaded-field metadata, and items invalidated while another fetch is in flight. Also confirm persistence round-trips keep `'*'` markers, browser-tab sync does not erase sibling metadata, and max-bytes cleanup no longer churns previously evicted items back into storage.

## Test Plan

- [ ] Tested locally
- [x] Added/updated tests
