### PR TITLE
Preserve realtime throttle for stale partial-resource refetches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsdf",
-  "version": "17.0.0-beta.2",
+  "version": "17.0.0-beta.3",
   "description": "A data fetching solution based on t-state",
   "license": "PolyForm-Noncommercial-1.0.0",
   "author": "Lucas Santos",

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -139,6 +139,21 @@ type ListQueryStoreStoreEvents<ItemPayload extends ValidPayload> = {
   tempEntityReconciled: { tempId: ItemPayload; finalPayload: ItemPayload };
 };
 
+/**
+ * A per-field invalidation that arrived for a field with no displayable
+ * cached value. It is deliberately not recorded as stale (the field must stay
+ * "genuinely missing" so its first load runs immediately instead of being
+ * throttled), but a fetch already in flight at `invalidatedAt` will commit a
+ * response produced before the invalidation — fetch-settle re-announces the
+ * invalidation when such a fetch ends up loading the field.
+ *
+ * @internal
+ */
+export type DroppedFieldInvalidation = {
+  invalidatedAt: number;
+  priority: FetchType;
+};
+
 /** @internal */
 export function createMutationApi<
   ItemState extends ValidStoreState,
@@ -256,6 +271,10 @@ export function createMutationApi<
     | undefined,
   itemPendingInvalidationFields: Map<string, string[]>,
   itemsPendingFullInvalidation: Set<string>,
+  itemDroppedFieldInvalidations: Map<
+    string,
+    Map<string, DroppedFieldInvalidation>
+  >,
 ) {
   type FilterQuery = FilterQueryFn<QueryPayload>;
   type FilterItem = FilterItemFn<ItemState, ItemPayload>;
@@ -535,6 +554,33 @@ export function createMutationApi<
                   (field) => effectiveLoadedFields?.includes(field) ?? false,
                 );
 
+          // Fields dropped from the stale record (never loaded) would be lost
+          // to a fetch already in flight — its response predates this
+          // invalidation but will still commit the field as fresh. Remember
+          // when each dropped invalidation arrived so fetch-settle can
+          // re-announce it when such a fetch loads the field.
+          if (staleInvalidateFields.length < invalidateFields.length) {
+            let droppedForItem = itemDroppedFieldInvalidations.get(itemKey);
+            for (const field of invalidateFields) {
+              if (staleInvalidateFields.includes(field)) continue;
+
+              if (!droppedForItem) {
+                droppedForItem = new Map();
+                itemDroppedFieldInvalidations.set(itemKey, droppedForItem);
+              }
+              const existingDropped = droppedForItem.get(field);
+              droppedForItem.set(field, {
+                invalidatedAt: Date.now(),
+                priority:
+                  existingDropped &&
+                  fetchTypePriority[existingDropped.priority] >
+                    fetchTypePriority[priority]
+                    ? existingDropped.priority
+                    : priority,
+              });
+            }
+          }
+
           if (staleInvalidateFields.length === 0) continue;
 
           staleInvalidateFieldsByItemKey.set(itemKey, staleInvalidateFields);
@@ -717,6 +763,102 @@ export function createMutationApi<
           });
         }
       }
+    }
+  }
+
+  /**
+   * Called when a fetch settles for `itemKeys` (item fetches and list fetches
+   * that committed the items). Per-field invalidations of never-loaded fields
+   * are dropped at invalidation time (see `invalidateQueryAndItems`) — but a
+   * fetch that STARTED BEFORE such an invalidation commits a response
+   * produced before it, so the just-loaded value may already be stale.
+   * Re-announce those invalidations as a regular per-field invalidation (the
+   * field now has a displayable value). Fields loaded by a fetch started
+   * after the invalidation are fresh relative to it — their record is simply
+   * discarded.
+   */
+  function reannounceInvalidationsDroppedDuringFetch(
+    itemKeys: string[],
+    fetchStartedAt: number,
+  ): void {
+    for (const itemKey of itemKeys) {
+      const droppedForItem = itemDroppedFieldInvalidations.get(itemKey);
+      if (!droppedForItem) continue;
+
+      const loadedFields = store.state.itemLoadedFields[itemKey];
+      let staleFields: string[] | undefined;
+      let stalePriority: FetchType | undefined;
+
+      for (const [field, dropped] of droppedForItem) {
+        const fieldIsLoaded =
+          loadedFields === '*' || (loadedFields?.includes(field) ?? false);
+        // Still unloaded: nothing was committed for the field, keep waiting
+        // for a fetch that loads it.
+        if (!fieldIsLoaded) continue;
+
+        droppedForItem.delete(field);
+
+        if (dropped.invalidatedAt > fetchStartedAt) {
+          (staleFields ??= []).push(field);
+          if (
+            !stalePriority ||
+            fetchTypePriority[dropped.priority] >
+              fetchTypePriority[stalePriority]
+          ) {
+            stalePriority = dropped.priority;
+          }
+        }
+      }
+
+      if (droppedForItem.size === 0) {
+        itemDroppedFieldInvalidations.delete(itemKey);
+      }
+
+      if (!staleFields || !stalePriority) continue;
+
+      // Same transaction as the per-field path of `invalidateQueryAndItems`:
+      // record the pending fields, strip them from the loaded metadata, and
+      // re-emit the invalidation event.
+      const existingPriority = itemFieldInvalidationPriorities.get(itemKey);
+      const mergedPriority =
+        existingPriority &&
+        fetchTypePriority[existingPriority] > fetchTypePriority[stalePriority]
+          ? existingPriority
+          : stalePriority;
+      const existingPendingFields =
+        itemPendingInvalidationFields.get(itemKey) ?? [];
+      itemPendingInvalidationFields.set(
+        itemKey,
+        Array.from(new Set([...existingPendingFields, ...staleFields])).sort(),
+      );
+      itemFieldInvalidationPriorities.set(itemKey, mergedPriority);
+
+      const staleFieldsToApply = staleFields;
+      store.produceState(
+        (draft) => {
+          const draftLoadedFields = draft.itemLoadedFields[itemKey];
+          if (!draftLoadedFields) return;
+
+          if (draftLoadedFields !== '*') {
+            draft.itemLoadedFields[itemKey] = draftLoadedFields.filter(
+              (f) => !staleFieldsToApply.includes(f),
+            );
+          }
+          const existingInvalidationFields =
+            draft.itemFieldInvalidationFields[itemKey] ?? [];
+          draft.itemFieldInvalidationFields[itemKey] = Array.from(
+            new Set([...existingInvalidationFields, ...staleFieldsToApply]),
+          ).sort();
+        },
+        { action: 'invalidate-item-fields' },
+      );
+
+      itemInvalidationWasTriggered.delete(itemKey);
+      emitInvalidateItem({
+        priority: mergedPriority,
+        itemKey,
+        invalidateFields: staleFields,
+      });
     }
   }
 
@@ -1106,6 +1248,7 @@ export function createMutationApi<
       itemFieldInvalidationPriorities.delete(itemKey);
       itemPendingInvalidationFields.delete(itemKey);
       itemsPendingFullInvalidation.delete(itemKey);
+      itemDroppedFieldInvalidations.delete(itemKey);
       itemInvalidationWasTriggered.delete(itemKey);
       publishItemSnapshot(itemKey);
     }
@@ -1123,6 +1266,7 @@ export function createMutationApi<
     itemFieldInvalidationPriorities.clear();
     itemPendingInvalidationFields.clear();
     itemsPendingFullInvalidation.clear();
+    itemDroppedFieldInvalidations.clear();
   }
 
   type ListQueryMutationArgs<T> = {
@@ -1424,6 +1568,7 @@ export function createMutationApi<
     itemFieldInvalidationPriorities,
     invalidateQueryAndItems,
     invalidateItem,
+    reannounceInvalidationsDroppedDuringFetch,
     startItemMutation,
     updateItemState,
     addItemToState,

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -490,15 +490,40 @@ export function createMutationApi<
           string,
           string[]
         >();
+        // Only fields with a displayable cached value can go stale: the ones
+        // tracked as loaded, or vouched by `inferFields` for metadata-free
+        // items (mirroring the full-invalidation path). A never-loaded field
+        // must not be recorded — it stays classified as genuinely missing so
+        // its first load runs immediately instead of waiting out a throttle.
+        const staleInvalidateFieldsByItemKey = new Map<string, string[]>();
 
         for (const { itemKey } of itemsKey) {
+          let effectiveLoadedFields = store.state.itemLoadedFields[itemKey];
+          if (effectiveLoadedFields === undefined) {
+            const itemState = store.state.items[itemKey];
+            if (itemState) {
+              effectiveLoadedFields = partialResources.inferFields(itemState);
+            }
+          }
+
+          const staleInvalidateFields =
+            effectiveLoadedFields === '*'
+              ? invalidateFields
+              : invalidateFields.filter(
+                  (field) => effectiveLoadedFields?.includes(field) ?? false,
+                );
+
+          if (staleInvalidateFields.length === 0) continue;
+
+          staleInvalidateFieldsByItemKey.set(itemKey, staleInvalidateFields);
+
           const existingPriority = itemFieldInvalidationPriorities.get(itemKey);
           const existingPendingFields =
             itemPendingInvalidationFields.get(itemKey) ?? [];
           nextPendingInvalidationFieldsByItemKey.set(
             itemKey,
             Array.from(
-              new Set([...existingPendingFields, ...invalidateFields]),
+              new Set([...existingPendingFields, ...staleInvalidateFields]),
             ).sort(),
           );
 
@@ -528,34 +553,46 @@ export function createMutationApi<
 
         store.produceState(
           (draft) => {
-            for (const { itemKey } of itemsKey) {
+            for (const [
+              itemKey,
+              staleInvalidateFields,
+            ] of staleInvalidateFieldsByItemKey) {
               const loadedFields = draft.itemLoadedFields[itemKey];
               if (!loadedFields) continue;
 
               if (loadedFields !== '*') {
                 draft.itemLoadedFields[itemKey] = loadedFields.filter(
-                  (f) => !invalidateFields.includes(f),
+                  (f) => !staleInvalidateFields.includes(f),
                 );
               }
               const existingInvalidationFields =
                 draft.itemFieldInvalidationFields[itemKey] ?? [];
               draft.itemFieldInvalidationFields[itemKey] = Array.from(
-                new Set([...existingInvalidationFields, ...invalidateFields]),
+                new Set([
+                  ...existingInvalidationFields,
+                  ...staleInvalidateFields,
+                ]),
               ).sort();
             }
           },
           { action: 'invalidate-item-fields' },
         );
 
-        // Emit invalidation events so hooks can detect missing fields and refetch
-        for (const { itemKey } of itemsKey) {
+        // Emit invalidation events so hooks can refetch their stale fields.
+        // Items where no invalidated field was loaded have nothing stale to
+        // re-announce; hooks requesting such fields already treat them as
+        // missing and fetch immediately on their own.
+        for (const [
+          itemKey,
+          staleInvalidateFields,
+        ] of staleInvalidateFieldsByItemKey) {
           itemInvalidationWasTriggered.delete(itemKey);
           const itemPriority =
             nextInvalidationPriorityByItemKey.get(itemKey) ?? priority;
           emitInvalidateItem({
             priority: itemPriority,
             itemKey,
-            invalidateFields,
+            invalidateFields: staleInvalidateFields,
           });
         }
       } else {

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -442,6 +442,35 @@ export function createMutationApi<
   const itemInvalidationWasTriggered = new Set<string>();
   const itemFieldInvalidationPriorities = new Map<string, FetchType>();
 
+  /**
+   * The staleness baseline for invalidations: a field is invalidatable
+   * exactly when it is displayable, and hooks display the UNION of the
+   * tracked `itemLoadedFields` metadata and whatever `inferFields` currently
+   * vouches for (e.g. fields a mutation wrote beyond the tracked metadata).
+   * Collapses to '*' when either side is '*' — the displayable set is then
+   * not enumerable.
+   */
+  function getInvalidationBaselineFields(
+    itemKey: string,
+  ): ItemLoadedFields | undefined {
+    const trackedLoadedFields = store.state.itemLoadedFields[itemKey];
+    if (trackedLoadedFields === '*') return '*';
+
+    if (!partialResources) return trackedLoadedFields;
+
+    const itemState = store.state.items[itemKey];
+    if (!itemState) return trackedLoadedFields;
+
+    const inferredFields = partialResources.inferFields(itemState);
+    if (inferredFields === '*') return '*';
+
+    if (!trackedLoadedFields || trackedLoadedFields.length === 0) {
+      return inferredFields;
+    }
+
+    return Array.from(new Set([...trackedLoadedFields, ...inferredFields]));
+  }
+
   function invalidateQueryAndItems(args: InvalidateQueryAndItemsArgs) {
     const itemPayload: ItemPayload | ItemPayload[] | FilterItem | false =
       args.all ? GET_ALL : args.itemPayload;
@@ -490,21 +519,14 @@ export function createMutationApi<
           string,
           string[]
         >();
-        // Only fields with a displayable cached value can go stale: the ones
-        // tracked as loaded, or vouched by `inferFields` for metadata-free
-        // items (mirroring the full-invalidation path). A never-loaded field
-        // must not be recorded — it stays classified as genuinely missing so
-        // its first load runs immediately instead of waiting out a throttle.
+        // Only fields with a displayable cached value can go stale (see
+        // getInvalidationBaselineFields). A never-loaded field must not be
+        // recorded — it stays classified as genuinely missing so its first
+        // load runs immediately instead of waiting out a throttle.
         const staleInvalidateFieldsByItemKey = new Map<string, string[]>();
 
         for (const { itemKey } of itemsKey) {
-          let effectiveLoadedFields = store.state.itemLoadedFields[itemKey];
-          if (effectiveLoadedFields === undefined) {
-            const itemState = store.state.items[itemKey];
-            if (itemState) {
-              effectiveLoadedFields = partialResources.inferFields(itemState);
-            }
-          }
+          const effectiveLoadedFields = getInvalidationBaselineFields(itemKey);
 
           const staleInvalidateFields =
             effectiveLoadedFields === '*'
@@ -614,17 +636,7 @@ export function createMutationApi<
 
       if (!item) continue;
 
-      // Metadata-free items (manually added, offline rows, hydrated fallback
-      // snapshots) have no `itemLoadedFields` entry — their staleness baseline
-      // is whatever `inferFields` currently vouches for, otherwise the
-      // invalidation would leave no durable marker behind.
-      let effectiveLoadedFields = store.state.itemLoadedFields[itemKey];
-      if (partialResources && effectiveLoadedFields === undefined) {
-        const itemState = store.state.items[itemKey];
-        if (itemState) {
-          effectiveLoadedFields = partialResources.inferFields(itemState);
-        }
-      }
+      const effectiveLoadedFields = getInvalidationBaselineFields(itemKey);
 
       const itemWasFullyLoaded =
         partialResources && effectiveLoadedFields === '*';

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -99,7 +99,10 @@ import {
   type ValidStoreState,
 } from '../utils/storeShared';
 import { createFetchApi } from './createFetchApi';
-import { createMutationApi } from './createMutationApi';
+import {
+  createMutationApi,
+  type DroppedFieldInvalidation,
+} from './createMutationApi';
 import {
   excludeLoadedFields,
   fallbackItemHasRequestedFields,
@@ -1902,6 +1905,15 @@ export function createListQueryStore<
   // refetches. It keeps other mounted hooks from trusting the stale snapshot via
   // `inferFields` until the item is fully reloaded (`loadedFields === '*'` again).
   const itemsPendingFullInvalidation = new Set<string>();
+  // Per-field invalidations of never-loaded fields, dropped from the stale
+  // record so the field's first load stays immediate — kept here so a fetch
+  // that was already in flight when the invalidation arrived (and whose
+  // response therefore predates it) gets re-announced at settle. See
+  // `reannounceInvalidationsDroppedDuringFetch`.
+  const itemDroppedFieldInvalidations = new Map<
+    string,
+    Map<string, DroppedFieldInvalidation>
+  >();
 
   const {
     getQueryState,
@@ -1971,12 +1983,12 @@ export function createListQueryStore<
         .filter(({ requestId }) => results.get(requestId) === true)
         .map(({ requestId }) => requestId);
       if (successfulQueryKeys.length > 0) {
-        touchQueries(successfulQueryKeys);
-        touchItems(
-          successfulQueryKeys.flatMap(
-            (queryKey) => store.state.queries[queryKey]?.items ?? [],
-          ),
+        const committedItemKeys = successfulQueryKeys.flatMap(
+          (queryKey) => store.state.queries[queryKey]?.items ?? [],
         );
+        touchQueries(successfulQueryKeys);
+        touchItems(committedItemKeys);
+        reannounceInvalidationsDroppedDuringFetch(committedItemKeys, startedAt);
         if (shouldScheduleCacheLimitEnforcement()) {
           scheduleCacheLimitEnforcement();
         }
@@ -2021,7 +2033,9 @@ export function createListQueryStore<
         .filter(({ requestId }) => results.get(requestId) === true)
         .map((request) => ({ itemKey: request.requestId }));
       if (successfulItems.length > 0) {
-        touchItems(successfulItems.map(({ itemKey }) => itemKey));
+        const committedItemKeys = successfulItems.map(({ itemKey }) => itemKey);
+        touchItems(committedItemKeys);
+        reannounceInvalidationsDroppedDuringFetch(committedItemKeys, startedAt);
         if (shouldScheduleCacheLimitEnforcement()) {
           scheduleCacheLimitEnforcement();
         }
@@ -2061,6 +2075,7 @@ export function createListQueryStore<
     itemFieldInvalidationPriorities,
     invalidateQueryAndItems,
     invalidateItem,
+    reannounceInvalidationsDroppedDuringFetch,
     startItemMutation,
     updateItemState: updateItemStateBase,
     addItemToState: addItemToStateBase,
@@ -2104,6 +2119,7 @@ export function createListQueryStore<
       : undefined,
     itemPendingInvalidationFields,
     itemsPendingFullInvalidation,
+    itemDroppedFieldInvalidations,
   );
 
   if (resolvedPersistentStorageConfig && resolvedOfflineConfig) {
@@ -2412,6 +2428,7 @@ export function createListQueryStore<
     itemFieldInvalidationPriorities.delete(itemKey);
     itemPendingInvalidationFields.delete(itemKey);
     itemsPendingFullInvalidation.delete(itemKey);
+    itemDroppedFieldInvalidations.delete(itemKey);
     itemInvalidationWasTriggered.delete(itemKey);
     itemCacheRuntime.clear(itemKey);
   }

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -2306,6 +2306,34 @@ export function createListQueryStore<
     }
   }
 
+  /**
+   * A confirmed remote snapshot cancels the pending local fetches it
+   * satisfies, but the sender may have refetched only a subset of the
+   * invalidated fields (it fetches only its own hooks' fields). Any fields
+   * still owed after applying the snapshot are re-announced so mounted hooks
+   * re-schedule refetches of their own remaining stale fields — without
+   * this, the cancelled local refetch would leave them stale forever.
+   */
+  function emitRemainingInvalidationFieldsAfterSnapshot(itemKey: string): void {
+    const stateInvalidationFields =
+      store.state.itemFieldInvalidationFields[itemKey];
+    const remainingFields =
+      stateInvalidationFields && stateInvalidationFields.length > 0
+        ? stateInvalidationFields
+        : excludeLoadedFields(
+            store.state.itemLoadedFields[itemKey],
+            itemPendingInvalidationFields.get(itemKey),
+          );
+
+    if (remainingFields.length === 0) return;
+
+    events.emit('invalidateItem', {
+      priority: itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority',
+      itemKey,
+      invalidateFields: remainingFields,
+    });
+  }
+
   function pruneItemInvalidationTracking(): void {
     for (const [itemKey, pendingFields] of itemPendingInvalidationFields) {
       // Fields still owed from earlier invalidations: the ones not yet
@@ -2614,6 +2642,9 @@ export function createListQueryStore<
       cleanupItemStateMetadata(message.itemKey);
     }
     pruneItemInvalidationTracking();
+    if (message.consistency === 'confirmed') {
+      emitRemainingInvalidationFieldsAfterSnapshot(message.itemKey);
+    }
     if (message.item === null && message.itemQuery === null) {
       if (payloadToCleanup) {
         deleteItemFetchResources([
@@ -2710,6 +2741,9 @@ export function createListQueryStore<
         item.itemKey,
         toBrowserTabsSyncVersion(message, message.consistency),
       );
+      if (message.consistency === 'confirmed') {
+        emitRemainingInvalidationFieldsAfterSnapshot(item.itemKey);
+      }
     }
     touchQueries([message.queryKey]);
     touchItems(message.items.map(({ itemKey }) => itemKey));

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -2320,6 +2320,20 @@ export function createListQueryStore<
    * a repeat cycle requires a new pending fetch at snapshot arrival.
    */
   function emitRemainingInvalidationFieldsAfterSnapshot(itemKey: string): void {
+    const priority =
+      itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority';
+
+    // A surviving full-invalidation marker means every not-yet-reloaded
+    // field is still owed, not just the explicitly tracked field list (a
+    // per-field invalidation can coexist with an unresolved full one).
+    // Re-announce the full invalidation itself so hooks whose fields are
+    // owed only through the marker also re-schedule — downgrading it to the
+    // explicit field list would leave them stale forever.
+    if (itemsPendingFullInvalidation.has(itemKey)) {
+      events.emit('invalidateItem', { priority, itemKey });
+      return;
+    }
+
     const stateInvalidationFields =
       store.state.itemFieldInvalidationFields[itemKey];
     const remainingFields =
@@ -2330,23 +2344,10 @@ export function createListQueryStore<
             itemPendingInvalidationFields.get(itemKey),
           );
 
-    if (remainingFields.length === 0) {
-      // A full invalidation of a '*'-loaded item is tracked only by the
-      // full-invalidation marker — there is no field list to re-announce.
-      // Re-announce the full invalidation itself so hooks whose cancelled
-      // refetch was vouched by the snapshot re-schedule their own fields.
-      if (itemsPendingFullInvalidation.has(itemKey)) {
-        events.emit('invalidateItem', {
-          priority:
-            itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority',
-          itemKey,
-        });
-      }
-      return;
-    }
+    if (remainingFields.length === 0) return;
 
     events.emit('invalidateItem', {
-      priority: itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority',
+      priority,
       itemKey,
       invalidateFields: remainingFields,
     });

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -2313,6 +2313,11 @@ export function createListQueryStore<
    * still owed after applying the snapshot are re-announced so mounted hooks
    * re-schedule refetches of their own remaining stale fields — without
    * this, the cancelled local refetch would leave them stale forever.
+   *
+   * Only called when the snapshot actually cancelled a pending local fetch:
+   * that cancellation is the refetch obligation being destroyed, and gating
+   * on it also guarantees the cross-tab re-announce ping-pong terminates —
+   * a repeat cycle requires a new pending fetch at snapshot arrival.
    */
   function emitRemainingInvalidationFieldsAfterSnapshot(itemKey: string): void {
     const stateInvalidationFields =
@@ -2325,7 +2330,20 @@ export function createListQueryStore<
             itemPendingInvalidationFields.get(itemKey),
           );
 
-    if (remainingFields.length === 0) return;
+    if (remainingFields.length === 0) {
+      // A full invalidation of a '*'-loaded item is tracked only by the
+      // full-invalidation marker — there is no field list to re-announce.
+      // Re-announce the full invalidation itself so hooks whose cancelled
+      // refetch was vouched by the snapshot re-schedule their own fields.
+      if (itemsPendingFullInvalidation.has(itemKey)) {
+        events.emit('invalidateItem', {
+          priority:
+            itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority',
+          itemKey,
+        });
+      }
+      return;
+    }
 
     events.emit('invalidateItem', {
       priority: itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority',
@@ -2627,13 +2645,16 @@ export function createListQueryStore<
       );
     });
 
-    if (message.consistency === 'confirmed') {
-      itemScheduler?.cancelPendingRequests([message.itemKey], ({ payload }) =>
-        itemSnapshotSatisfiesRequestedFields(
-          message.item,
-          message.loadedFields,
-          payload.fields,
-        ),
+    let cancelledPendingItemFetch = false;
+    if (message.consistency === 'confirmed' && itemScheduler) {
+      cancelledPendingItemFetch = itemScheduler.cancelPendingRequests(
+        [message.itemKey],
+        ({ payload }) =>
+          itemSnapshotSatisfiesRequestedFields(
+            message.item,
+            message.loadedFields,
+            payload.fields,
+          ),
       );
     }
 
@@ -2642,7 +2663,7 @@ export function createListQueryStore<
       cleanupItemStateMetadata(message.itemKey);
     }
     pruneItemInvalidationTracking();
-    if (message.consistency === 'confirmed') {
+    if (cancelledPendingItemFetch) {
       emitRemainingInvalidationFieldsAfterSnapshot(message.itemKey);
     }
     if (message.item === null && message.itemQuery === null) {
@@ -2665,31 +2686,36 @@ export function createListQueryStore<
       { kind: 'list-query-snapshot' }
     >,
   ): void {
+    let cancelledPendingQueryFetch = false;
+    const itemKeysWithCancelledFetch = new Set<string>();
     if (message.consistency === 'confirmed') {
       const snapshotItemsByKey = new Map(
         message.items.map((item) => [item.itemKey, item]),
       );
 
-      getOrCreateQueryScheduler(message.queryKey).cancelPendingRequests(
-        [message.queryKey],
-        (request) =>
-          querySnapshotSatisfiesPendingQueryFetch(
-            message,
-            snapshotItemsByKey,
-            request,
-          ),
+      cancelledPendingQueryFetch = getOrCreateQueryScheduler(
+        message.queryKey,
+      ).cancelPendingRequests([message.queryKey], (request) =>
+        querySnapshotSatisfiesPendingQueryFetch(
+          message,
+          snapshotItemsByKey,
+          request,
+        ),
       );
 
       for (const item of message.items) {
         const itemScheduler = getKnownItemScheduler(item.itemKey);
 
-        itemScheduler?.cancelPendingRequests([item.itemKey], ({ payload }) =>
-          itemSnapshotSatisfiesRequestedFields(
-            item.item,
-            item.loadedFields,
-            payload.fields,
-          ),
+        const cancelled = itemScheduler?.cancelPendingRequests(
+          [item.itemKey],
+          ({ payload }) =>
+            itemSnapshotSatisfiesRequestedFields(
+              item.item,
+              item.loadedFields,
+              payload.fields,
+            ),
         );
+        if (cancelled) itemKeysWithCancelledFetch.add(item.itemKey);
       }
     }
 
@@ -2741,7 +2767,10 @@ export function createListQueryStore<
         item.itemKey,
         toBrowserTabsSyncVersion(message, message.consistency),
       );
-      if (message.consistency === 'confirmed') {
+      if (
+        cancelledPendingQueryFetch ||
+        itemKeysWithCancelledFetch.has(item.itemKey)
+      ) {
         emitRemainingInvalidationFieldsAfterSnapshot(item.itemKey);
       }
     }

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -749,13 +749,38 @@ export function useMultipleItems<
       fieldsToFetch = Array.from(new Set(event.invalidateFields)).sort();
     }
 
+    // The item's other owed stale fields: the union of the state
+    // invalidation record and the pending invalidation fields not yet
+    // reloaded. The immediate fetch scheduled below replaces any pending
+    // scheduled fetch for this item (the scheduler cancels it), and that
+    // pending fetch may have been carrying these fields at a lower priority
+    // (e.g. a throttled realtime invalidation) — so for per-field events,
+    // instances whose fields only overlap the owed fields are affected too,
+    // and the owed fields must ride along with the new fetch or the replaced
+    // fetch's obligation is lost.
+    const hasUnresolvedFullInvalidation = itemsPendingFullInvalidation.has(
+      event.itemKey,
+    );
+    const loadedFields = store.state.itemLoadedFields[event.itemKey];
+    const owedStaleFields = new Set([
+      ...(store.state.itemFieldInvalidationFields[event.itemKey] ?? []),
+      ...excludeLoadedFields(
+        loadedFields,
+        itemPendingInvalidationFields.get(event.itemKey),
+      ),
+    ]);
+
     const affectedQueries = fieldsToFetch
       ? queriesForItem.filter(({ fields }) => {
           if (fields === '*') return true;
           if (!fields || fields.length === 0) return true;
-          return fields.some((field) =>
-            event.invalidateFields?.includes(field),
-          );
+          if (fields.some((field) => event.invalidateFields?.includes(field)))
+            return true;
+          // After an unresolved full ('*') invalidation every field not yet
+          // reloaded is owed.
+          return hasUnresolvedFullInvalidation
+            ? excludeLoadedFields(loadedFields, fields).length > 0
+            : fields.some((field) => owedStaleFields.has(field));
         })
       : queriesForItem;
 
@@ -778,8 +803,6 @@ export function useMultipleItems<
 
     if (matchingQueries.length === 0) return;
 
-    if (itemInvalidationWasTriggered.has(event.itemKey)) return;
-
     const allQueriesDisableRefetches = matchingQueries.every(
       (q) => q.disableRefetches,
     );
@@ -793,38 +816,52 @@ export function useMultipleItems<
     const firstQuery = matchingQueries[0];
     if (!firstQuery) return;
 
-    // The immediate fetch scheduled below replaces any pending scheduled
-    // fetch for this item (the scheduler cancels it), and that pending fetch
-    // may have been carrying other owed stale fields at a lower priority
-    // (e.g. a throttled realtime invalidation). Ride this instance's other
-    // owed stale fields along so the replaced fetch's obligation isn't lost.
+    const hookFields = firstQuery.fields;
+    const isUnboundedHook =
+      !hookFields || hookFields === '*' || hookFields.length === 0;
+
+    if (itemInvalidationWasTriggered.has(event.itemKey)) {
+      if (!fieldsToFetch) return;
+
+      // Another instance's handler already scheduled the immediate fetch for
+      // this event, carrying only that instance's fields. Contribute this
+      // instance's own owed stale fields so they merge into the same fetch
+      // via the scheduler's coalescing window instead of being dropped with
+      // the replaced pending fetch.
+      const contributionFields = hasUnresolvedFullInvalidation
+        ? isUnboundedHook
+          ? undefined
+          : excludeLoadedFields(loadedFields, hookFields)
+        : isUnboundedHook
+          ? Array.from(owedStaleFields)
+          : hookFields.filter((field) => owedStaleFields.has(field));
+
+      if (contributionFields && contributionFields.length === 0) return;
+
+      scheduleAutomaticItemFetch(event.priority, firstQuery.payload, {
+        fields: contributionFields,
+      });
+      return;
+    }
+
+    // Ride this instance's other owed stale fields along with the event's
+    // fields so the replaced pending fetch's obligation isn't lost.
     if (fieldsToFetch) {
-      const hookFields = firstQuery.fields;
-      const loadedFields = store.state.itemLoadedFields[event.itemKey];
-      if (itemsPendingFullInvalidation.has(event.itemKey)) {
+      if (hasUnresolvedFullInvalidation) {
         // After an unresolved full ('*') invalidation every field not yet
         // reloaded is owed; for an unbounded hook that means a full fetch.
-        fieldsToFetch =
-          !hookFields || hookFields === '*' || hookFields.length === 0
-            ? undefined
-            : Array.from(
-                new Set([
-                  ...fieldsToFetch,
-                  ...excludeLoadedFields(loadedFields, hookFields),
-                ]),
-              ).sort();
+        fieldsToFetch = isUnboundedHook
+          ? undefined
+          : Array.from(
+              new Set([
+                ...fieldsToFetch,
+                ...excludeLoadedFields(loadedFields, hookFields),
+              ]),
+            ).sort();
       } else {
-        const owedFields = new Set([
-          ...(store.state.itemFieldInvalidationFields[event.itemKey] ?? []),
-          ...excludeLoadedFields(
-            loadedFields,
-            itemPendingInvalidationFields.get(event.itemKey),
-          ),
-        ]);
-        const rideAlongFields =
-          !hookFields || hookFields === '*' || hookFields.length === 0
-            ? Array.from(owedFields)
-            : hookFields.filter((field) => owedFields.has(field));
+        const rideAlongFields = isUnboundedHook
+          ? Array.from(owedStaleFields)
+          : hookFields.filter((field) => owedStaleFields.has(field));
         fieldsToFetch = Array.from(
           new Set([...fieldsToFetch, ...rideAlongFields]),
         ).sort();

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -793,6 +793,44 @@ export function useMultipleItems<
     const firstQuery = matchingQueries[0];
     if (!firstQuery) return;
 
+    // The immediate fetch scheduled below replaces any pending scheduled
+    // fetch for this item (the scheduler cancels it), and that pending fetch
+    // may have been carrying other owed stale fields at a lower priority
+    // (e.g. a throttled realtime invalidation). Ride this instance's other
+    // owed stale fields along so the replaced fetch's obligation isn't lost.
+    if (fieldsToFetch) {
+      const hookFields = firstQuery.fields;
+      const loadedFields = store.state.itemLoadedFields[event.itemKey];
+      if (itemsPendingFullInvalidation.has(event.itemKey)) {
+        // After an unresolved full ('*') invalidation every field not yet
+        // reloaded is owed; for an unbounded hook that means a full fetch.
+        fieldsToFetch =
+          !hookFields || hookFields === '*' || hookFields.length === 0
+            ? undefined
+            : Array.from(
+                new Set([
+                  ...fieldsToFetch,
+                  ...excludeLoadedFields(loadedFields, hookFields),
+                ]),
+              ).sort();
+      } else {
+        const owedFields = new Set([
+          ...(store.state.itemFieldInvalidationFields[event.itemKey] ?? []),
+          ...excludeLoadedFields(
+            loadedFields,
+            itemPendingInvalidationFields.get(event.itemKey),
+          ),
+        ]);
+        const rideAlongFields =
+          !hookFields || hookFields === '*' || hookFields.length === 0
+            ? Array.from(owedFields)
+            : hookFields.filter((field) => owedFields.has(field));
+        fieldsToFetch = Array.from(
+          new Set([...fieldsToFetch, ...rideAlongFields]),
+        ).sort();
+      }
+    }
+
     store.produceState((draft) => {
       const query = draft.itemQueries[event.itemKey];
       if (!query?.refetchOnMount) return;

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -740,31 +740,43 @@ export function useMultipleItems<
   useOnEvtmitterEvent(events, 'invalidateItem', ({ payload: event }) => {
     if (loadFromStateOnly || !fetchItemFn) return;
 
-    const matchingQueries = fetchQueriesWithId.filter(
-      ({ itemKey, isOffScreen }) => !isOffScreen && itemKey === event.itemKey,
+    const queriesForItem = fetchQueriesWithId.filter(
+      ({ itemKey }) => itemKey === event.itemKey,
     );
-
-    if (matchingQueries.length === 0) return;
 
     let fieldsToFetch: string[] | undefined;
     if (event.invalidateFields && event.invalidateFields.length > 0) {
       fieldsToFetch = Array.from(new Set(event.invalidateFields)).sort();
-
-      const hasAffectedHook = matchingQueries.some(({ fields }) => {
-        if (fields === '*') return true;
-        if (!fields || fields.length === 0) return true;
-        return fields.some((field) => event.invalidateFields?.includes(field));
-      });
-
-      if (!hasAffectedHook) return;
     }
+
+    const affectedQueries = fieldsToFetch
+      ? queriesForItem.filter(({ fields }) => {
+          if (fields === '*') return true;
+          if (!fields || fields.length === 0) return true;
+          return fields.some((field) =>
+            event.invalidateFields?.includes(field),
+          );
+        })
+      : queriesForItem;
+
+    if (affectedQueries.length === 0) return;
 
     // A new invalidation is a new refetch obligation: re-open the mount-once
     // gate so the auto-fetch effect can schedule the refetch of this
-    // instance's own stale fields at the tracked invalidation priority. The
-    // fetch scheduled below only covers the first hook instance's fields —
+    // instance's own stale fields at the tracked invalidation priority. This
+    // must happen even when every affected instance is off-screen — the gate
+    // means "one automatic attempt per invalidation" and an off-screen
+    // instance hasn't spent its attempt yet; the effect schedules its refetch
+    // when it returns on-screen. Only the scheduling below is on-screen-only.
+    // The fetch scheduled below only covers the first hook instance's fields —
     // the scheduler coalesces/dedupes the per-instance schedules.
     ignoreItemsInRefetchOnMount.delete(event.itemKey);
+
+    const matchingQueries = affectedQueries.filter(
+      ({ isOffScreen }) => !isOffScreen,
+    );
+
+    if (matchingQueries.length === 0) return;
 
     if (itemInvalidationWasTriggered.has(event.itemKey)) return;
 

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -735,6 +735,8 @@ export function useMultipleItems<
     }
   }, [automaticRetryState, queriesWithId, store, visibleStoreState]);
 
+  const ignoreItemsInRefetchOnMount = useConst(() => new Set<string>());
+
   useOnEvtmitterEvent(events, 'invalidateItem', ({ payload: event }) => {
     if (loadFromStateOnly || !fetchItemFn) return;
 
@@ -743,17 +745,6 @@ export function useMultipleItems<
     );
 
     if (matchingQueries.length === 0) return;
-    if (itemInvalidationWasTriggered.has(event.itemKey)) return;
-
-    const allQueriesDisableRefetches = matchingQueries.every(
-      (q) => q.disableRefetches,
-    );
-    if (
-      allQueriesDisableRefetches &&
-      store.state.itemQueries[event.itemKey]?.wasLoaded
-    ) {
-      return;
-    }
 
     let fieldsToFetch: string[] | undefined;
     if (event.invalidateFields && event.invalidateFields.length > 0) {
@@ -766,6 +757,25 @@ export function useMultipleItems<
       });
 
       if (!hasAffectedHook) return;
+    }
+
+    // A new invalidation is a new refetch obligation: re-open the mount-once
+    // gate so the auto-fetch effect can schedule the refetch of this
+    // instance's own stale fields at the tracked invalidation priority. The
+    // fetch scheduled below only covers the first hook instance's fields —
+    // the scheduler coalesces/dedupes the per-instance schedules.
+    ignoreItemsInRefetchOnMount.delete(event.itemKey);
+
+    if (itemInvalidationWasTriggered.has(event.itemKey)) return;
+
+    const allQueriesDisableRefetches = matchingQueries.every(
+      (q) => q.disableRefetches,
+    );
+    if (
+      allQueriesDisableRefetches &&
+      store.state.itemQueries[event.itemKey]?.wasLoaded
+    ) {
+      return;
     }
 
     const firstQuery = matchingQueries[0];
@@ -783,8 +793,6 @@ export function useMultipleItems<
     });
     itemInvalidationWasTriggered.add(event.itemKey);
   });
-
-  const ignoreItemsInRefetchOnMount = useConst(() => new Set<string>());
 
   useLayoutEffect(() => {
     if (
@@ -869,17 +877,10 @@ export function useMultipleItems<
               : undefined;
 
           if (Array.isArray(fields) && fields.length > 0) {
-            const affectedInvalidationFields = fields.filter((field) =>
-              unresolvedPendingInvalidationFields.includes(field),
-            );
             // Per-field stale-or-missing check: `inferFields` keeps vouching
             // for unaffected fields even while other fields of the item have
             // unresolved invalidations (stale pending fields are never
-            // vouched). Fields still tracked as loaded can only be stale, not
-            // missing — their refetch is handled by the invalidation path
-            // below (event handler for mounted hooks, mount-once gate for
-            // late-mounting ones), so they are excluded here to avoid
-            // re-scheduling them on every effect run.
+            // vouched).
             const staleOrMissingFields = getStaleOrMissingRequestedFields(
               itemKey,
               loadedFields,
@@ -889,21 +890,36 @@ export function useMultipleItems<
               itemsPendingFullInvalidation,
               unresolvedPendingInvalidationFields,
             );
-            const missingFields =
-              loadedFields === '*'
-                ? []
-                : staleOrMissingFields.filter(
-                    (field) => !loadedFields.includes(field),
-                  );
+            // Genuinely missing fields (never loaded, not vouched, not merely
+            // stale) justify an immediate required fetch. Stale fields (owed
+            // after an invalidation, cached data still present) refetch at the
+            // tracked invalidation priority so scheduler throttling (e.g.
+            // realtime updates) stays effective; their refetch is handled by
+            // the invalidation path below (event handler for mounted hooks,
+            // mount-once gate for late-mounting ones) to avoid re-scheduling
+            // on every effect run.
+            const missingFields = getGenuinelyMissingRequestedFields(
+              itemKey,
+              { item, loadedFields },
+              fields,
+              partialResources.inferFields,
+              itemsPendingFullInvalidation,
+              unresolvedPendingInvalidationFields,
+            );
+            const staleInvalidatedFields = staleOrMissingFields.filter(
+              (field) => !missingFields.includes(field),
+            );
             const hasMissingFields = missingFields.length > 0;
-            const hasAffectedFieldInvalidation =
-              affectedInvalidationFields.length > 0;
-            // Pending invalidations no longer surface as missing fields for
-            // fully loaded ('*') items, so they must trigger the fetch here for
-            // hooks that mount after the invalidation happened.
+            const hasStaleInvalidatedFields = staleInvalidatedFields.length > 0;
+            // Stale fields with a tracked invalidation priority are gated on
+            // the mount-once set — the local `invalidateItem` event re-opens
+            // the gate for each new invalidation. Untracked stale fields
+            // (e.g. invalidations adopted from another tab via state sync)
+            // have no local event to re-open the gate, so they stay ungated.
             const shouldFetchForInvalidation =
-              hasAffectedFieldInvalidation &&
-              !ignoreItemsInRefetchOnMount.has(itemKey);
+              hasStaleInvalidatedFields &&
+              (!invalidationPriority ||
+                !ignoreItemsInRefetchOnMount.has(itemKey));
 
             if (
               (hasMissingFields || shouldFetchForInvalidation) &&
@@ -912,17 +928,25 @@ export function useMultipleItems<
               shouldFetch = true;
               requiredFetch = true;
               fieldsToFetch = Array.from(
-                new Set([...missingFields, ...affectedInvalidationFields]),
+                new Set([...missingFields, ...staleInvalidatedFields]),
               );
-              // Low-priority follow-ups can be skipped while scheduler phase is still fetching.
-              // Keep stronger priorities intact; only lift low priority.
-              if (fetchType === 'lowPriority') {
+              // Genuinely missing data — or stale fields with no tracked
+              // invalidation priority (e.g. invalidations adopted from
+              // another tab) — must fetch immediately. Low-priority
+              // follow-ups can be skipped while the scheduler phase is still
+              // fetching; keep stronger priorities intact, only lift low
+              // priority.
+              if (
+                (hasMissingFields || !invalidationPriority) &&
+                fetchType === 'lowPriority'
+              ) {
                 fetchType = 'highPriority';
               }
             }
 
             if (
-              hasAffectedFieldInvalidation &&
+              hasStaleInvalidatedFields &&
+              !hasMissingFields &&
               invalidationPriority &&
               fetchTypePriority[invalidationPriority] >
                 fetchTypePriority[fetchType]
@@ -930,20 +954,31 @@ export function useMultipleItems<
               fetchType = invalidationPriority;
             }
           } else if (fields === '*') {
+            // A fully invalidated item whose (now stale) data is still
+            // present is a refetch of stale data, not a load of missing data
+            // — it must keep the tracked invalidation priority.
+            const hasStaleFullInvalidation =
+              hasUnresolvedFullInvalidation && !!item;
             const missingFullItem =
-              !snapshotIsFullyLoaded(
+              !hasStaleFullInvalidation &&
+              (!snapshotIsFullyLoaded(
                 loadedFields,
                 item,
                 partialResources.inferFields,
-              ) || hasUnresolvedFullInvalidation;
-            // Invalidation-only refetches (item still complete, some fields
-            // stale) are gated on the mount-once set, mirroring the array-field
-            // branch. A missing full item is not gated, so a hook mounting while
-            // another fetch is in flight still refetches once that fetch settles.
+              ) ||
+                hasUnresolvedFullInvalidation);
+            // Invalidation-only refetches (stale data still present) are gated
+            // on the mount-once set, mirroring the array-field branch. A
+            // missing full item is not gated, so a hook mounting while another
+            // fetch is in flight still refetches once that fetch settles.
+            // Untracked invalidations (adopted from another tab) have no
+            // local event to re-open the gate, so they stay ungated too.
             const shouldFetchForInvalidation =
               !missingFullItem &&
-              unresolvedPendingInvalidationFields.length > 0 &&
-              !ignoreItemsInRefetchOnMount.has(itemKey);
+              (unresolvedPendingInvalidationFields.length > 0 ||
+                hasStaleFullInvalidation) &&
+              (!invalidationPriority ||
+                !ignoreItemsInRefetchOnMount.has(itemKey));
 
             if (
               (missingFullItem || shouldFetchForInvalidation) &&
@@ -951,17 +986,24 @@ export function useMultipleItems<
             ) {
               shouldFetch = true;
               requiredFetch = true;
-              fieldsToFetch = missingFullItem
-                ? '*'
-                : unresolvedPendingInvalidationFields;
+              fieldsToFetch =
+                missingFullItem || hasStaleFullInvalidation
+                  ? '*'
+                  : unresolvedPendingInvalidationFields;
 
-              // Low-priority follow-ups can be skipped while the scheduler phase
-              // is still fetching; lift a required full fetch to high priority.
-              if (fetchType === 'lowPriority') {
+              // Genuinely missing data — or stale data with no tracked
+              // invalidation priority — must fetch immediately; only lift low
+              // priority. Stale-only refetches keep the tracked invalidation
+              // priority so scheduler throttling stays effective.
+              if (
+                (missingFullItem || !invalidationPriority) &&
+                fetchType === 'lowPriority'
+              ) {
                 fetchType = 'highPriority';
               }
 
               if (
+                !missingFullItem &&
                 invalidationPriority &&
                 fetchTypePriority[invalidationPriority] >
                   fetchTypePriority[fetchType]

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -45,6 +45,7 @@ import {
   fallbackItemHasRequestedFields,
   getGenuinelyMissingRequestedFields,
   getStaleOrMissingRequestedFields,
+  hasFullyLoadedFields,
   snapshotIsFullyLoaded,
   snapshotIsFullyLoadedAndFresh,
 } from './itemFieldUtils';
@@ -424,8 +425,20 @@ export function useMultipleListQueries<
       for (const itemKey of itemKeys) {
         const unresolvedInvalidationFields =
           getUnresolvedPendingInvalidationFields(itemKey);
-        if (unresolvedInvalidationFields.length === 0) continue;
+        // A fully invalidated ('*'-loaded) item has no field list to
+        // enumerate — the pending-full marker alone proves every field
+        // (requested ones included) is awaiting the re-fetch.
+        const hasUnresolvedFullInvalidation =
+          itemsPendingFullInvalidation.has(itemKey) &&
+          !hasFullyLoadedFields(store.state.itemLoadedFields[itemKey]);
         if (
+          unresolvedInvalidationFields.length === 0 &&
+          !hasUnresolvedFullInvalidation
+        ) {
+          continue;
+        }
+        if (
+          !hasUnresolvedFullInvalidation &&
           requestedFields &&
           !requestedFields.some((field) =>
             unresolvedInvalidationFields.includes(field),
@@ -446,7 +459,12 @@ export function useMultipleListQueries<
 
       return highestPriority;
     },
-    [getUnresolvedPendingInvalidationFields, itemFieldInvalidationPriorities],
+    [
+      getUnresolvedPendingInvalidationFields,
+      itemFieldInvalidationPriorities,
+      itemsPendingFullInvalidation,
+      store,
+    ],
   );
 
   const getVisibleQueryItemKeys = useCallback(
@@ -1301,8 +1319,19 @@ export function useMultipleListQueries<
             effectiveQueryState.status === 'loadingMore';
 
           if (Array.isArray(fields) && fields.length > 0) {
-            const hasMissingRequestedFields = effectiveQueryState.items.some(
-              (itemKey) =>
+            // Stale fields (previously loaded, owed after an invalidation)
+            // and genuinely missing fields (never loaded, not vouched by
+            // `inferFields`) both require a fetch, but at different
+            // priorities: missing data justifies an immediate required fetch,
+            // while stale data must refetch at the tracked invalidation
+            // priority so scheduler throttling (e.g. realtime updates) stays
+            // effective.
+            let hasStaleOrMissingRequestedFields = false;
+            let hasGenuinelyMissingFields = false;
+            for (const itemKey of effectiveQueryState.items) {
+              const unresolvedInvalidationFields =
+                getUnresolvedPendingInvalidationFields(itemKey);
+              if (
                 getStaleOrMissingRequestedFields(
                   itemKey,
                   store.state.itemLoadedFields[itemKey],
@@ -1310,48 +1339,57 @@ export function useMultipleListQueries<
                   fields,
                   partialResources.inferFields,
                   itemsPendingFullInvalidation,
-                  getUnresolvedPendingInvalidationFields(itemKey),
-                ).length > 0,
-            );
+                  unresolvedInvalidationFields,
+                ).length === 0
+              ) {
+                continue;
+              }
 
-            if (hasMissingRequestedFields && !isQueryFetchInFlight) {
-              shouldFetch = true;
-              requiredFetch = true;
-              fieldsToFetch = fields;
-              // Low-priority follow-ups can be skipped while scheduler phase is still fetching.
-              // Keep stronger priorities intact; only lift low priority.
-              if (fetchType === 'lowPriority') {
-                fetchType = 'highPriority';
+              hasStaleOrMissingRequestedFields = true;
+
+              if (
+                getGenuinelyMissingRequestedFields(
+                  itemKey,
+                  {
+                    item: store.state.items[itemKey],
+                    loadedFields: store.state.itemLoadedFields[itemKey],
+                  },
+                  fields,
+                  partialResources.inferFields,
+                  itemsPendingFullInvalidation,
+                  unresolvedInvalidationFields,
+                ).length > 0
+              ) {
+                hasGenuinelyMissingFields = true;
+                break;
               }
             }
 
-            const hasAffectedFieldInvalidation = effectiveQueryState.items.some(
-              (itemKey) => {
-                const itemFieldInvalidationFields =
-                  getUnresolvedPendingInvalidationFields(itemKey);
-
-                return (
-                  itemFieldInvalidationFields.length > 0 &&
-                  fields.some((f) => itemFieldInvalidationFields.includes(f))
-                );
-              },
-            );
-
-            if (hasAffectedFieldInvalidation && !isQueryFetchInFlight) {
+            if (hasStaleOrMissingRequestedFields && !isQueryFetchInFlight) {
               shouldFetch = true;
               requiredFetch = true;
               fieldsToFetch = fields;
 
-              const invalidationPriority =
-                getHighestPendingInvalidationPriority(
-                  effectiveQueryState.items,
-                  fields,
-                );
+              const invalidationPriority = hasGenuinelyMissingFields
+                ? undefined
+                : getHighestPendingInvalidationPriority(
+                    effectiveQueryState.items,
+                    fields,
+                  );
 
-              if (
-                invalidationPriority &&
+              if (!invalidationPriority) {
+                // Genuinely missing data — or stale fields with no tracked
+                // invalidation priority (e.g. invalidations adopted from
+                // another tab) — must fetch immediately. Low-priority
+                // follow-ups can be skipped while the scheduler phase is
+                // still fetching; keep stronger priorities intact, only lift
+                // low priority.
+                if (fetchType === 'lowPriority') {
+                  fetchType = 'highPriority';
+                }
+              } else if (
                 fetchTypePriority[invalidationPriority] >
-                  fetchTypePriority[fetchType]
+                fetchTypePriority[fetchType]
               ) {
                 fetchType = invalidationPriority;
               }

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -1420,41 +1420,76 @@ export function useMultipleListQueries<
               }
             }
           } else if (fields === '*') {
-            const hasAnyPartialItem = effectiveQueryState.items.some(
-              (itemKey) =>
-                !snapshotIsFullyLoadedAndFresh(
-                  itemKey,
-                  store.state.itemLoadedFields[itemKey],
-                  store.state.items[itemKey],
+            // Genuinely missing data (fields never loaded on some item) and
+            // stale-but-displayable data (a full invalidation whose snapshot
+            // is still present, or pending field invalidations) both require
+            // a fetch, but at different priorities — mirroring the array
+            // branch above and the item-side '*' branch: missing data
+            // justifies an immediate fetch, while stale-only data must keep
+            // the tracked invalidation priority so scheduler throttling
+            // (e.g. realtime updates) stays effective.
+            let hasStaleItemData = false;
+            let hasGenuinelyMissingItemData = false;
+            for (const itemKey of effectiveQueryState.items) {
+              const item = store.state.items[itemKey];
+              const loadedFields = store.state.itemLoadedFields[itemKey];
+              // A '*'-loaded item resolved its full invalidation even if the
+              // tracking marker hasn't been pruned yet.
+              const hasUnresolvedFullInvalidation =
+                itemsPendingFullInvalidation.has(itemKey) &&
+                !hasFullyLoadedFields(loadedFields);
+              // A fully invalidated item whose (now stale) snapshot is still
+              // present is a refetch of stale data, not a load of missing
+              // data.
+              const hasStaleFullInvalidation =
+                hasUnresolvedFullInvalidation && !!item;
+
+              if (
+                !hasStaleFullInvalidation &&
+                (!snapshotIsFullyLoaded(
+                  loadedFields,
+                  item,
                   partialResources.inferFields,
-                  itemsPendingFullInvalidation,
-                ),
-            );
-            const hasAnyFieldInvalidation = effectiveQueryState.items.some(
-              (itemKey) => {
-                return (
-                  getUnresolvedPendingInvalidationFields(itemKey).length > 0
-                );
-              },
-            );
+                ) ||
+                  hasUnresolvedFullInvalidation)
+              ) {
+                hasGenuinelyMissingItemData = true;
+                break;
+              }
+
+              if (
+                hasStaleFullInvalidation ||
+                getUnresolvedPendingInvalidationFields(itemKey).length > 0
+              ) {
+                hasStaleItemData = true;
+              }
+            }
 
             if (
-              (hasAnyPartialItem || hasAnyFieldInvalidation) &&
+              (hasGenuinelyMissingItemData || hasStaleItemData) &&
               !isQueryFetchInFlight
             ) {
               shouldFetch = true;
               requiredFetch = true;
 
-              const invalidationPriority =
-                getHighestPendingInvalidationPriority(
-                  effectiveQueryState.items,
-                  undefined,
-                );
+              const invalidationPriority = hasGenuinelyMissingItemData
+                ? undefined
+                : getHighestPendingInvalidationPriority(
+                    effectiveQueryState.items,
+                    undefined,
+                  );
 
-              if (
-                invalidationPriority &&
+              if (!invalidationPriority) {
+                // Genuinely missing data — or stale data with no tracked
+                // invalidation priority (e.g. invalidations adopted from
+                // another tab) — must fetch immediately; only lift low
+                // priority.
+                if (fetchType === 'lowPriority') {
+                  fetchType = 'highPriority';
+                }
+              } else if (
                 fetchTypePriority[invalidationPriority] >
-                  fetchTypePriority[fetchType]
+                fetchTypePriority[fetchType]
               ) {
                 fetchType = invalidationPriority;
               }

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -1215,11 +1215,17 @@ export function useMultipleListQueries<
           query.refetchOnMount = false;
         });
 
-        scheduleAutomaticListQueryFetch(event.priority, payload, loadSize, {
-          fields,
-        });
         queryInvalidationWasTriggered.add(key);
       }
+
+      // Every instance schedules its own fields/loadSize — instances watching
+      // the same query with different field subsets each contribute theirs,
+      // and the scheduler's coalescing window merges the schedules into a
+      // single fetch. Deduping the schedule per query key would drop the
+      // other instances' fields, leaving them stale forever.
+      scheduleAutomaticListQueryFetch(event.priority, payload, loadSize, {
+        fields,
+      });
     }
   });
 

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -1186,6 +1186,15 @@ export function useMultipleListQueries<
     visibleStoreState,
   ]);
 
+  // Invalidations that arrived while an instance was off-screen, keyed by
+  // query key. The first visible instance handling an `invalidateQuery` event
+  // clears the query's shared `refetchOnMount`, so an off-screen instance's
+  // obligation must survive per hook instance — the auto-fetch effect
+  // consumes it when the instance returns on-screen.
+  const pendingOffScreenQueryInvalidations = useConst(
+    () => new Map<string, FetchType>(),
+  );
+
   useOnEvtmitterEvent(events, 'invalidateQuery', ({ payload: event }) => {
     for (const {
       key,
@@ -1195,8 +1204,6 @@ export function useMultipleListQueries<
       isOffScreen,
       disableRefetches,
     } of fetchQueriesWithId) {
-      if (isOffScreen) continue;
-
       if (key !== event.queryKey) continue;
 
       const resolvedQuery = resolveEffectiveQuery(store.state, {
@@ -1205,6 +1212,18 @@ export function useMultipleListQueries<
         fields,
       });
       if (disableRefetches && resolvedQuery?.query.wasLoaded) continue;
+
+      if (isOffScreen) {
+        const existingPriority = pendingOffScreenQueryInvalidations.get(key);
+        if (
+          !existingPriority ||
+          fetchTypePriority[event.priority] >
+            fetchTypePriority[existingPriority]
+        ) {
+          pendingOffScreenQueryInvalidations.set(key, event.priority);
+        }
+        continue;
+      }
 
       if (!queryInvalidationWasTriggered.has(key)) {
         stickyDerivedQueryKeys.delete(key);
@@ -1443,6 +1462,24 @@ export function useMultipleListQueries<
           }
         }
 
+        // Consume an invalidation that arrived while this instance was
+        // off-screen: the visible instances consumed the event itself (and
+        // cleared the query's shared `refetchOnMount`), so this per-instance
+        // record is the only surviving signal that the instance's fields are
+        // still owed a refetch.
+        const offScreenInvalidationPriority =
+          pendingOffScreenQueryInvalidations.get(queryId);
+        if (offScreenInvalidationPriority !== undefined) {
+          pendingOffScreenQueryInvalidations.delete(queryId);
+          shouldFetch = true;
+          if (
+            fetchTypePriority[offScreenInvalidationPriority] >
+            fetchTypePriority[fetchType]
+          ) {
+            fetchType = offScreenInvalidationPriority;
+          }
+        }
+
         if (!shouldFetch && ignoreQueriesInRefetchOnMount.has(queryId)) {
           continue;
         }
@@ -1481,6 +1518,7 @@ export function useMultipleListQueries<
     getQueryState,
     getDerivedPreloadPayloads,
     ignoreQueriesInRefetchOnMount,
+    pendingOffScreenQueryInvalidations,
     preloadDerivedQueryItems,
     preloadQueries,
     preloadQueriesBeforePaint,

--- a/src/requestScheduler.ts
+++ b/src/requestScheduler.ts
@@ -1209,15 +1209,7 @@ export class RequestScheduler<T> {
 
     this.#state.pending.rtuDelayed.set(requestId, {
       timeoutId: setTimeout(() => {
-        this.#state.pending.rtuDelayed.delete(requestId);
-        this.#onEvent?.('scheduled-rt-fetch-started');
-        this.#scheduleRequest(
-          requestId,
-          'highPriority',
-          payload,
-          undefined,
-          remoteStartCancelable,
-        );
+        this.#executeDelayedRTUFetch(requestId);
       }, delay),
       requestId,
       payload,
@@ -1230,6 +1222,24 @@ export class RequestScheduler<T> {
     this.#onEvent?.('rt-fetch-scheduled', { delayMs: delay });
 
     return true;
+  }
+
+  /** Executes from the current delayed entry, not from the args captured when
+   * the timeout was created — realtime updates arriving during the delay
+   * coalesce their payloads into the entry. */
+  #executeDelayedRTUFetch(requestId: string): void {
+    const delayedRequest = this.#state.pending.rtuDelayed.get(requestId);
+    if (!delayedRequest) return;
+
+    this.#state.pending.rtuDelayed.delete(requestId);
+    this.#onEvent?.('scheduled-rt-fetch-started');
+    this.#scheduleRequest(
+      requestId,
+      'highPriority',
+      delayedRequest.payload,
+      undefined,
+      delayedRequest.remoteStartCancelable,
+    );
   }
 
   #handleMediumPriority(

--- a/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
+++ b/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
@@ -569,30 +569,32 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
   `);
   expect(envA.timelineString).toMatchInlineSnapshot(`
     "
-    time  | name-age-hook |
-    4.62s | Alice:30      | -- timeline-cleared
-    .     | Alice:30      | [users||1] server-data-changed (value: {"id":1,"name":"Alicia","age":31,"city":"Lisbon"})
-    .     | Alice:30      | [users||1] received-ws-data-change-event
-    .     | Alice:30      | rt-fetch-scheduled (delay: 100ms)
-    4.63s | Alice:30      | rt-fetch-cancelled
-    .     | Alice:30      | 🟠 [users||1] >fetch-started
-    5.43s | Alice:30      | 🟠 [users||1] <fetch-finished (value: {"name":"Alicia","age":31})
-    .     | Alicia:31     | [name-age-hook] ui-changed
-    9.24s | Alicia:31     | [users||1] <confirmed-item-snapshot-received (value: {"age":31,"city":"Lisbon","name":"Alicia"})
+    time   | name-age-hook |
+    4.62s  | Alice:30      | -- timeline-cleared
+    .      | Alice:30      | [users||1] server-data-changed (value: {"id":1,"name":"Alicia","age":31,"city":"Lisbon"})
+    .      | Alice:30      | [users||1] received-ws-data-change-event
+    .      | Alice:30      | rt-fetch-scheduled (delay: 100ms)
+    4.72s  | Alice:30      | scheduled-rt-fetch-started
+    4.73s  | Alice:30      | 🟠 [users||1] >fetch-started
+    5.53s  | Alice:30      | 🟠 [users||1] <fetch-finished (value: {"name":"Alicia","age":31})
+    .      | Alicia:31     | [name-age-hook] ui-changed
+    10.34s | Alicia:31     | [users||1] <confirmed-item-snapshot-received (value: {"age":31,"city":"Lisbon","name":"Alicia"})
     "
   `);
   expect(envB.timelineString).toMatchInlineSnapshot(`
     "
-    time  | city-hook | name-age-hook |
-    4.62s | London    | Alice:30      | -- timeline-cleared
-    .     | London    | Alice:30      | [users||1] received-ws-data-change-event
-    .     | London    | Alice:30      | rt-fetch-scheduled (delay: 1000ms)
-    5.43s | London    | Alice:30      | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"London"})
-    .     | London    | Alice:30      | rt-fetch-cancelled
-    .     | London    | Alicia:31     | [name-age-hook] ui-changed
-    8.44s | London    | Alicia:31     | 🟠 [users||1] >fetch-started
-    9.24s | London    | Alicia:31     | 🟠 [users||1] <fetch-finished (value: {"city":"Lisbon"})
-    .     | Lisbon    | Alicia:31     | [city-hook] ui-changed
+    time   | city-hook | name-age-hook |
+    4.62s  | London    | Alice:30      | -- timeline-cleared
+    .      | London    | Alice:30      | [users||1] received-ws-data-change-event
+    .      | London    | Alice:30      | rt-fetch-scheduled (delay: 1000ms)
+    5.53s  | London    | Alice:30      | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"London"})
+    .      | London    | Alice:30      | rt-fetch-cancelled
+    .      | London    | Alice:30      | rt-fetch-scheduled (delay: 1000ms)
+    .      | London    | Alicia:31     | [name-age-hook] ui-changed
+    6.53s  | London    | Alicia:31     | scheduled-rt-fetch-started
+    9.54s  | London    | Alicia:31     | 🟠 [users||1] >fetch-started
+    10.34s | London    | Alicia:31     | 🟠 [users||1] <fetch-finished (value: {"city":"Lisbon"})
+    .      | Lisbon    | Alicia:31     | [city-hook] ui-changed
     "
   `);
 });
@@ -684,30 +686,32 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
 
   expect(envA.timelineString).toMatchInlineSnapshot(`
     "
-    time  | name-age  |
-    4.62s | Alice:30  | -- timeline-cleared
-    .     | Alice:30  | [users||1] server-data-changed (value: {"id":1,"name":"Alicia","age":31,"city":"Lisbon"})
-    .     | Alice:30  | [users||1] received-ws-data-change-event
-    .     | Alice:30  | rt-fetch-scheduled (delay: 100ms)
-    4.63s | Alice:30  | rt-fetch-cancelled
-    .     | Alice:30  | 🟠 [users||1] >fetch-started
-    5.43s | Alice:30  | 🟠 [users||1] <fetch-finished (value: {"name":"Alicia","age":31})
-    .     | Alicia:31 | [name-age] ui-changed
-    9.24s | Alicia:31 | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"Lisbon"})
+    time   | name-age  |
+    4.62s  | Alice:30  | -- timeline-cleared
+    .      | Alice:30  | [users||1] server-data-changed (value: {"id":1,"name":"Alicia","age":31,"city":"Lisbon"})
+    .      | Alice:30  | [users||1] received-ws-data-change-event
+    .      | Alice:30  | rt-fetch-scheduled (delay: 100ms)
+    4.72s  | Alice:30  | scheduled-rt-fetch-started
+    4.73s  | Alice:30  | 🟠 [users||1] >fetch-started
+    5.53s  | Alice:30  | 🟠 [users||1] <fetch-finished (value: {"name":"Alicia","age":31})
+    .      | Alicia:31 | [name-age] ui-changed
+    10.34s | Alicia:31 | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"Lisbon"})
     "
   `);
   expect(envB.timelineString).toMatchInlineSnapshot(`
     "
-    time  | name-age-city    |
-    4.62s | Alice:30:London  | -- timeline-cleared
-    .     | Alice:30:London  | [users||1] received-ws-data-change-event
-    .     | Alice:30:London  | rt-fetch-scheduled (delay: 1000ms)
-    5.43s | Alice:30:London  | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"London"})
-    .     | Alice:30:London  | rt-fetch-cancelled
-    .     | Alicia:31:London | [name-age-city] ui-changed
-    8.44s | Alicia:31:London | 🟠 [users||1] >fetch-started
-    9.24s | Alicia:31:London | 🟠 [users||1] <fetch-finished (value: {"city":"Lisbon"})
-    .     | Alicia:31:Lisbon | [name-age-city] ui-changed
+    time   | name-age-city    |
+    4.62s  | Alice:30:London  | -- timeline-cleared
+    .      | Alice:30:London  | [users||1] received-ws-data-change-event
+    .      | Alice:30:London  | rt-fetch-scheduled (delay: 1000ms)
+    5.53s  | Alice:30:London  | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"London"})
+    .      | Alice:30:London  | rt-fetch-cancelled
+    .      | Alice:30:London  | rt-fetch-scheduled (delay: 1000ms)
+    .      | Alicia:31:London | [name-age-city] ui-changed
+    6.53s  | Alicia:31:London | scheduled-rt-fetch-started
+    9.54s  | Alicia:31:London | 🟠 [users||1] >fetch-started
+    10.34s | Alicia:31:London | 🟠 [users||1] <fetch-finished (value: {"city":"Lisbon"})
+    .      | Alicia:31:Lisbon | [name-age-city] ui-changed
     "
   `);
 });
@@ -779,30 +783,32 @@ test('focused RTU list refetch lets makes a background tab correctly invalidate 
 
   expect(focusedTab.timelineString).toMatchInlineSnapshot(`
     "
-    time  | first-item | second-item |
-    4.62s | Alice:30   | Bob:25      | -- timeline-cleared
-    .     | Alice:30   | Bob:25      | [users||1] server-data-changed (value: {"id":1,"name":"Alicia","age":31,"city":"Lisbon"})
-    .     | Alice:30   | Bob:25      | [users||1] received-ws-data-change-event
-    .     | Alice:30   | Bob:25      | rt-fetch-scheduled (delay: 100ms)
-    4.63s | Alice:30   | Bob:25      | rt-fetch-cancelled
-    .     | Alice:30   | Bob:25      | 🟠 >list-fetch-started
-    5.43s | Alice:30   | Bob:25      | 🟠 <list-fetch-finished (value: {"count":2})
-    .     | Alicia:31  | Bob:25      | [first-item] ui-changed
-    9.24s | Alicia:31  | Bob:25      | <confirmed-query-snapshot-received (value: {"queryKey":"{tableId:\\"users\\"}","itemCount":2})
+    time   | first-item | second-item |
+    4.62s  | Alice:30   | Bob:25      | -- timeline-cleared
+    .      | Alice:30   | Bob:25      | [users||1] server-data-changed (value: {"id":1,"name":"Alicia","age":31,"city":"Lisbon"})
+    .      | Alice:30   | Bob:25      | [users||1] received-ws-data-change-event
+    .      | Alice:30   | Bob:25      | rt-fetch-scheduled (delay: 100ms)
+    4.72s  | Alice:30   | Bob:25      | scheduled-rt-fetch-started
+    4.73s  | Alice:30   | Bob:25      | 🟠 >list-fetch-started
+    5.53s  | Alice:30   | Bob:25      | 🟠 <list-fetch-finished (value: {"count":2})
+    .      | Alicia:31  | Bob:25      | [first-item] ui-changed
+    10.34s | Alicia:31  | Bob:25      | <confirmed-query-snapshot-received (value: {"queryKey":"{tableId:\\"users\\"}","itemCount":2})
     "
   `);
   expect(backgroundTab.timelineString).toMatchInlineSnapshot(`
     "
-    time  | first-item       | second-item  |
-    4.62s | Alice:30:London  | Bob:25:Paris | -- timeline-cleared
-    .     | Alice:30:London  | Bob:25:Paris | [users||1] received-ws-data-change-event
-    .     | Alice:30:London  | Bob:25:Paris | rt-fetch-scheduled (delay: 1000ms)
-    5.43s | Alice:30:London  | Bob:25:Paris | <confirmed-query-snapshot-received (value: {"queryKey":"{tableId:\\"users\\"}","itemCount":2})
-    .     | Alice:30:London  | Bob:25:Paris | rt-fetch-cancelled
-    .     | Alicia:31:London | Bob:25:Paris | [first-item] ui-changed
-    8.44s | Alicia:31:London | Bob:25:Paris | 🟠 >list-fetch-started
-    9.24s | Alicia:31:London | Bob:25:Paris | 🟠 <list-fetch-finished (value: {"count":2})
-    .     | Alicia:31:Lisbon | Bob:25:Paris | [first-item] ui-changed
+    time   | first-item       | second-item  |
+    4.62s  | Alice:30:London  | Bob:25:Paris | -- timeline-cleared
+    .      | Alice:30:London  | Bob:25:Paris | [users||1] received-ws-data-change-event
+    .      | Alice:30:London  | Bob:25:Paris | rt-fetch-scheduled (delay: 1000ms)
+    5.53s  | Alice:30:London  | Bob:25:Paris | <confirmed-query-snapshot-received (value: {"queryKey":"{tableId:\\"users\\"}","itemCount":2})
+    .      | Alice:30:London  | Bob:25:Paris | rt-fetch-cancelled
+    .      | Alicia:31:London | Bob:25:Paris | [first-item] ui-changed
+    .      | Alicia:31:London | Bob:25:Paris | rt-fetch-scheduled (delay: 1000ms)
+    6.53s  | Alicia:31:London | Bob:25:Paris | scheduled-rt-fetch-started
+    9.54s  | Alicia:31:London | Bob:25:Paris | 🟠 >list-fetch-started
+    10.34s | Alicia:31:London | Bob:25:Paris | 🟠 <list-fetch-finished (value: {"count":2})
+    .      | Alicia:31:Lisbon | Bob:25:Paris | [first-item] ui-changed
     "
   `);
   expect(backgroundTab.serverTable.getRequestHistory('list'))
@@ -818,7 +824,7 @@ test('focused RTU list refetch lets makes a background tab correctly invalidate 
           fields: ['name', 'age', 'city']
           pos: { limit: 2, offset: 0 }
         returned_items: 2
-        time: '8.44s -> 9.24s | duration: 800ms'
+        time: '9.54s -> 10.34s | duration: 800ms'
     `);
 });
 

--- a/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
+++ b/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
@@ -539,7 +539,7 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
     envBFetchCountBeforeRTU + 1,
   );
   expect(pick(envAFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
-    `fields: ['name', 'age']`,
+    `fields: ['age', 'name']`,
   );
   expect(pick(envBFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
     `fields: ['city']`,
@@ -576,7 +576,7 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
     .      | Alice:30      | rt-fetch-scheduled (delay: 100ms)
     4.72s  | Alice:30      | scheduled-rt-fetch-started
     4.73s  | Alice:30      | 🟠 [users||1] >fetch-started
-    5.53s  | Alice:30      | 🟠 [users||1] <fetch-finished (value: {"name":"Alicia","age":31})
+    5.53s  | Alice:30      | 🟠 [users||1] <fetch-finished (value: {"age":31,"name":"Alicia"})
     .      | Alicia:31     | [name-age-hook] ui-changed
     10.34s | Alicia:31     | [users||1] <confirmed-item-snapshot-received (value: {"age":31,"city":"Lisbon","name":"Alicia"})
     "
@@ -676,7 +676,7 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
     envBFetchCountBeforeRTU + 1,
   );
   expect(pick(envAFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
-    `fields: ['name', 'age']`,
+    `fields: ['age', 'name']`,
   );
   expect(pick(envBFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
     `fields: ['city']`,
@@ -693,7 +693,7 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
     .      | Alice:30  | rt-fetch-scheduled (delay: 100ms)
     4.72s  | Alice:30  | scheduled-rt-fetch-started
     4.73s  | Alice:30  | 🟠 [users||1] >fetch-started
-    5.53s  | Alice:30  | 🟠 [users||1] <fetch-finished (value: {"name":"Alicia","age":31})
+    5.53s  | Alice:30  | 🟠 [users||1] <fetch-finished (value: {"age":31,"name":"Alicia"})
     .      | Alicia:31 | [name-age] ui-changed
     10.34s | Alicia:31 | [users||1] <confirmed-item-snapshot-received (value: {"name":"Alicia","age":31,"city":"Lisbon"})
     "
@@ -816,7 +816,7 @@ test('a full invalidation of a fully-loaded item is re-announced to a background
     envBFetchCountBeforeRTU + 1,
   );
   expect(pick(envAFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
-    `fields: ['name', 'age']`,
+    `fields: ['age', 'name']`,
   );
   expect(pick(envBFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
     `fields: ['city']`,

--- a/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
+++ b/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
@@ -848,6 +848,136 @@ test('a full invalidation of a fully-loaded item is re-announced to a background
   `);
 });
 
+test('a surviving full invalidation is not downgraded to a field-only re-announce by a coexisting per-field invalidation', async () => {
+  const { envA, envB } = createEnvs({
+    storeId: 'list-query-full-invalidation-not-downgraded',
+    data: {
+      users: [{ id: 1, name: 'Alice', age: 30, city: 'London', role: 'admin' }],
+    },
+    focusedTab: 'a',
+    usesRealTimeUpdates: true,
+  });
+
+  // Same setup as the previous test: both tabs load the item as a full
+  // resource ('*') so a later full invalidation is tracked only by the
+  // full-invalidation marker.
+  const envAFullHook = renderHook(() =>
+    envA.apiStore.useItem('users||1', { fields: '*' }),
+  );
+  await flushAllTimers();
+  const envBFullHook = renderHook(() =>
+    envB.apiStore.useItem('users||1', { fields: '*' }),
+  );
+  await flushAllTimers();
+
+  // Steady-state subset hooks: the focused tab watches name/age, the
+  // background tab watches only city.
+  const envAHook = renderHook(() => {
+    const item = envA.apiStore.useItem('users||1', {
+      returnRefetchingStatus: true,
+      fields: ['name', 'age'],
+    });
+
+    envA.trackItemUI('name-age-hook', getTrackedUserSummary(item.data));
+    return item;
+  });
+  const envBHook = renderHook(() => {
+    const item = envB.apiStore.useItem('users||1', {
+      returnRefetchingStatus: true,
+      fields: ['city'],
+    });
+
+    envB.trackItemUI(
+      'city-hook',
+      typeof item.data?.city === 'string' ? item.data.city : null,
+    );
+    return item;
+  });
+  await flushAllTimers();
+
+  envAFullHook.unmount();
+  envBFullHook.unmount();
+  await flushAllTimers();
+
+  const itemKey = envB.getStoreItemKeyFromRaw('users||1');
+  expect(envA.store.state.itemLoadedFields[itemKey]).toBe('*');
+  expect(envB.store.state.itemLoadedFields[itemKey]).toBe('*');
+
+  const envBFetchCountBeforeRTU = countFetchHistoryEntries(
+    envB.serverTable.fetchHistory,
+    'fetch',
+  );
+
+  envA.clearTimeline();
+  envB.clearTimeline();
+
+  // A real-time update changes all fields — both tabs invalidate the item
+  // fully (tracked by the full-invalidation marker).
+  act(() => {
+    envA.serverTable.setItem(
+      'users||1',
+      { id: 1, name: 'Alicia', age: 31, city: 'Lisbon', role: 'editor' },
+      { triggerRTUEvent: true },
+    );
+  });
+
+  // While both tabs' throttled refetches are still pending, the background
+  // tab also receives a per-field invalidation for 'role' — a field no
+  // mounted hook displays, so it stays recorded as an explicit unresolved
+  // field alongside the full-invalidation marker.
+  await advanceTime(100);
+  act(() => {
+    envB.apiStore.invalidateQueryAndItems({
+      queryPayload: false,
+      itemPayload: 'users||1',
+      type: 'realtimeUpdate',
+      fields: ['role'],
+    });
+  });
+  await flushAllTimers();
+
+  // The focused tab refetched only name/age and its snapshot (whose merged
+  // item still carries the stale city, vouched via inferFields) cancelled the
+  // background tab's pending refetch. The re-announce after that cancellation
+  // must stay a FULL invalidation — the surviving 'role' field record must
+  // not downgrade it to a role-only event, or the city hook would never
+  // reschedule and would show the stale city forever.
+  expect(countFetchHistoryEntries(envB.serverTable.fetchHistory, 'fetch')).toBe(
+    envBFetchCountBeforeRTU + 1,
+  );
+  const envBFetchEntries = envB.serverTable.fetchHistory.filter(
+    (entry) => entry.type === 'fetch',
+  );
+  expect(pick(envBFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
+    `fields: ['city']`,
+  );
+  expect(pick(envBHook.result.current, ['status', 'data']))
+    .toMatchInlineSnapshot(`
+      data: { city: 'Lisbon' }
+      status: 'success'
+    `);
+  expect(pick(envAHook.result.current, ['status', 'data']))
+    .toMatchInlineSnapshot(`
+      data: { age: 31, name: 'Alicia' }
+      status: 'success'
+    `);
+  expect(envB.timelineString).toMatchInlineSnapshot(`
+    "
+    time   | city-hook |
+    4.62s  | London    | -- timeline-cleared
+    .      | London    | [users||1] received-ws-data-change-event
+    .      | London    | rt-fetch-scheduled (delay: 1000ms)
+    5.53s  | London    | [users||1] <confirmed-item-snapshot-received (value: {"id":1,"name":"Alicia","age":31,"city":"London","role":"admin"})
+    .      | London    | rt-fetch-cancelled
+    .      | London    | rt-fetch-scheduled (delay: 1000ms)
+    6.53s  | London    | scheduled-rt-fetch-started
+    9.54s  | London    | 🟠 [users||1] >fetch-started
+    10.34s | London    | 🟠 [users||1] <fetch-finished (value: {"city":"Lisbon"})
+    .      | Lisbon    | [city-hook] ui-changed
+    "
+  `);
+});
+
 test('focused RTU list refetch lets makes a background tab correctly invalidate the list with extra fields', async () => {
   const { envA: focusedTab, envB: backgroundTab } = createEnvs({
     storeId: 'list-query-focused-item-rtu-extra-field',

--- a/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
+++ b/tests/browser-tabs/browser-tabs-partial-resources.test.tsx
@@ -716,6 +716,138 @@ test('focused RTU item refetch lets a background tab reuse snapshot fields and r
   `);
 });
 
+test('a full invalidation of a fully-loaded item is re-announced to a background tab whose cancelled refetch left fields stale', async () => {
+  const { envA, envB } = createEnvs({
+    storeId: 'list-query-full-invalidation-reannounce',
+    data: { users: [{ id: 1, name: 'Alice', age: 30, city: 'London' }] },
+    focusedTab: 'a',
+    usesRealTimeUpdates: true,
+  });
+
+  // Both tabs first load the item as a full resource (fields: '*') so their
+  // loadedFields become the '*' sentinel — a later full invalidation of a
+  // '*'-loaded item is tracked only by the full-invalidation marker, with no
+  // per-field list left to re-announce.
+  const envAFullHook = renderHook(() =>
+    envA.apiStore.useItem('users||1', { fields: '*' }),
+  );
+  await flushAllTimers();
+  const envBFullHook = renderHook(() =>
+    envB.apiStore.useItem('users||1', { fields: '*' }),
+  );
+  await flushAllTimers();
+
+  // Steady-state subset hooks: the focused tab watches name/age, the
+  // background tab watches only city. Both are satisfied from state.
+  const envAHook = renderHook(() => {
+    const item = envA.apiStore.useItem('users||1', {
+      returnRefetchingStatus: true,
+      fields: ['name', 'age'],
+    });
+
+    envA.trackItemUI('name-age-hook', getTrackedUserSummary(item.data));
+    return item;
+  });
+  const envBHook = renderHook(() => {
+    const item = envB.apiStore.useItem('users||1', {
+      returnRefetchingStatus: true,
+      fields: ['city'],
+    });
+
+    envB.trackItemUI(
+      'city-hook',
+      typeof item.data?.city === 'string' ? item.data.city : null,
+    );
+    return item;
+  });
+  await flushAllTimers();
+
+  // Unmount the full-resource hooks so nothing refetches '*' after the
+  // invalidation — only the subset hooks remain mounted.
+  envAFullHook.unmount();
+  envBFullHook.unmount();
+  await flushAllTimers();
+
+  const itemKey = envB.getStoreItemKeyFromRaw('users||1');
+  expect(envA.store.state.itemLoadedFields[itemKey]).toBe('*');
+  expect(envB.store.state.itemLoadedFields[itemKey]).toBe('*');
+
+  const envAFetchCountBeforeRTU = countFetchHistoryEntries(
+    envA.serverTable.fetchHistory,
+    'fetch',
+  );
+  const envBFetchCountBeforeRTU = countFetchHistoryEntries(
+    envB.serverTable.fetchHistory,
+    'fetch',
+  );
+  expect(envAFetchCountBeforeRTU).toBe(1);
+  expect(envBFetchCountBeforeRTU).toBe(1);
+
+  envA.clearTimeline();
+  envB.clearTimeline();
+
+  // The real-time update changes all fields, so both tabs invalidate the item
+  // fully. The focused tab refetches only its own name/age fields and
+  // broadcasts a snapshot whose merged item still carries the stale city —
+  // which wrongly cancels the background tab's pending city refetch (the
+  // snapshot vouches for city via inferFields). The surviving
+  // full-invalidation marker must be re-announced so the background tab
+  // reschedules its city refetch instead of staying stale forever.
+  act(() => {
+    envA.serverTable.setItem(
+      'users||1',
+      { id: 1, name: 'Alicia', age: 31, city: 'Lisbon' },
+      { triggerRTUEvent: true },
+    );
+  });
+  await flushAllTimers();
+
+  const envAFetchEntries = envA.serverTable.fetchHistory.filter(
+    (entry) => entry.type === 'fetch',
+  );
+  const envBFetchEntries = envB.serverTable.fetchHistory.filter(
+    (entry) => entry.type === 'fetch',
+  );
+  expect(countFetchHistoryEntries(envA.serverTable.fetchHistory, 'fetch')).toBe(
+    envAFetchCountBeforeRTU + 1,
+  );
+  // The background tab must refetch its own city field after the re-announce.
+  expect(countFetchHistoryEntries(envB.serverTable.fetchHistory, 'fetch')).toBe(
+    envBFetchCountBeforeRTU + 1,
+  );
+  expect(pick(envAFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
+    `fields: ['name', 'age']`,
+  );
+  expect(pick(envBFetchEntries.at(-1), ['fields'])).toMatchInlineSnapshot(
+    `fields: ['city']`,
+  );
+  expect(pick(envAHook.result.current, ['status', 'data']))
+    .toMatchInlineSnapshot(`
+      data: { age: 31, name: 'Alicia' }
+      status: 'success'
+    `);
+  expect(pick(envBHook.result.current, ['status', 'data']))
+    .toMatchInlineSnapshot(`
+      data: { city: 'Lisbon' }
+      status: 'success'
+    `);
+  expect(envB.timelineString).toMatchInlineSnapshot(`
+    "
+    time   | city-hook |
+    4.62s  | London    | -- timeline-cleared
+    .      | London    | [users||1] received-ws-data-change-event
+    .      | London    | rt-fetch-scheduled (delay: 1000ms)
+    5.53s  | London    | [users||1] <confirmed-item-snapshot-received (value: {"id":1,"name":"Alicia","age":31,"city":"London"})
+    .      | London    | rt-fetch-cancelled
+    .      | London    | rt-fetch-scheduled (delay: 1000ms)
+    6.53s  | London    | scheduled-rt-fetch-started
+    9.54s  | London    | 🟠 [users||1] >fetch-started
+    10.34s | London    | 🟠 [users||1] <fetch-finished (value: {"city":"Lisbon"})
+    .      | Lisbon    | [city-hook] ui-changed
+    "
+  `);
+});
+
 test('focused RTU list refetch lets makes a background tab correctly invalidate the list with extra fields', async () => {
   const { envA: focusedTab, envB: backgroundTab } = createEnvs({
     storeId: 'list-query-focused-item-rtu-extra-field',

--- a/tests/list-query-features/list-query-partial-resources-3.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-3.test.ts
@@ -406,7 +406,7 @@ describe('list query field accumulation edge cases', () => {
           fields: ['id', 'name', 'address']
           pos: { limit: 50, offset: 0 }
         returned_items: 10
-        time: '820ms -> 1.62s | duration: 800ms'
+        time: '920ms -> 1.72s | duration: 800ms'
     `);
   });
 });

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -1913,6 +1913,183 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
       name: 'New User 1'
     `);
   });
+
+  test('an escalated field invalidation does not strand stale fields owed to other mounted hooks', async () => {
+    const env = createRealtimeEnv();
+
+    // Two independent components display different fields of the same item.
+    const nameHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name'] }),
+    );
+    const addressHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['address'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // A realtime record-change event fully invalidates the item inside the
+    // throttle window — both hooks' stale fields ride on a single delayed
+    // refetch scheduled at the throttle boundary.
+    await advanceTime(100);
+    env.serverTable.updateItem('users||1', {
+      name: 'New User 1',
+      address: 'New Address 1',
+    });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // While that refetch is still waiting, the app explicitly invalidates
+    // only 'name' at highPriority. The immediate escalated fetch replaces the
+    // delayed one — which was also carrying the address hook's stale field.
+    await advanceTime(50);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+        fields: ['name'],
+      });
+    });
+
+    await flushAllTimers();
+
+    // The address hook's owed field must ride along on the escalated fetch —
+    // one immediate request covering both hooks' stale fields. Without this,
+    // the cancelled delayed fetch was the only carrier of 'address' and the
+    // address hook would show the stale value forever.
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | server-data-changed (value: {"name":"New User 1","address":"New Address 1"})
+      .     | rt-fetch-scheduled (delay: 900ms)
+      970ms | rt-fetch-cancelled
+      .     | 🟠 >fetch-started
+      1.77s | 🟠 <fetch-finished (value: {"address":"New Address 1","name":"New User 1"})
+      "
+    `);
+    expect(nameHook.result.current.data?.name).toBe('New User 1');
+    expect(addressHook.result.current.data?.address).toBe('New Address 1');
+  });
+
+  test('stale fields owed to other hooks are preserved regardless of hook registration order', async () => {
+    const env = createRealtimeEnv();
+
+    // Same scenario as above, but the hook that does NOT match the escalated
+    // event's fields registers first — so its handler runs first and becomes
+    // the one scheduling the immediate fetch, while the name hook's handler
+    // contributes afterwards.
+    const addressHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['address'] }),
+    );
+    const nameHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // Full realtime invalidation inside the throttle window...
+    await advanceTime(100);
+    env.serverTable.updateItem('users||1', {
+      name: 'New User 1',
+      address: 'New Address 1',
+    });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // ...escalated by an explicit high-priority 'name' invalidation.
+    await advanceTime(50);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+        fields: ['name'],
+      });
+    });
+
+    await flushAllTimers();
+
+    // Still a single immediate fetch covering both hooks' stale fields.
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | server-data-changed (value: {"name":"New User 1","address":"New Address 1"})
+      .     | rt-fetch-scheduled (delay: 900ms)
+      970ms | rt-fetch-cancelled
+      .     | 🟠 >fetch-started
+      1.77s | 🟠 <fetch-finished (value: {"address":"New Address 1","name":"New User 1"})
+      "
+    `);
+    expect(nameHook.result.current.data?.name).toBe('New User 1');
+    expect(addressHook.result.current.data?.address).toBe('New Address 1');
+  });
+});
+
+describe('partial resources: query invalidations with multiple same-payload hooks', () => {
+  // Finding: the `invalidateQuery` event handler dedups per query key, so
+  // with two hook instances watching the same query with different field
+  // subsets only the first instance's fields were scheduled on invalidation —
+  // the other instance's fields were never refetched and kept showing stale
+  // data forever.
+  test('a query invalidation refetches the fields of every mounted hook watching the query', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // Two components watch the same list with different field subsets.
+    const nameHook = renderHook(() =>
+      env.apiStore.useListQuery({ tableId: 'users' }, { fields: ['name'] }),
+    );
+    const addressHook = renderHook(() =>
+      env.apiStore.useListQuery({ tableId: 'users' }, { fields: ['address'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    // The server data changes and the app invalidates the query.
+    env.serverTable.updateItem('users||1', {
+      name: 'New User 1',
+      address: 'New Address 1',
+    });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: { tableId: 'users' },
+        itemPayload: false,
+        type: 'highPriority',
+      });
+    });
+    await flushAllTimers();
+
+    // A single coalesced refetch must cover both hooks' field subsets — the
+    // per-instance schedules merge in the scheduler's coalescing window.
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['address', 'name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+
+    // Both hooks must show the fresh values — with the buggy per-key dedup
+    // the second hook's fields were dropped and it kept the stale address
+    // forever.
+    expect(nameHook.result.current.items[0]?.name).toBe('New User 1');
+    expect(addressHook.result.current.items[0]?.address).toBe('New Address 1');
+  });
 });
 
 describe('partial resources: invalidations arriving while a hook is off-screen', () => {

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -1464,3 +1464,225 @@ describe('partial resources: inferFields reporting a complete snapshot', () => {
       `);
   });
 });
+
+describe('partial resources: realtime invalidations keep the scheduler throttle', () => {
+  // Finding: a full realtime invalidation resets `itemLoadedFields` to `[]`
+  // while the (stale) item data stays in state. The auto-fetch effect then
+  // classified every previously loaded field as "missing requested data" and
+  // promoted the refetch from `realtimeUpdate` to `highPriority` — cancelling
+  // the scheduler's delayed realtime fetch and firing an immediate duplicate
+  // request. Previously loaded fields owed after an invalidation are STALE,
+  // not missing: they must refetch at the tracked invalidation priority so
+  // the realtime throttle stays effective.
+
+  function createRealtimeEnv() {
+    return createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+      usesRealTimeUpdates: true,
+      dynamicRealtimeThrottleMs: () => 1000,
+    });
+  }
+
+  /** Mounts a list query hook and resolves the initial load so the realtime
+   * throttle has a baseline fetch. */
+  async function primeMountedListQuery(
+    env: ReturnType<typeof createRealtimeEnv>,
+  ) {
+    renderHook(() => {
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'address'] },
+      );
+    });
+    await flushAllTimers();
+    env.clearTimeline();
+  }
+
+  /** The shape a realtime record-change event produces: a full invalidation
+   * of the query and its items at `realtimeUpdate` priority. */
+  function invalidateAllAsRealtimeUpdate(
+    env: ReturnType<typeof createRealtimeEnv>,
+  ) {
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: { tableId: 'users' },
+        itemPayload: (item) => item.startsWith('users||'),
+        type: 'realtimeUpdate',
+      });
+    });
+  }
+
+  test('a realtime full invalidation refetches once, delayed by the throttle, without an immediate duplicate fetch', async () => {
+    const env = createRealtimeEnv();
+    await primeMountedListQuery(env);
+
+    // A realtime record-change event fully invalidates the query and its
+    // items inside the throttle window.
+    await advanceTime(100);
+    invalidateAllAsRealtimeUpdate(env);
+
+    await flushAllTimers();
+
+    // The refetch must stay delayed by the throttle: one rt-fetch-scheduled,
+    // no rt-fetch-cancelled, and a single list fetch at the throttle
+    // boundary. Previously the auto-fetch effect promoted the stale fields to
+    // `highPriority`, cancelling the delayed fetch and firing immediately.
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | rt-fetch-scheduled (delay: 900ms)
+      1.81s | scheduled-rt-fetch-started
+      1.82s | 🟠 >list-fetch-started
+      2.62s | 🟠 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+
+    // Exactly one refetch after the initial load — fired at the throttle
+    // boundary, not at invalidation time.
+    expect(env.serverTable.getRequestHistory('list')).toMatchInlineSnapshot(`
+      - _type: 'list'
+        payload:
+          fields: ['id', 'name', 'address']
+          pos: { limit: 50, offset: 0 }
+        returned_items: 5
+        time: '10ms -> 810ms | duration: 800ms'
+      - _type: 'list'
+        payload:
+          fields: ['id', 'name', 'address']
+          pos: { limit: 50, offset: 0 }
+        returned_items: 5
+        time: '1.82s -> 2.62s | duration: 800ms'
+    `);
+  });
+
+  test('repeated realtime invalidations inside the throttle window coalesce into one delayed refetch', async () => {
+    const env = createRealtimeEnv();
+    await primeMountedListQuery(env);
+
+    // Two realtime record-change events arrive inside the same throttle
+    // window.
+    await advanceTime(100);
+    invalidateAllAsRealtimeUpdate(env);
+
+    await advanceTime(200);
+    invalidateAllAsRealtimeUpdate(env);
+
+    await flushAllTimers();
+
+    // Both invalidations coalesce into a single delayed realtime refetch —
+    // no cancellation, no immediate fetches, one refetch request total.
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | rt-fetch-scheduled (delay: 900ms)
+      1.81s | scheduled-rt-fetch-started
+      1.82s | 🟠 >list-fetch-started
+      2.62s | 🟠 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+
+    expect(env.serverTable.getRequestHistory('list').length).toBe(2);
+  });
+
+  test('a genuinely missing requested field still fetches immediately instead of waiting for a throttle', async () => {
+    const env = createRealtimeEnv();
+    await primeMountedListQuery(env);
+
+    // A second hook on the same query requests a field that was never loaded
+    // ('age'). This is genuinely missing data — the fetch must run
+    // immediately (promoted past the lowPriority mount default), not wait for
+    // any throttle.
+    await advanceTime(100);
+    const { result } = renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'age'] },
+      ),
+    );
+
+    await flushAllTimers();
+
+    // The missing field is fetched immediately and resolves with data.
+    expect(result.current.status).toBe('success');
+    expect(result.current.items[0]?.age).toBe(10);
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      920ms | 🟠 >list-fetch-started
+      1.72s | 🟠 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+  });
+
+  test('mixed stale + genuinely missing fields fetch immediately, covering both', async () => {
+    const env = createRealtimeEnv();
+    await primeMountedListQuery(env);
+
+    // A realtime invalidation marks the loaded fields stale (delayed refetch
+    // scheduled)...
+    await advanceTime(100);
+    invalidateAllAsRealtimeUpdate(env);
+
+    // ...then a hook mounts requesting a genuinely never-loaded field ('age')
+    // alongside the now-stale ones.
+    await advanceTime(50);
+    const { result } = renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'address', 'age'] },
+      ),
+    );
+
+    await flushAllTimers();
+
+    // Genuinely missing data justifies an immediate required fetch. It covers
+    // the stale fields too, superseding the delayed realtime refetch — so
+    // only one refetch happens in total.
+    expect(result.current.status).toBe('success');
+    expect(result.current.items[0]?.age).toBe(10);
+    expect(env.serverTable.getRequestHistory('list').length).toBe(2);
+  });
+
+  test('a realtime full item invalidation on a mounted item hook stays throttled', async () => {
+    const env = createRealtimeEnv();
+
+    // Load an item through a mounted field hook so the item scheduler has a
+    // baseline fetch for the throttle.
+    renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name', 'address'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // A realtime record-change event fully invalidates the item inside the
+    // throttle window.
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+      });
+    });
+
+    await flushAllTimers();
+
+    // Same contract as the list query: the item refetch stays delayed by the
+    // throttle instead of being promoted to an immediate highPriority fetch.
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | rt-fetch-scheduled (delay: 900ms)
+      1.81s | scheduled-rt-fetch-started
+      1.82s | 🟠 >fetch-started
+      2.62s | 🟠 <fetch-finished (value: {"name":"User 1","address":"Address 1"})
+      "
+    `);
+
+    expect(env.serverTable.getRequestHistory('item').length).toBe(2);
+  });
+});

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -1465,6 +1465,123 @@ describe('partial resources: inferFields reporting a complete snapshot', () => {
   });
 });
 
+describe('partial resources: invalidating fields vouched beyond the tracked metadata', () => {
+  // Finding: the invalidation staleness baseline consulted `inferFields` only
+  // when the `itemLoadedFields` metadata entry was entirely absent. But hooks
+  // display any field `inferFields` vouches for — including fields a mutation
+  // wrote beyond the tracked metadata (see the "hooks trust fields written
+  // beyond the tracked metadata" test above). A field is invalidatable
+  // exactly when it is displayable, so the baseline must be the UNION of the
+  // tracked metadata and `inferFields`, or invalidations of vouched-only
+  // fields are silently dropped and hooks show the stale value forever.
+
+  test('invalidating a mutation-written field beyond the tracked metadata refetches it', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: starInferFieldsConfig,
+    });
+
+    // The item is partially fetched: metadata tracks only ['id', 'name'].
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: ['id', 'name'],
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A client mutation fills in the remaining fields — only `inferFields`
+    // vouches for them, the tracked metadata is not updated.
+    act(() => {
+      env.apiStore.updateItemState('users||1', (draft) => {
+        draft.address = 'Client Address 1';
+        draft.age = 10;
+        draft.country = 'Country 1';
+      });
+    });
+
+    // A hook displays the mutation-written field without fetching.
+    const { result } = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      }),
+    );
+    await flushAllTimers();
+    expect(result.current.data?.address).toBe('Client Address 1');
+    expect(env.serverTable.getRequestHistory('item').length).toBe(1);
+
+    // The server has newer data and the app invalidates exactly that field.
+    env.serverTable.updateItem('users||1', { address: 'Server Address 1' });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+        fields: ['address'],
+      });
+    });
+    await flushAllTimers();
+
+    // The hook must refetch the invalidated field even though it is not part
+    // of the tracked metadata — it is displayed, so it can be stale.
+    expect(result.current.status).toBe('success');
+    expect(result.current.data?.address).toBe('Server Address 1');
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['id', 'name']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload:
+            fields: ['address']
+            itemId: 'users||1'
+      `);
+  });
+
+  test('a full invalidation marks mutation-written fields stale for hooks that mount later', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // The item is partially fetched through a mounted hook: metadata tracks
+    // only ['name']. A client mutation then writes 'address' beyond it.
+    renderHook(() => env.apiStore.useItem('users||1', { fields: ['name'] }));
+    await flushAllTimers();
+    act(() => {
+      env.apiStore.updateItemState('users||1', (draft) => {
+        draft.address = 'Client Address 1';
+      });
+    });
+
+    // The server has newer data and a full invalidation fires. The mounted
+    // ['name'] hook consumes the invalidation event and refetches its own
+    // field right away.
+    env.serverTable.updateItem('users||1', { address: 'Server Address 1' });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+      });
+    });
+    await flushAllTimers();
+
+    // A hook for the mutation-written field mounts only after the
+    // invalidation settled: the field must still be owed a refetch — the full
+    // invalidation covered everything displayable, not just the tracked
+    // metadata fields.
+    const lateHook = renderHook(() =>
+      env.apiStore.useItem('users||1', {
+        returnRefetchingStatus: true,
+        fields: ['address'],
+      }),
+    );
+    await flushAllTimers();
+
+    expect(lateHook.result.current.status).toBe('success');
+    expect(lateHook.result.current.data?.address).toBe('Server Address 1');
+  });
+});
+
 describe('partial resources: realtime invalidations keep the scheduler throttle', () => {
   // Finding: a full realtime invalidation resets `itemLoadedFields` to `[]`
   // while the (stale) item data stays in state. The auto-fetch effect then
@@ -1728,6 +1845,73 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
     `);
 
     expect(env.serverTable.getRequestHistory('item').length).toBe(2);
+  });
+
+  test('an explicit high-priority field invalidation escalates past a pending throttled full invalidation', async () => {
+    const env = createRealtimeEnv();
+
+    // Load an item through a mounted field hook so the item scheduler has a
+    // baseline fetch for the throttle.
+    const { result } = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name', 'address'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // A realtime record-change event fully invalidates the item inside the
+    // throttle window — its refetch is scheduled at the throttle boundary.
+    await advanceTime(100);
+    env.serverTable.updateItem('users||1', {
+      name: 'New User 1',
+      address: 'New Address 1',
+    });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // While that refetch is still waiting, the app explicitly invalidates one
+    // field at highPriority (e.g. a mutation response says 'name' changed).
+    await advanceTime(50);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+        fields: ['name'],
+      });
+    });
+
+    // The high-priority field must refetch immediately instead of being
+    // dropped and left to wait out the realtime throttle with the rest. The
+    // immediate fetch replaces (cancels) the pending throttled refetch that
+    // was carrying the other stale field ('address'), so it must carry that
+    // owed field along — a single fetch covering both.
+    await advanceTime(100);
+
+    await flushAllTimers();
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | server-data-changed (value: {"name":"New User 1","address":"New Address 1"})
+      .     | rt-fetch-scheduled (delay: 900ms)
+      970ms | rt-fetch-cancelled
+      .     | 🟠 >fetch-started
+      1.77s | 🟠 <fetch-finished (value: {"address":"New Address 1","name":"New User 1"})
+      "
+    `);
+    expect(env.serverTable.getRequestHistory('item').length).toBe(2);
+
+    // Both the escalated field and the field owed to the cancelled throttled
+    // refetch end up fresh.
+    expect(result.current.data).toMatchInlineSnapshot(`
+      address: 'New Address 1'
+      name: 'New User 1'
+    `);
   });
 });
 

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -1646,6 +1646,50 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
     expect(env.serverTable.getRequestHistory('list').length).toBe(2);
   });
 
+  test('invalidating a never-loaded field does not delay its first load behind the throttle', async () => {
+    const env = createRealtimeEnv();
+
+    // Load some of the item's fields so the item scheduler has a baseline
+    // fetch for the throttle — but never load 'age'.
+    renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name', 'address'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // A realtime event invalidates a field that was never loaded, inside the
+    // throttle window. There is no cached 'age' value that could go stale.
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+        fields: ['age'],
+      });
+    });
+
+    // A hook mounts requesting the never-loaded field: this is genuinely
+    // missing data with nothing to display — it must fetch immediately
+    // instead of waiting out the realtime throttle as if it were stale.
+    await advanceTime(50);
+    const { result } = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['age'] }),
+    );
+
+    await flushAllTimers();
+
+    expect(result.current.data?.age).toBe(10);
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      970ms | 🟠 >fetch-started
+      1.77s | 🟠 <fetch-finished (value: {"age":10})
+      "
+    `);
+  });
+
   test('a realtime full item invalidation on a mounted item hook stays throttled', async () => {
     const env = createRealtimeEnv();
 
@@ -1684,5 +1728,118 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
     `);
 
     expect(env.serverTable.getRequestHistory('item').length).toBe(2);
+  });
+});
+
+describe('partial resources: invalidations arriving while a hook is off-screen', () => {
+  // Finding: the `invalidateItem` event handler returned early when all of a
+  // hook's instances were off-screen — before re-opening the mount-once
+  // refetch gate. Per-field invalidations never set `refetchOnMount`, so
+  // nothing else could rescue the instance: back on-screen it kept showing
+  // the stale field with `status: 'success'` and never refetched.
+
+  function createOffScreenRealtimeEnv() {
+    return createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+      usesRealTimeUpdates: true,
+      dynamicRealtimeThrottleMs: () => 1000,
+    });
+  }
+
+  test('a field invalidated while its hook is off-screen refetches when the hook returns on-screen', async () => {
+    const env = createOffScreenRealtimeEnv();
+
+    // Load the item's fields through a mounted hook...
+    const { result, rerender } = renderHook(
+      ({ isOffScreen }: { isOffScreen: boolean }) =>
+        env.apiStore.useItem('users||1', {
+          fields: ['name', 'address'],
+          isOffScreen,
+        }),
+      { initialProps: { isOffScreen: false } },
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // ...then move it off-screen (e.g. the row scrolled out of a virtualized
+    // list).
+    rerender({ isOffScreen: true });
+
+    // The address changes on the server, and a realtime event invalidates
+    // only that field while the hook is off-screen.
+    await advanceTime(100);
+    env.serverTable.updateItem('users||1', { address: 'New Address 1' });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+        fields: ['address'],
+      });
+    });
+
+    // The whole realtime throttle window passes while still off-screen —
+    // off-screen hooks must not fetch.
+    await flushAllTimers();
+    expect(env.serverTable.getRequestHistory('item').length).toBe(1);
+    expect(result.current.data?.address).toBe('Address 1');
+
+    // Back on-screen: the stale field must refetch and show the fresh value.
+    rerender({ isOffScreen: false });
+    await flushAllTimers();
+
+    expect(result.current.status).toBe('success');
+    expect(result.current.data?.address).toBe('New Address 1');
+    // One initial load plus one refetch of only the stale field.
+    expect(env.serverTable.getRequestHistory('item').length).toBe(2);
+  });
+
+  test('an off-screen hook still refetches after an on-screen hook consumed the same full invalidation', async () => {
+    const env = createOffScreenRealtimeEnv();
+
+    // Two hooks on the same item: one stays on-screen with its own field,
+    // the other loads a different field and then goes off-screen.
+    renderHook(() => env.apiStore.useItem('users||1', { fields: ['name'] }));
+    const offScreenHook = renderHook(
+      ({ isOffScreen }: { isOffScreen: boolean }) =>
+        env.apiStore.useItem('users||1', { fields: ['address'], isOffScreen }),
+      { initialProps: { isOffScreen: false } },
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    offScreenHook.rerender({ isOffScreen: true });
+
+    // A realtime record-change event fully invalidates the item. The
+    // on-screen hook consumes the event (it schedules its own refetch and
+    // clears `refetchOnMount`), the off-screen hook cannot react yet.
+    await advanceTime(100);
+    act(() => {
+      env.serverTable.setItem(
+        'users||1',
+        {
+          id: 1,
+          name: 'New User 1',
+          address: 'New Address 1',
+          age: 10,
+          country: 'Country 1',
+        },
+        { triggerRTUEvent: true },
+      );
+    });
+
+    // The on-screen hook's throttled refetch of its own field resolves while
+    // the other hook is still off-screen.
+    await flushAllTimers();
+    expect(offScreenHook.result.current.data?.address).toBe('Address 1');
+
+    // Back on-screen: the hook's own stale field must refetch too — the
+    // other hook's consumption of the invalidation event must not have
+    // discarded this hook's refetch obligation.
+    offScreenHook.rerender({ isOffScreen: false });
+    await flushAllTimers();
+
+    expect(offScreenHook.result.current.status).toBe('success');
+    expect(offScreenHook.result.current.data?.address).toBe('New Address 1');
   });
 });

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -1666,7 +1666,7 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
         time: '10ms -> 810ms | duration: 800ms'
       - _type: 'list'
         payload:
-          fields: ['id', 'name', 'address']
+          fields: ['address', 'id', 'name']
           pos: { limit: 50, offset: 0 }
         returned_items: 5
         time: '1.82s -> 2.62s | duration: 800ms'
@@ -1840,7 +1840,7 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
       910ms | rt-fetch-scheduled (delay: 900ms)
       1.81s | scheduled-rt-fetch-started
       1.82s | 🟠 >fetch-started
-      2.62s | 🟠 <fetch-finished (value: {"name":"User 1","address":"Address 1"})
+      2.62s | 🟠 <fetch-finished (value: {"address":"Address 1","name":"User 1"})
       "
     `);
 
@@ -2035,6 +2035,65 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
     expect(nameHook.result.current.data?.name).toBe('New User 1');
     expect(addressHook.result.current.data?.address).toBe('New Address 1');
   });
+
+  test('successive realtime field invalidations inside the throttle window all land in the delayed refetch', async () => {
+    const env = createRealtimeEnv();
+
+    // Two independent components display different fields of the same item.
+    const nameHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name'] }),
+    );
+    const addressHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['address'] }),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    // A realtime event invalidates 'name' inside the throttle window — the
+    // refetch is scheduled at the throttle boundary.
+    await advanceTime(100);
+    env.serverTable.updateItem('users||1', { name: 'New User 1' });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+        fields: ['name'],
+      });
+    });
+
+    // A second realtime event invalidates 'address' while that delayed fetch
+    // is still pending. Both fields must ride on the same delayed fetch.
+    await advanceTime(100);
+    env.serverTable.updateItem('users||1', { address: 'New Address 1' });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+        fields: ['address'],
+      });
+    });
+
+    await flushAllTimers();
+
+    // A single delayed refetch fires at the throttle boundary carrying BOTH
+    // invalidated fields — the delayed fetch must execute with the payload
+    // coalesced across the whole wait, not the payload captured when it was
+    // first scheduled (which only carried 'name', leaving 'address' stale
+    // forever).
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['address', 'name']
+            itemId: 'users||1'
+      `);
+
+    expect(nameHook.result.current.data?.name).toBe('New User 1');
+    expect(addressHook.result.current.data?.address).toBe('New Address 1');
+  });
 });
 
 describe('partial resources: query invalidations with multiple same-payload hooks', () => {
@@ -2202,5 +2261,82 @@ describe('partial resources: invalidations arriving while a hook is off-screen',
 
     expect(offScreenHook.result.current.status).toBe('success');
     expect(offScreenHook.result.current.data?.address).toBe('New Address 1');
+  });
+
+  test('an off-screen query instance still refetches its fields after an on-screen instance consumed the query invalidation', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // Two components watch the same list with different field subsets; the
+    // address one later goes off-screen (e.g. a collapsed panel).
+    const nameHook = renderHook(() =>
+      env.apiStore.useListQuery({ tableId: 'users' }, { fields: ['name'] }),
+    );
+    const addressHook = renderHook(
+      ({ isOffScreen }: { isOffScreen: boolean }) =>
+        env.apiStore.useListQuery(
+          { tableId: 'users' },
+          { fields: ['address'], isOffScreen },
+        ),
+      { initialProps: { isOffScreen: false } },
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    addressHook.rerender({ isOffScreen: true });
+
+    // The server data changes and the app invalidates the query while the
+    // address instance is off-screen.
+    env.serverTable.updateItem('users||1', {
+      name: 'New User 1',
+      address: 'New Address 1',
+    });
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: { tableId: 'users' },
+        itemPayload: false,
+        type: 'highPriority',
+      });
+    });
+    await flushAllTimers();
+
+    // Only the on-screen instance refetches, with its own fields — off-screen
+    // instances must not fetch.
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+    expect(addressHook.result.current.items[0]?.address).toBe('Address 1');
+
+    // Back on-screen: the instance's fields are still owed a refetch — the
+    // visible instance consuming the invalidation (clearing the query's
+    // shared `refetchOnMount`) must not have discarded this instance's
+    // obligation.
+    addressHook.rerender({ isOffScreen: false });
+    await flushAllTimers();
+
+    expect(addressHook.result.current.items[0]?.address).toBe('New Address 1');
+    // Exactly one extra fetch, scoped to the returning instance's fields.
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+        - _type: 'list'
+          payload:
+            fields: ['address']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+    // The on-screen instance keeps its fresh value too.
+    expect(nameHook.result.current.items[0]?.name).toBe('New User 1');
   });
 });

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -2340,3 +2340,182 @@ describe('partial resources: invalidations arriving while a hook is off-screen',
     expect(nameHook.result.current.items[0]?.name).toBe('New User 1');
   });
 });
+
+describe("partial resources: invalidations arriving during a field's first fetch", () => {
+  // Finding: a per-field invalidation of a never-loaded field is not recorded
+  // as stale — correct on its own, since the field's first load must run
+  // immediately instead of being throttled as a stale refetch (see the
+  // throttle suite above). But when the field's FIRST fetch is already in
+  // flight, the in-flight response predates the invalidation and commits
+  // possibly-stale data as fresh. With the invalidation discarded, no
+  // follow-up refetch is owed and the stale value sticks forever.
+
+  function createRealtimeEnv() {
+    return createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+      usesRealTimeUpdates: true,
+      dynamicRealtimeThrottleMs: () => 1000,
+    });
+  }
+
+  test("an invalidation arriving during a field's first item fetch still produces a follow-up refetch", async () => {
+    const env = createRealtimeEnv();
+
+    // The first-ever fetch of the item starts (no field was loaded before).
+    const { result } = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['age'] }),
+    );
+
+    // While that fetch is in flight, the value changes on the server and the
+    // realtime invalidation for the field arrives. The in-flight response was
+    // produced before the change, so it will still carry the old value.
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+        fields: ['age'],
+      });
+    });
+
+    // The in-flight fetch settles with the pre-invalidation value...
+    await advanceTime(800);
+    expect(result.current.data?.age).toBe(10);
+
+    // ...and only fetches from here on can observe the changed value.
+    act(() => {
+      env.serverTable.updateItem('users||1', { age: 99 });
+    });
+
+    await flushAllTimers();
+
+    // The invalidation must survive the in-flight first fetch: a follow-up
+    // refetch (still throttled — it is a realtime refetch of now-stale data)
+    // picks up the changed value.
+    expect(result.current.data?.age).toBe(99);
+    expect(env.serverTable.getRequestHistory('item', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'item'
+          payload:
+            fields: ['age']
+            itemId: 'users||1'
+        - _type: 'item'
+          payload:
+            fields: ['age']
+            itemId: 'users||1'
+      `);
+  });
+
+  test("an invalidation arriving during a field's first list fetch still produces a follow-up refetch", async () => {
+    const env = createRealtimeEnv();
+
+    // The first-ever list fetch starts, loading 'name' for all items.
+    const { result } = renderHook(() =>
+      env.apiStore.useListQuery({ tableId: 'users' }, { fields: ['name'] }),
+    );
+
+    // While the list fetch is in flight, item 1's name changes on the server
+    // and its realtime invalidation arrives — 'name' was never loaded, so the
+    // invalidation has no displayable value to mark stale yet.
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+        fields: ['name'],
+      });
+    });
+
+    // The in-flight list fetch settles with the pre-invalidation value...
+    await advanceTime(800);
+    expect(result.current.items[0]?.name).toBe('User 1');
+
+    // ...and only fetches from here on can observe the changed value.
+    act(() => {
+      env.serverTable.updateItem('users||1', { name: 'Renamed User 1' });
+    });
+
+    await flushAllTimers();
+
+    // The list fetch committing 'name' must not swallow the invalidation that
+    // arrived while it was in flight — a follow-up refetch picks up the
+    // changed value.
+    expect(result.current.items[0]?.name).toBe('Renamed User 1');
+  });
+});
+
+describe("partial resources: a fields:'*' query mounting over genuinely missing data", () => {
+  // Finding: the `'*'` branch of the query auto-fetch effect adopted the
+  // tracked invalidation priority whenever any pending invalidation existed —
+  // even when the hook's items were genuinely missing data (fields never
+  // loaded, not merely stale). A first load of missing data must run
+  // immediately; only refetches of still-displayable stale data may wait out
+  // the realtime throttle. The item-side `'*'` branch already distinguishes
+  // these.
+
+  test('a full-resource hook mounting with never-loaded fields fetches immediately despite a pending realtime invalidation', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+      usesRealTimeUpdates: true,
+      dynamicRealtimeThrottleMs: () => 1000,
+    });
+
+    // Prime the query with a subset of fields — 'address', 'age' and
+    // 'country' are never loaded.
+    renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name'] },
+      ),
+    );
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // A realtime invalidation of the loaded field arrives: its refetch is
+    // correctly throttled (stale data is still displayable).
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: (itemKey) => itemKey.startsWith('users||'),
+        type: 'realtimeUpdate',
+        fields: ['name'],
+      });
+    });
+
+    // A full-resource hook mounts on the same query: most of its fields were
+    // never loaded, so this is a first load of missing data — it must fetch
+    // immediately instead of inheriting the pending realtime priority and
+    // waiting out the throttle.
+    await advanceTime(50);
+    const { result } = renderHook(() =>
+      env.apiStore.useListQuery({ tableId: 'users' }, { fields: '*' }),
+    );
+
+    // Enough time for an immediate fetch to finish, but before the throttled
+    // alternative (throttle boundary ~1.81s) would even have started fetching.
+    await advanceTime(850);
+    expect(result.current.status).toBe('success');
+    expect(result.current.items[0]?.age).toBe(10);
+
+    await flushAllTimers();
+
+    // A single full fetch serves both the missing data and the pending 'name'
+    // invalidation — no separate throttled refetch remains.
+    expect(env.serverTable.getRequestHistory('list', { includeTime: false }))
+      .toMatchInlineSnapshot(`
+        - _type: 'list'
+          payload:
+            fields: ['id', 'name']
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+        - _type: 'list'
+          payload:
+            fields: '*'
+            pos: { limit: 50, offset: 0 }
+          returned_items: 5
+      `);
+  });
+});

--- a/tests/list-query-features/list-query-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-partial-resources.test.ts
@@ -1919,7 +1919,7 @@ describe('RTU with partial resources', () => {
         payload:
           fields: ['id', 'name']
           itemId: 'users||1'
-        time: '820ms -> 1.62s | duration: 800ms'
+        time: '920ms -> 1.72s | duration: 800ms'
     `);
   });
 });


### PR DESCRIPTION
## Summary

This PR distinguishes stale data from genuinely missing data in partial-resource refetch logic so realtime invalidations stay throttled instead of being promoted to immediate duplicate fetches. It also ensures remaining invalidated fields are re-announced after confirmed snapshots so mounted hooks can finish refetching their own stale fields.
### Changes

- Reclassify stale invalidated fields separately from genuinely missing fields in item and list query refetch scheduling.
- Keep tracked realtime invalidations at their original priority instead of escalating them to high-priority fetches.
- Re-emit remaining invalidation fields after confirmed snapshots so canceled local refetches do not leave hooks stale.
- Handle full-item invalidations from state sync and browser-tab reuse without dropping outstanding stale-field refetches.
- Add regression coverage for realtime throttling, mixed stale/missing field behavior, and cross-tab partial-resource snapshots.

### Testing Notes

Verify that a realtime invalidation triggers one delayed refetch, not an immediate duplicate, for both item and list hooks. Also test mixed requests where one hook asks for a never-loaded field while another is only stale, plus cross-tab/confirmed-snapshot flows to ensure remaining invalidated fields still refetch correctly.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
