### PR TITLE
Track partial invalidation priorities per field

### DIFF
--- a/docs/partial-resources.md
+++ b/docs/partial-resources.md
@@ -130,6 +130,8 @@ userStore.invalidateQueryAndItems({
 
 This removes the specified fields from `itemLoadedFields`, causing hooks that request those fields to trigger a refetch — but only for those fields.
 
+Invalidation priorities are tracked per field: each field keeps the highest priority it was invalidated with since it was last reloaded, and hooks adopt priorities only from the fields they actually request. A leftover obligation on a field no mounted hook displays (e.g. after a full high-priority invalidation followed by a narrower refetch) never escalates unrelated refetches, so scheduler throttling — such as `dynamicRealtimeThrottleMs` for realtime updates — keeps working.
+
 ## Loading Behavior
 
 When a hook requests fields that are partially loaded:

--- a/docs/persistent-storage.md
+++ b/docs/persistent-storage.md
@@ -137,7 +137,7 @@ TSDF does not choose a persistence adapter automatically. Pass one of the built-
 - Can hydrate synchronously during initial state creation for `DocumentStore`.
 - `CollectionStore` and `ListQueryStore` use lazy hydration for unknown entries from initial keys scan.
 - Writes are debounced and may be dropped if serialization errors occur.
-- When a write hits the browser `QuotaExceededError` (the shared origin quota is full, e.g. because other parts of the app filled `localStorage`), TSDF automatically evicts its own least recently used entries — across all TSDF stores and sessions — and retries, escalating to all non-offline-protected entries if needed. Offline data and non-TSDF keys are never touched. If even that cannot free enough space, a single descriptive error is reported through `onPersistentStorageError` and persistence writes are silently skipped until the next page load.
+- When a write hits the browser `QuotaExceededError` (the shared origin quota is full, e.g. because other parts of the app filled `localStorage`), TSDF automatically evicts its own least recently used entries — across all TSDF stores and sessions — and retries, escalating to all non-offline-protected entries if needed. Offline data and non-TSDF keys are never touched. If even that cannot free enough space, a single descriptive error is reported through `onPersistentStorageError` and persistence writes are silently skipped until the next page load. Removals of persisted entries (e.g. after deleting an item) still go through while writes are disabled, so deleted data never resurrects on the next load.
 
 Use it with:
 

--- a/src/collectionStore/useMultipleItems.ts
+++ b/src/collectionStore/useMultipleItems.ts
@@ -397,7 +397,18 @@ export function useMultipleItems<
           item.refetchOnMount = false;
         });
 
-        scheduleAutomaticFetch(event.priority, payload);
+        // The refetch inherits the invalidation's priority, which the
+        // scheduler may delay (e.g. `realtimeUpdate` with
+        // `dynamicRealtimeThrottleMs`). Waiting is only acceptable when stale
+        // data is still displayable — an item that was never loaded has
+        // nothing to show, so its fetch must run immediately (mirrors the
+        // mount path).
+        const fetchPriority: FetchType =
+          event.priority !== 'highPriority' && !store.state[itemKey]?.wasLoaded
+            ? 'highPriority'
+            : event.priority;
+
+        scheduleAutomaticFetch(fetchPriority, payload);
         invalidationWasTriggered.add(itemKey);
       }
     }

--- a/src/listQueryStore/createFetchApi.ts
+++ b/src/listQueryStore/createFetchApi.ts
@@ -257,8 +257,8 @@ export function createFetchApi<
     ItemPayload
   >['onItemFetchSettled'],
   offlineController: OfflineAwareFetchController | null | undefined,
-  itemPendingInvalidationFields: Map<string, string[]>,
-  itemsPendingFullInvalidation: Set<string>,
+  itemPendingInvalidationFields: Map<string, Map<string, FetchType | null>>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
 ) {
   type Query = TSFDListQuery<QueryPayload>;
 
@@ -1146,9 +1146,10 @@ export function createFetchApi<
       return stateInvalidationFields;
     }
 
+    const pendingFields = itemPendingInvalidationFields.get(itemKey);
     return excludeLoadedFields(
       store.state.itemLoadedFields[itemKey],
-      itemPendingInvalidationFields.get(itemKey),
+      pendingFields && Array.from(pendingFields.keys()),
     );
   }
 

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -276,6 +276,7 @@ export function createMutationApi<
     string,
     Map<string, DroppedFieldInvalidation>
   >,
+  itemMutationCountsWithoutScheduler: Map<string, number>,
 ) {
   type FilterQuery = FilterQueryFn<QueryPayload>;
   type FilterItem = FilterItemFn<ItemState, ItemPayload>;
@@ -607,10 +608,12 @@ export function createMutationApi<
           const loadedFields = store.state.itemLoadedFields[itemKey];
 
           for (const field of staleInvalidateFields) {
-            let fieldPriority = higherFetchType(
-              pendingFields.get(field),
-              priority,
-            );
+            const existingPriority = pendingFields.get(field);
+            // `null` entries keep their stronger unknown-priority (immediate
+            // refetch) semantics — a known lower priority must not downgrade
+            // them.
+            if (existingPriority === null) continue;
+            let fieldPriority = higherFetchType(existingPriority, priority);
             // A field not reloaded since an unresolved full invalidation is
             // still owed at the marker's priority — absorb it into the field
             // entry, which supersedes the marker for this field from now on.
@@ -746,6 +749,27 @@ export function createMutationApi<
             }
           }
         }
+        // The baseline can be '*' via `inferFields` vouching while the
+        // tracked `itemLoadedFields` is still an enumerable array (e.g. a
+        // narrow refetch after an earlier full invalidation). Those tracked
+        // fields were reloaded since any surviving marker, so the marker no
+        // longer owes them — record them as per-field entries at the
+        // incoming priority (superseding the marker) BEFORE the state update
+        // clears the loaded metadata, or they would fall back to the
+        // marker's possibly higher priority and escalate their refetch.
+        const trackedLoadedFields = store.state.itemLoadedFields[itemKey];
+        if (trackedLoadedFields && trackedLoadedFields !== '*') {
+          const pendingFields =
+            existingPendingFields ?? new Map<string, FetchType | null>();
+          for (const field of trackedLoadedFields) {
+            // Existing entries were already escalated above; `null` entries
+            // keep their stronger unknown-priority (immediate) semantics.
+            if (!pendingFields.has(field)) pendingFields.set(field, priority);
+          }
+          if (pendingFields.size > 0) {
+            itemPendingInvalidationFields.set(itemKey, pendingFields);
+          }
+        }
       } else if (trackedInvalidationFields.length > 0) {
         const markerPriority = itemsPendingFullInvalidation.get(itemKey);
         const loadedFields = store.state.itemLoadedFields[itemKey];
@@ -753,10 +777,12 @@ export function createMutationApi<
           existingPendingFields ?? new Map<string, FetchType | null>();
 
         for (const field of trackedInvalidationFields) {
-          let fieldPriority = higherFetchType(
-            pendingFields.get(field),
-            priority,
-          );
+          const existingPriority = pendingFields.get(field);
+          // `null` entries keep their stronger unknown-priority (immediate
+          // refetch) semantics — a known lower priority must not downgrade
+          // them.
+          if (existingPriority === null) continue;
+          let fieldPriority = higherFetchType(existingPriority, priority);
           // A field not reloaded since an unresolved full invalidation is
           // still owed at the marker's priority — absorb it into the field
           // entry, which supersedes the marker for this field from now on.
@@ -858,9 +884,14 @@ export function createMutationApi<
         itemPendingInvalidationFields.set(itemKey, pendingFields);
       }
       for (const [field, fieldPriority] of staleFieldPriorities) {
+        const existingPriority = pendingFields.get(field);
+        // `null` entries keep their stronger unknown-priority (immediate
+        // refetch) semantics — a known lower priority must not downgrade
+        // them.
+        if (existingPriority === null) continue;
         pendingFields.set(
           field,
-          higherFetchType(pendingFields.get(field), fieldPriority),
+          higherFetchType(existingPriority, fieldPriority),
         );
       }
 
@@ -904,6 +935,27 @@ export function createMutationApi<
       if (fetchItemFn) {
         const itemScheduler = getOrCreateItemScheduler(itemKey, payload);
         endMutations.push(itemScheduler.startMutation(itemKey));
+      } else {
+        // List-only stores have no item scheduler to track the mutation, but
+        // a standalone item (not referenced by any query) still needs cache
+        // eviction protection while a mutation targets it. Refcounted so
+        // overlapping mutations on the same item keep the protection until
+        // the last one ends.
+        itemMutationCountsWithoutScheduler.set(
+          itemKey,
+          (itemMutationCountsWithoutScheduler.get(itemKey) ?? 0) + 1,
+        );
+        let ended = false;
+        endMutations.push(() => {
+          // Idempotent: `performMutation` may call the ender more than once
+          // (e.g. on both settle and error paths).
+          if (ended) return false;
+          ended = true;
+          const count = itemMutationCountsWithoutScheduler.get(itemKey) ?? 0;
+          if (count <= 1) itemMutationCountsWithoutScheduler.delete(itemKey);
+          else itemMutationCountsWithoutScheduler.set(itemKey, count - 1);
+          return true;
+        });
       }
 
       for (const [queryKey, query] of Object.entries(store.state.queries)) {

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -23,6 +23,7 @@ import {
 } from '../utils/performMutation';
 import {
   fetchTypePriority,
+  higherFetchType,
   mutationSkipped,
   type MutationSkipped,
   type StoreError,
@@ -269,8 +270,8 @@ export function createMutationApi<
   onOfflineTimelineEvent:
     | ((event: TestOfflineTimelineEvent) => void)
     | undefined,
-  itemPendingInvalidationFields: Map<string, string[]>,
-  itemsPendingFullInvalidation: Set<string>,
+  itemPendingInvalidationFields: Map<string, Map<string, FetchType | null>>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
   itemDroppedFieldInvalidations: Map<
     string,
     Map<string, DroppedFieldInvalidation>
@@ -301,8 +302,7 @@ export function createMutationApi<
     itemQuery: TSDFItemQuery<ItemPayload> | null | undefined;
     loadedFields: ItemLoadedFields | undefined;
     invalidationFields: string[] | undefined;
-    invalidationPriority: FetchType | undefined;
-    pendingInvalidationFields: string[] | undefined;
+    pendingInvalidationFields: Map<string, FetchType | null> | undefined;
     invalidationWasTriggered: boolean;
   };
   type MutationQueryRollbackSnapshot = {
@@ -389,21 +389,12 @@ export function createMutationApi<
       );
 
       for (const snapshot of itemSnapshots) {
-        if (snapshot.invalidationPriority === undefined) {
-          itemFieldInvalidationPriorities.delete(snapshot.itemKey);
-        } else {
-          itemFieldInvalidationPriorities.set(
-            snapshot.itemKey,
-            snapshot.invalidationPriority,
-          );
-        }
-
         if (snapshot.pendingInvalidationFields === undefined) {
           itemPendingInvalidationFields.delete(snapshot.itemKey);
         } else {
           itemPendingInvalidationFields.set(
             snapshot.itemKey,
-            snapshot.pendingInvalidationFields,
+            new Map(snapshot.pendingInvalidationFields),
           );
         }
 
@@ -459,7 +450,6 @@ export function createMutationApi<
 
   const queryInvalidationWasTriggered = new Set<string>();
   const itemInvalidationWasTriggered = new Set<string>();
-  const itemFieldInvalidationPriorities = new Map<string, FetchType>();
 
   /**
    * The staleness baseline for invalidations: a field is invalidatable
@@ -533,11 +523,6 @@ export function createMutationApi<
       if (partialResources && invalidateFields) {
         // Per-field invalidation: remove specified fields from itemLoadedFields
         const itemsKey = getItemsKeyArray(itemPayload);
-        const nextInvalidationPriorityByItemKey = new Map<string, FetchType>();
-        const nextPendingInvalidationFieldsByItemKey = new Map<
-          string,
-          string[]
-        >();
         // Only fields with a displayable cached value can go stale (see
         // getInvalidationBaselineFields). A never-loaded field must not be
         // recorded — it stays classified as genuinely missing so its first
@@ -571,12 +556,7 @@ export function createMutationApi<
               const existingDropped = droppedForItem.get(field);
               droppedForItem.set(field, {
                 invalidatedAt: Date.now(),
-                priority:
-                  existingDropped &&
-                  fetchTypePriority[existingDropped.priority] >
-                    fetchTypePriority[priority]
-                    ? existingDropped.priority
-                    : priority,
+                priority: higherFetchType(existingDropped?.priority, priority),
               });
             }
           }
@@ -584,39 +564,46 @@ export function createMutationApi<
           if (staleInvalidateFields.length === 0) continue;
 
           staleInvalidateFieldsByItemKey.set(itemKey, staleInvalidateFields);
-
-          const existingPriority = itemFieldInvalidationPriorities.get(itemKey);
-          const existingPendingFields =
-            itemPendingInvalidationFields.get(itemKey) ?? [];
-          nextPendingInvalidationFieldsByItemKey.set(
-            itemKey,
-            Array.from(
-              new Set([...existingPendingFields, ...staleInvalidateFields]),
-            ).sort(),
-          );
-
-          nextInvalidationPriorityByItemKey.set(
-            itemKey,
-            existingPriority &&
-              fetchTypePriority[existingPriority] > fetchTypePriority[priority]
-              ? existingPriority
-              : priority,
-          );
         }
 
         // Keep map-based tracking in sync before the state update so selectors
-        // that read these maps see the same invalidation transaction.
+        // that read these maps see the same invalidation transaction. Each
+        // field keeps the highest priority it has been invalidated with since
+        // it was last reloaded.
         for (const [
           itemKey,
-          itemPriority,
-        ] of nextInvalidationPriorityByItemKey) {
-          itemFieldInvalidationPriorities.set(itemKey, itemPriority);
-        }
-        for (const [
-          itemKey,
-          invalidationFields,
-        ] of nextPendingInvalidationFieldsByItemKey) {
-          itemPendingInvalidationFields.set(itemKey, invalidationFields);
+          staleInvalidateFields,
+        ] of staleInvalidateFieldsByItemKey) {
+          let pendingFields = itemPendingInvalidationFields.get(itemKey);
+          if (!pendingFields) {
+            pendingFields = new Map();
+            itemPendingInvalidationFields.set(itemKey, pendingFields);
+          }
+
+          const fullInvalidationPriority =
+            itemsPendingFullInvalidation.get(itemKey);
+          const loadedFields = store.state.itemLoadedFields[itemKey];
+
+          for (const field of staleInvalidateFields) {
+            let fieldPriority = higherFetchType(
+              pendingFields.get(field),
+              priority,
+            );
+            // A field not reloaded since an unresolved full invalidation is
+            // still owed at the marker's priority — absorb it into the field
+            // entry, which supersedes the marker for this field from now on.
+            if (
+              fullInvalidationPriority !== undefined &&
+              loadedFields !== '*' &&
+              !(loadedFields?.includes(field) ?? false)
+            ) {
+              fieldPriority = higherFetchType(
+                fullInvalidationPriority,
+                fieldPriority,
+              );
+            }
+            pendingFields.set(field, fieldPriority);
+          }
         }
 
         store.produceState(
@@ -650,15 +637,17 @@ export function createMutationApi<
         // Items where no invalidated field was loaded have nothing stale to
         // re-announce; hooks requesting such fields already treat them as
         // missing and fetch immediately on their own.
+        // The event carries the INCOMING priority only: fields owed to
+        // earlier invalidations keep their own tracked per-field priorities,
+        // and merging them into the event would escalate unrelated
+        // lower-priority refetches (e.g. break the realtime throttle).
         for (const [
           itemKey,
           staleInvalidateFields,
         ] of staleInvalidateFieldsByItemKey) {
           itemInvalidationWasTriggered.delete(itemKey);
-          const itemPriority =
-            nextInvalidationPriorityByItemKey.get(itemKey) ?? priority;
           emitInvalidateItem({
-            priority: itemPriority,
+            priority,
             itemKey,
             invalidateFields: staleInvalidateFields,
           });
@@ -686,6 +675,7 @@ export function createMutationApi<
 
       const itemWasFullyLoaded =
         partialResources && effectiveLoadedFields === '*';
+      const existingPendingFields = itemPendingInvalidationFields.get(itemKey);
       const trackedInvalidationFields =
         partialResources && !itemWasFullyLoaded
           ? Array.from(
@@ -693,44 +683,65 @@ export function createMutationApi<
                 ...(effectiveLoadedFields === '*'
                   ? []
                   : (effectiveLoadedFields ?? [])),
-                ...(itemPendingInvalidationFields.get(itemKey) ?? []),
+                ...(existingPendingFields?.keys() ?? []),
               ]),
             ).sort()
           : [];
-      const trackedInvalidationPriority =
-        trackedInvalidationFields.length > 0 ||
-        itemsPendingFullInvalidation.has(itemKey)
-          ? itemFieldInvalidationPriorities.get(itemKey)
-          : undefined;
-      const nextInvalidationPriority =
-        trackedInvalidationPriority &&
-        fetchTypePriority[trackedInvalidationPriority] >
-          fetchTypePriority[priority]
-          ? trackedInvalidationPriority
-          : priority;
       const currentInvalidationPriority = item.refetchOnMount
         ? fetchTypePriority[item.refetchOnMount]
         : -1;
-      const newInvalidationPriority =
-        fetchTypePriority[nextInvalidationPriority];
 
-      if (currentInvalidationPriority >= newInvalidationPriority) continue;
+      if (currentInvalidationPriority >= fetchTypePriority[priority]) continue;
 
       // Update the invalidation tracking maps before the state change so
       // subscribers notified by it see the same invalidation transaction.
+      // This invalidation itself only propagates at the INCOMING priority;
+      // fields owed to earlier invalidations keep their own tracked
+      // priorities instead of escalating the whole item (which would e.g.
+      // break the realtime throttle for every later realtime invalidation).
       if (itemWasFullyLoaded) {
         // No enumerable field list for a '*' item — record the durable
         // full-invalidation marker so catch-up hooks refetch their own fields
-        // instead of trusting the stale snapshot.
-        itemsPendingFullInvalidation.add(itemKey);
+        // instead of trusting the stale snapshot. The marker keeps the
+        // highest priority it was invalidated with; per-field entries fold
+        // into it since the marker now owes every field until a '*' reload.
+        let markerPriority = higherFetchType(
+          itemsPendingFullInvalidation.get(itemKey),
+          priority,
+        );
+        if (existingPendingFields) {
+          for (const fieldPriority of existingPendingFields.values()) {
+            markerPriority = higherFetchType(fieldPriority, markerPriority);
+          }
+        }
+        itemsPendingFullInvalidation.set(itemKey, markerPriority);
         itemPendingInvalidationFields.delete(itemKey);
-        itemFieldInvalidationPriorities.set(itemKey, nextInvalidationPriority);
       } else if (trackedInvalidationFields.length > 0) {
-        itemPendingInvalidationFields.set(itemKey, trackedInvalidationFields);
-        itemFieldInvalidationPriorities.set(itemKey, nextInvalidationPriority);
+        const markerPriority = itemsPendingFullInvalidation.get(itemKey);
+        const loadedFields = store.state.itemLoadedFields[itemKey];
+        const pendingFields =
+          existingPendingFields ?? new Map<string, FetchType | null>();
+
+        for (const field of trackedInvalidationFields) {
+          let fieldPriority = higherFetchType(
+            pendingFields.get(field),
+            priority,
+          );
+          // A field not reloaded since an unresolved full invalidation is
+          // still owed at the marker's priority — absorb it into the field
+          // entry, which supersedes the marker for this field from now on.
+          if (
+            markerPriority !== undefined &&
+            loadedFields !== '*' &&
+            !(loadedFields?.includes(field) ?? false)
+          ) {
+            fieldPriority = higherFetchType(markerPriority, fieldPriority);
+          }
+          pendingFields.set(field, fieldPriority);
+        }
+        itemPendingInvalidationFields.set(itemKey, pendingFields);
       } else {
         itemPendingInvalidationFields.delete(itemKey);
-        itemFieldInvalidationPriorities.delete(itemKey);
       }
       itemInvalidationWasTriggered.delete(itemKey);
 
@@ -739,7 +750,7 @@ export function createMutationApi<
           const query = draft.itemQueries[itemKey];
           if (!query) return;
 
-          query.refetchOnMount = nextInvalidationPriority;
+          query.refetchOnMount = priority;
 
           // Clear loaded fields so all hooks refetch their fields
           if (partialResources) {
@@ -750,17 +761,13 @@ export function createMutationApi<
         { action: 'invalidate-item' },
       );
 
-      emitInvalidateItem({ priority: nextInvalidationPriority, itemKey });
+      emitInvalidateItem({ priority, itemKey });
 
       if (onInvalidateItem) {
         const itemState = store.state.items[itemKey];
 
         if (itemState) {
-          onInvalidateItem({
-            priority: nextInvalidationPriority,
-            itemState,
-            payload,
-          });
+          onInvalidateItem({ priority, itemState, payload });
         }
       }
     }
@@ -786,7 +793,7 @@ export function createMutationApi<
       if (!droppedForItem) continue;
 
       const loadedFields = store.state.itemLoadedFields[itemKey];
-      let staleFields: string[] | undefined;
+      let staleFieldPriorities: Map<string, FetchType> | undefined;
       let stalePriority: FetchType | undefined;
 
       for (const [field, dropped] of droppedForItem) {
@@ -799,14 +806,8 @@ export function createMutationApi<
         droppedForItem.delete(field);
 
         if (dropped.invalidatedAt > fetchStartedAt) {
-          (staleFields ??= []).push(field);
-          if (
-            !stalePriority ||
-            fetchTypePriority[dropped.priority] >
-              fetchTypePriority[stalePriority]
-          ) {
-            stalePriority = dropped.priority;
-          }
+          (staleFieldPriorities ??= new Map()).set(field, dropped.priority);
+          stalePriority = higherFetchType(stalePriority, dropped.priority);
         }
       }
 
@@ -814,24 +815,24 @@ export function createMutationApi<
         itemDroppedFieldInvalidations.delete(itemKey);
       }
 
-      if (!staleFields || !stalePriority) continue;
+      if (!staleFieldPriorities || !stalePriority) continue;
+
+      const staleFields = Array.from(staleFieldPriorities.keys());
 
       // Same transaction as the per-field path of `invalidateQueryAndItems`:
       // record the pending fields, strip them from the loaded metadata, and
       // re-emit the invalidation event.
-      const existingPriority = itemFieldInvalidationPriorities.get(itemKey);
-      const mergedPriority =
-        existingPriority &&
-        fetchTypePriority[existingPriority] > fetchTypePriority[stalePriority]
-          ? existingPriority
-          : stalePriority;
-      const existingPendingFields =
-        itemPendingInvalidationFields.get(itemKey) ?? [];
-      itemPendingInvalidationFields.set(
-        itemKey,
-        Array.from(new Set([...existingPendingFields, ...staleFields])).sort(),
-      );
-      itemFieldInvalidationPriorities.set(itemKey, mergedPriority);
+      let pendingFields = itemPendingInvalidationFields.get(itemKey);
+      if (!pendingFields) {
+        pendingFields = new Map();
+        itemPendingInvalidationFields.set(itemKey, pendingFields);
+      }
+      for (const [field, fieldPriority] of staleFieldPriorities) {
+        pendingFields.set(
+          field,
+          higherFetchType(pendingFields.get(field), fieldPriority),
+        );
+      }
 
       const staleFieldsToApply = staleFields;
       store.produceState(
@@ -855,7 +856,7 @@ export function createMutationApi<
 
       itemInvalidationWasTriggered.delete(itemKey);
       emitInvalidateItem({
-        priority: mergedPriority,
+        priority: stalePriority,
         itemKey,
         invalidateFields: staleFields,
       });
@@ -1245,7 +1246,6 @@ export function createMutationApi<
     );
 
     for (const { itemKey } of itemsId) {
-      itemFieldInvalidationPriorities.delete(itemKey);
       itemPendingInvalidationFields.delete(itemKey);
       itemsPendingFullInvalidation.delete(itemKey);
       itemDroppedFieldInvalidations.delete(itemKey);
@@ -1263,7 +1263,6 @@ export function createMutationApi<
   function resetInvalidationTracking() {
     queryInvalidationWasTriggered.clear();
     itemInvalidationWasTriggered.clear();
-    itemFieldInvalidationPriorities.clear();
     itemPendingInvalidationFields.clear();
     itemsPendingFullInvalidation.clear();
     itemDroppedFieldInvalidations.clear();
@@ -1412,20 +1411,22 @@ export function createMutationApi<
     };
 
     if (affectedItemEntries) {
-      itemRollbackSnapshots = affectedItemEntries.map(({ itemKey }) => ({
-        itemKey,
-        item: klona(store.state.items[itemKey]),
-        itemQuery: klona(store.state.itemQueries[itemKey]),
-        loadedFields: klona(store.state.itemLoadedFields[itemKey]),
-        invalidationFields: klona(
-          store.state.itemFieldInvalidationFields[itemKey],
-        ),
-        invalidationPriority: itemFieldInvalidationPriorities.get(itemKey),
-        pendingInvalidationFields: klona(
-          itemPendingInvalidationFields.get(itemKey),
-        ),
-        invalidationWasTriggered: itemInvalidationWasTriggered.has(itemKey),
-      }));
+      itemRollbackSnapshots = affectedItemEntries.map(({ itemKey }) => {
+        const pendingInvalidationFields =
+          itemPendingInvalidationFields.get(itemKey);
+        return {
+          itemKey,
+          item: klona(store.state.items[itemKey]),
+          itemQuery: klona(store.state.itemQueries[itemKey]),
+          loadedFields: klona(store.state.itemLoadedFields[itemKey]),
+          invalidationFields: klona(
+            store.state.itemFieldInvalidationFields[itemKey],
+          ),
+          pendingInvalidationFields:
+            pendingInvalidationFields && new Map(pendingInvalidationFields),
+          invalidationWasTriggered: itemInvalidationWasTriggered.has(itemKey),
+        };
+      });
     }
 
     storeEvents.emit('mutationStart', { mutationId, items: affectedItems });
@@ -1565,7 +1566,6 @@ export function createMutationApi<
     storeEvents,
     queryInvalidationWasTriggered,
     itemInvalidationWasTriggered,
-    itemFieldInvalidationPriorities,
     invalidateQueryAndItems,
     invalidateItem,
     reannounceInvalidationsDroppedDuringFetch,

--- a/src/listQueryStore/createMutationApi.ts
+++ b/src/listQueryStore/createMutationApi.ts
@@ -303,6 +303,10 @@ export function createMutationApi<
     loadedFields: ItemLoadedFields | undefined;
     invalidationFields: string[] | undefined;
     pendingInvalidationFields: Map<string, FetchType | null> | undefined;
+    pendingFullInvalidation: FetchType | undefined;
+    droppedFieldInvalidations:
+      | Map<string, DroppedFieldInvalidation>
+      | undefined;
     invalidationWasTriggered: boolean;
   };
   type MutationQueryRollbackSnapshot = {
@@ -395,6 +399,24 @@ export function createMutationApi<
           itemPendingInvalidationFields.set(
             snapshot.itemKey,
             new Map(snapshot.pendingInvalidationFields),
+          );
+        }
+
+        if (snapshot.pendingFullInvalidation === undefined) {
+          itemsPendingFullInvalidation.delete(snapshot.itemKey);
+        } else {
+          itemsPendingFullInvalidation.set(
+            snapshot.itemKey,
+            snapshot.pendingFullInvalidation,
+          );
+        }
+
+        if (snapshot.droppedFieldInvalidations === undefined) {
+          itemDroppedFieldInvalidations.delete(snapshot.itemKey);
+        } else {
+          itemDroppedFieldInvalidations.set(
+            snapshot.itemKey,
+            new Map(snapshot.droppedFieldInvalidations),
           );
         }
 
@@ -702,20 +724,28 @@ export function createMutationApi<
       if (itemWasFullyLoaded) {
         // No enumerable field list for a '*' item — record the durable
         // full-invalidation marker so catch-up hooks refetch their own fields
-        // instead of trusting the stale snapshot. The marker keeps the
-        // highest priority it was invalidated with; per-field entries fold
-        // into it since the marker now owes every field until a '*' reload.
-        let markerPriority = higherFetchType(
-          itemsPendingFullInvalidation.get(itemKey),
-          priority,
+        // instead of trusting the stale snapshot. The marker keeps only the
+        // highest priority IT was invalidated with; existing per-field
+        // entries stay and supersede the marker for their fields, so a
+        // leftover obligation on an undisplayed field cannot escalate the
+        // whole item. Each entry is escalated to at least the incoming
+        // priority (the full invalidation owes every field that much), while
+        // `null` entries keep their stronger unknown-priority (immediate
+        // refetch) semantics.
+        itemsPendingFullInvalidation.set(
+          itemKey,
+          higherFetchType(itemsPendingFullInvalidation.get(itemKey), priority),
         );
         if (existingPendingFields) {
-          for (const fieldPriority of existingPendingFields.values()) {
-            markerPriority = higherFetchType(fieldPriority, markerPriority);
+          for (const [field, fieldPriority] of existingPendingFields) {
+            if (fieldPriority !== null) {
+              existingPendingFields.set(
+                field,
+                higherFetchType(fieldPriority, priority),
+              );
+            }
           }
         }
-        itemsPendingFullInvalidation.set(itemKey, markerPriority);
-        itemPendingInvalidationFields.delete(itemKey);
       } else if (trackedInvalidationFields.length > 0) {
         const markerPriority = itemsPendingFullInvalidation.get(itemKey);
         const loadedFields = store.state.itemLoadedFields[itemKey];
@@ -1414,6 +1444,8 @@ export function createMutationApi<
       itemRollbackSnapshots = affectedItemEntries.map(({ itemKey }) => {
         const pendingInvalidationFields =
           itemPendingInvalidationFields.get(itemKey);
+        const droppedFieldInvalidations =
+          itemDroppedFieldInvalidations.get(itemKey);
         return {
           itemKey,
           item: klona(store.state.items[itemKey]),
@@ -1424,6 +1456,9 @@ export function createMutationApi<
           ),
           pendingInvalidationFields:
             pendingInvalidationFields && new Map(pendingInvalidationFields),
+          pendingFullInvalidation: itemsPendingFullInvalidation.get(itemKey),
+          droppedFieldInvalidations:
+            droppedFieldInvalidations && new Map(droppedFieldInvalidations),
           invalidationWasTriggered: itemInvalidationWasTriggered.has(itemKey),
         };
       });

--- a/src/listQueryStore/itemFieldUtils.ts
+++ b/src/listQueryStore/itemFieldUtils.ts
@@ -1,3 +1,4 @@
+import type { FetchType } from '../requestScheduler';
 import { reusePrevIfEqual } from '../utils/reusePrevIfEqual';
 import type { ValidStoreState } from '../utils/storeShared';
 import type { ItemLoadedFields, PartialResourcesConfig } from './types';
@@ -39,7 +40,7 @@ export function snapshotIsFullyLoadedAndFresh<
   loadedFields: ItemLoadedFields | undefined,
   item: ItemState | null | undefined,
   inferFields: (item: ItemState) => ItemLoadedFields,
-  itemsPendingFullInvalidation: Set<string>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
 ): boolean {
   if (loadedFields !== '*' && itemsPendingFullInvalidation.has(itemKey)) {
     return false;
@@ -61,7 +62,7 @@ export function getStaleOrMissingRequestedFields<
   item: ItemState | null | undefined,
   requestedFields: readonly string[],
   inferFields: (item: ItemState) => ItemLoadedFields,
-  itemsPendingFullInvalidation: Set<string>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
   pendingInvalidationFields: readonly string[],
 ): string[] {
   // Requested fields awaiting an invalidation re-fetch are stale even when
@@ -179,7 +180,7 @@ export function getGenuinelyMissingRequestedFields<
     | undefined,
   requestedFields: readonly string[],
   inferFields: (item: ItemState) => ItemLoadedFields,
-  itemsPendingFullInvalidation: Set<string>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
   unresolvedPendingInvalidationFields: readonly string[],
 ): string[] {
   const fallbackMissingFields = getFallbackMissingRequestedFields(

--- a/src/listQueryStore/itemFieldUtils.ts
+++ b/src/listQueryStore/itemFieldUtils.ts
@@ -1,5 +1,6 @@
 import type { FetchType } from '../requestScheduler';
 import { reusePrevIfEqual } from '../utils/reusePrevIfEqual';
+import { higherFetchType } from '../utils/storeShared';
 import type { ValidStoreState } from '../utils/storeShared';
 import type { ItemLoadedFields, PartialResourcesConfig } from './types';
 
@@ -201,6 +202,56 @@ export function getGenuinelyMissingRequestedFields<
   return fallbackMissingFields.filter(
     (field) => !unresolvedPendingInvalidationFields.includes(field),
   );
+}
+
+/**
+ * Highest tracked invalidation priority owed to `requestedFields` (or to any
+ * unresolved field when `requestedFields` is `undefined` — an unbounded hook).
+ * Fields without a tracked priority (e.g. invalidations adopted from another
+ * tab via state sync) contribute nothing, so an all-unknown result stays
+ * `undefined` and callers treat the refetch as untracked (ungated, immediate).
+ * The full-invalidation marker owes a requested field only when that field is
+ * neither reloaded nor covered by a per-field entry (an entry supersedes the
+ * marker for its field).
+ */
+export function getPendingInvalidationPriorityOfFields(
+  requestedFields: readonly string[] | undefined,
+  loadedFields: ItemLoadedFields | undefined,
+  unresolvedPendingInvalidationFields: readonly string[],
+  pendingFieldPriorities: Map<string, FetchType | null> | undefined,
+  fullInvalidationPriority: FetchType | undefined,
+): FetchType | undefined {
+  let highestPriority: FetchType | undefined;
+
+  const fieldsToCheck = requestedFields
+    ? requestedFields.filter((field) =>
+        unresolvedPendingInvalidationFields.includes(field),
+      )
+    : unresolvedPendingInvalidationFields;
+  for (const field of fieldsToCheck) {
+    const fieldPriority = pendingFieldPriorities?.get(field);
+    if (fieldPriority) {
+      highestPriority = higherFetchType(highestPriority, fieldPriority);
+    }
+  }
+
+  if (fullInvalidationPriority !== undefined) {
+    const owedByMarker = requestedFields
+      ? requestedFields.some(
+          (field) =>
+            !(loadedFields?.includes(field) ?? false) &&
+            !pendingFieldPriorities?.has(field),
+        )
+      : true;
+    if (owedByMarker) {
+      highestPriority = higherFetchType(
+        highestPriority,
+        fullInvalidationPriority,
+      );
+    }
+  }
+
+  return highestPriority;
 }
 
 /**

--- a/src/listQueryStore/itemFieldUtils.ts
+++ b/src/listQueryStore/itemFieldUtils.ts
@@ -212,7 +212,8 @@ export function getGenuinelyMissingRequestedFields<
  * `undefined` and callers treat the refetch as untracked (ungated, immediate).
  * The full-invalidation marker owes a requested field only when that field is
  * neither reloaded nor covered by a per-field entry (an entry supersedes the
- * marker for its field).
+ * marker for its field). A `'*'`-loaded item has already resolved the marker
+ * (it only awaits pruning), so the marker contributes nothing then.
  */
 export function getPendingInvalidationPriorityOfFields(
   requestedFields: readonly string[] | undefined,
@@ -235,7 +236,11 @@ export function getPendingInvalidationPriorityOfFields(
     }
   }
 
-  if (fullInvalidationPriority !== undefined) {
+  // When `loadedFields` is '*' the item was fully reloaded after the marker
+  // was set — the marker is resolved and only awaits pruning, so it owes
+  // nothing. Skipping it here also avoids the `'*'.includes(field)` substring
+  // trap below (`loadedFields` would be the string '*', not an array).
+  if (fullInvalidationPriority !== undefined && loadedFields !== '*') {
     const owedByMarker = requestedFields
       ? requestedFields.some(
           (field) =>

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -88,6 +88,7 @@ import {
 import { createStoreFocusLifecycle } from '../utils/storeFocusLifecycle';
 import {
   DEFAULT_BATCH_KEY,
+  higherFetchType,
   resolveManagerFallback,
   StoreFetchError,
   StoreMutationError,
@@ -1897,14 +1898,25 @@ export function createListQueryStore<
   // Invalidation obligations that outlive the state-level
   // `itemFieldInvalidationFields` record (which is consumed when a re-fetch
   // starts). Shared by the fetch api (require-fresh imperative reads), the
-  // mutation api (which records invalidations) and the hooks.
-  const itemPendingInvalidationFields = new Map<string, string[]>();
-  // Items whose entire ('*') snapshot was invalidated. A fully-loaded ('*')
-  // item has no enumerable field list to store in `itemPendingInvalidationFields`,
-  // so this set is the durable "everything is stale" marker that survives partial
-  // refetches. It keeps other mounted hooks from trusting the stale snapshot via
-  // `inferFields` until the item is fully reloaded (`loadedFields === '*'` again).
-  const itemsPendingFullInvalidation = new Set<string>();
+  // mutation api (which records invalidations) and the hooks. Each field maps
+  // to the highest priority it was invalidated with since it was last
+  // reloaded — hooks adopt the max over THEIR requested fields only, so a
+  // leftover high-priority obligation on an undisplayed field cannot escalate
+  // unrelated refetches. `null` means the obligation was adopted without a
+  // known priority (e.g. synced from another tab); hooks treat it as an
+  // immediate refetch.
+  const itemPendingInvalidationFields = new Map<
+    string,
+    Map<string, FetchType | null>
+  >();
+  // Items whose entire ('*') snapshot was invalidated, mapped to the highest
+  // priority of those invalidations. A fully-loaded ('*') item has no
+  // enumerable field list to store in `itemPendingInvalidationFields`, so this
+  // map is the durable "everything is stale" marker that survives partial
+  // refetches. It keeps other mounted hooks from trusting the stale snapshot
+  // via `inferFields` until the item is fully reloaded (`loadedFields === '*'`
+  // again).
+  const itemsPendingFullInvalidation = new Map<string, FetchType>();
   // Per-field invalidations of never-loaded fields, dropped from the stale
   // record so the field's first load stays immediate — kept here so a fetch
   // that was already in flight when the invalidation arrived (and whose
@@ -2072,7 +2084,6 @@ export function createListQueryStore<
     storeEvents,
     queryInvalidationWasTriggered,
     itemInvalidationWasTriggered,
-    itemFieldInvalidationPriorities,
     invalidateQueryAndItems,
     invalidateItem,
     reannounceInvalidationsDroppedDuringFetch,
@@ -2336,20 +2347,22 @@ export function createListQueryStore<
    * a repeat cycle requires a new pending fetch at snapshot arrival.
    */
   function emitRemainingInvalidationFieldsAfterSnapshot(itemKey: string): void {
-    const priority =
-      itemFieldInvalidationPriorities.get(itemKey) ?? 'highPriority';
-
     // A surviving full-invalidation marker means every not-yet-reloaded
     // field is still owed, not just the explicitly tracked field list (a
     // per-field invalidation can coexist with an unresolved full one).
     // Re-announce the full invalidation itself so hooks whose fields are
     // owed only through the marker also re-schedule — downgrading it to the
     // explicit field list would leave them stale forever.
-    if (itemsPendingFullInvalidation.has(itemKey)) {
-      events.emit('invalidateItem', { priority, itemKey });
+    const fullInvalidationPriority = itemsPendingFullInvalidation.get(itemKey);
+    if (fullInvalidationPriority !== undefined) {
+      events.emit('invalidateItem', {
+        priority: fullInvalidationPriority,
+        itemKey,
+      });
       return;
     }
 
+    const pendingFields = itemPendingInvalidationFields.get(itemKey);
     const stateInvalidationFields =
       store.state.itemFieldInvalidationFields[itemKey];
     const remainingFields =
@@ -2357,13 +2370,23 @@ export function createListQueryStore<
         ? stateInvalidationFields
         : excludeLoadedFields(
             store.state.itemLoadedFields[itemKey],
-            itemPendingInvalidationFields.get(itemKey),
+            pendingFields && Array.from(pendingFields.keys()),
           );
 
     if (remainingFields.length === 0) return;
 
+    // Re-announce at the highest priority still owed to the remaining
+    // fields; fields without a tracked priority refetch immediately.
+    let priority: FetchType | undefined;
+    for (const field of remainingFields) {
+      priority = higherFetchType(
+        priority,
+        pendingFields?.get(field) ?? 'highPriority',
+      );
+    }
+
     events.emit('invalidateItem', {
-      priority,
+      priority: priority ?? 'highPriority',
       itemKey,
       invalidateFields: remainingFields,
     });
@@ -2371,28 +2394,31 @@ export function createListQueryStore<
 
   function pruneItemInvalidationTracking(): void {
     for (const [itemKey, pendingFields] of itemPendingInvalidationFields) {
-      // Fields still owed from earlier invalidations: the ones not yet
-      // reloaded, plus any per-field invalidations still recorded in state —
-      // the state record must never *replace* the tracked pending fields, or
-      // fields owed from an earlier (e.g. full) invalidation would be dropped.
-      const remainingFields = excludeLoadedFields(
-        store.state.itemLoadedFields[itemKey],
-        pendingFields,
-      );
-
+      const loadedFields = store.state.itemLoadedFields[itemKey];
       const stateInvalidationFields =
         store.state.itemFieldInvalidationFields[itemKey];
-      if (stateInvalidationFields && stateInvalidationFields.length > 0) {
-        const mergedFields = Array.from(
-          new Set([...stateInvalidationFields, ...remainingFields]),
-        ).sort();
-        itemPendingInvalidationFields.set(itemKey, mergedFields);
-        continue;
+
+      // Fields reloaded since their invalidation are resolved — unless the
+      // state record still lists them as stale (a per-field invalidation on
+      // a '*'-loaded item keeps them in `loadedFields`).
+      for (const field of pendingFields.keys()) {
+        if (stateInvalidationFields?.includes(field)) continue;
+        if (loadedFields === '*' || (loadedFields?.includes(field) ?? false)) {
+          pendingFields.delete(field);
+        }
       }
 
-      if (remainingFields.length > 0) {
-        itemPendingInvalidationFields.set(itemKey, remainingFields);
-      } else {
+      // Per-field invalidations recorded only in state (e.g. adopted from
+      // another tab) must also be tracked so the obligation survives the
+      // record's consumption at fetch start. Their priority is unknown —
+      // hooks treat them as an immediate refetch.
+      if (stateInvalidationFields) {
+        for (const field of stateInvalidationFields) {
+          if (!pendingFields.has(field)) pendingFields.set(field, null);
+        }
+      }
+
+      if (pendingFields.size === 0) {
         itemPendingInvalidationFields.delete(itemKey);
       }
     }
@@ -2400,32 +2426,14 @@ export function createListQueryStore<
     // A full-invalidation marker is resolved once the item is fully reloaded
     // ('*' again); until then it stays so late-mounting hooks keep refetching
     // their own not-yet-reloaded fields.
-    for (const itemKey of itemsPendingFullInvalidation) {
+    for (const itemKey of itemsPendingFullInvalidation.keys()) {
       if (store.state.itemLoadedFields[itemKey] === '*') {
         itemsPendingFullInvalidation.delete(itemKey);
-      }
-    }
-
-    for (const itemKey of itemFieldInvalidationPriorities.keys()) {
-      const hasPendingStateInvalidation =
-        !!store.state.itemFieldInvalidationFields[itemKey];
-      const hasPendingTrackedInvalidation =
-        (itemPendingInvalidationFields.get(itemKey)?.length ?? 0) > 0;
-      const hasPendingFullInvalidation =
-        itemsPendingFullInvalidation.has(itemKey);
-
-      if (
-        !hasPendingStateInvalidation &&
-        !hasPendingTrackedInvalidation &&
-        !hasPendingFullInvalidation
-      ) {
-        itemFieldInvalidationPriorities.delete(itemKey);
       }
     }
   }
 
   function cleanupItemStateMetadata(itemKey: string): void {
-    itemFieldInvalidationPriorities.delete(itemKey);
     itemPendingInvalidationFields.delete(itemKey);
     itemsPendingFullInvalidation.delete(itemKey);
     itemDroppedFieldInvalidations.delete(itemKey);
@@ -2994,7 +3002,6 @@ export function createListQueryStore<
       persistence?.readHydratedItem,
       scheduleAutomaticListQueryFetch,
       queryInvalidationWasTriggered,
-      itemFieldInvalidationPriorities,
       itemPendingInvalidationFields,
       itemsPendingFullInvalidation,
       globalDisableRefetchOnMount,
@@ -3082,7 +3089,6 @@ export function createListQueryStore<
       !!persistence && !persistence.hasAsyncPreload,
       persistence?.readHydratedItem,
       itemInvalidationWasTriggered,
-      itemFieldInvalidationPriorities,
       itemPendingInvalidationFields,
       itemsPendingFullInvalidation,
       globalDisableRefetchOnMount,

--- a/src/listQueryStore/listQueryStore.ts
+++ b/src/listQueryStore/listQueryStore.ts
@@ -1903,8 +1903,12 @@ export function createListQueryStore<
   // reloaded — hooks adopt the max over THEIR requested fields only, so a
   // leftover high-priority obligation on an undisplayed field cannot escalate
   // unrelated refetches. `null` means the obligation was adopted without a
-  // known priority (e.g. synced from another tab); hooks treat it as an
-  // immediate refetch.
+  // known priority (e.g. synced from another tab); later invalidations never
+  // downgrade a `null` entry to a known priority. When `null` entries are the
+  // only pending information for a hook's requested fields, the refetch is
+  // treated as untracked (ungated, immediate); when they are mixed with
+  // tracked-priority fields, the max over the KNOWN priorities wins — the
+  // unknown-priority fields simply ride along with that refetch.
   const itemPendingInvalidationFields = new Map<
     string,
     Map<string, FetchType | null>
@@ -1926,6 +1930,12 @@ export function createListQueryStore<
     string,
     Map<string, DroppedFieldInvalidation>
   >();
+  // In-flight mutation refcounts for items on stores without a `fetchItemFn`
+  // (which have no item scheduler to track mutations). Used only to protect
+  // standalone items — items not referenced by any query — from cache eviction
+  // while a mutation targeting them is in flight. Entries self-clean when the
+  // last overlapping mutation on the item settles.
+  const itemMutationCountsWithoutScheduler = new Map<string, number>();
 
   const {
     getQueryState,
@@ -2131,6 +2141,7 @@ export function createListQueryStore<
     itemPendingInvalidationFields,
     itemsPendingFullInvalidation,
     itemDroppedFieldInvalidations,
+    itemMutationCountsWithoutScheduler,
   );
 
   if (resolvedPersistentStorageConfig && resolvedOfflineConfig) {
@@ -2532,8 +2543,9 @@ export function createListQueryStore<
   ): boolean {
     if (itemCacheRuntime.isActive(itemKey)) return true;
     // Only inspect an existing scheduler: creating one would throw on
-    // list-only stores without a fetchItemFn, and a store that can't have an
-    // item scheduler can't have an item fetch or mutation in progress either.
+    // list-only stores without a fetchItemFn. Those stores can't have an item
+    // fetch in progress, but mutations can still target their items — those
+    // are tracked in `itemMutationCountsWithoutScheduler` instead.
     const scheduler = getKnownItemScheduler(itemKey);
     if (
       itemQuery.status === 'loading' ||
@@ -2543,7 +2555,10 @@ export function createListQueryStore<
       return true;
     }
 
-    return scheduler?.isMutationInProgress(itemKey) ?? false;
+    return (
+      (scheduler?.isMutationInProgress(itemKey) ?? false) ||
+      itemMutationCountsWithoutScheduler.has(itemKey)
+    );
   }
 
   function mergeIncomingItemSnapshot(

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -34,6 +34,7 @@ import {
 } from '../utils/payloadDebounce';
 import {
   fetchTypePriority,
+  higherFetchType,
   type PayloadDebounce,
   ValidPayload,
   ValidStoreState,
@@ -142,9 +143,8 @@ export function useMultipleItems<
         | undefined)
     | undefined,
   itemInvalidationWasTriggered: Set<string>,
-  itemFieldInvalidationPriorities: Map<string, FetchType>,
-  itemPendingInvalidationFields: Map<string, string[]>,
-  itemsPendingFullInvalidation: Set<string>,
+  itemPendingInvalidationFields: Map<string, Map<string, FetchType | null>>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
   globalDisableRefetchOnMount: boolean | undefined,
   fetchItemFn: unknown,
   partialResources: PartialResourcesConfig<ItemState> | undefined,
@@ -252,9 +252,10 @@ export function useMultipleItems<
       const itemLoadedFields = state
         ? state.itemLoadedFields
         : store.state.itemLoadedFields;
+      const pendingFields = itemPendingInvalidationFields.get(itemKey);
       return excludeLoadedFields(
         itemLoadedFields[itemKey],
-        itemPendingInvalidationFields.get(itemKey),
+        pendingFields && Array.from(pendingFields.keys()),
       );
     },
     [itemPendingInvalidationFields, store],
@@ -762,11 +763,14 @@ export function useMultipleItems<
       event.itemKey,
     );
     const loadedFields = store.state.itemLoadedFields[event.itemKey];
+    const eventItemPendingFields = itemPendingInvalidationFields.get(
+      event.itemKey,
+    );
     const owedStaleFields = new Set([
       ...(store.state.itemFieldInvalidationFields[event.itemKey] ?? []),
       ...excludeLoadedFields(
         loadedFields,
-        itemPendingInvalidationFields.get(event.itemKey),
+        eventItemPendingFields && Array.from(eventItemPendingFields.keys()),
       ),
     ]);
 
@@ -957,11 +961,51 @@ export function useMultipleItems<
           const hasUnresolvedFullInvalidation =
             itemsPendingFullInvalidation.has(itemKey) &&
             !hasFullyLoadedFields(loadedFields);
-          const invalidationPriority =
-            unresolvedPendingInvalidationFields.length > 0 ||
-            hasUnresolvedFullInvalidation
-              ? itemFieldInvalidationPriorities.get(itemKey)
-              : undefined;
+          // Highest tracked priority among the fields this hook instance
+          // still owes. Fields whose invalidation priority is unknown (e.g.
+          // adopted from another tab via state sync) contribute nothing, so
+          // an all-unknown result stays undefined and the code below treats
+          // the refetch as untracked (ungated, lifted to immediate).
+          const pendingFieldPriorities =
+            itemPendingInvalidationFields.get(itemKey);
+          const fullInvalidationPriority = hasUnresolvedFullInvalidation
+            ? itemsPendingFullInvalidation.get(itemKey)
+            : undefined;
+          let invalidationPriority: FetchType | undefined;
+          const requestedFieldList =
+            Array.isArray(fields) && fields.length > 0 ? fields : undefined;
+          const fieldsToCheckPriority = requestedFieldList
+            ? requestedFieldList.filter((field) =>
+                unresolvedPendingInvalidationFields.includes(field),
+              )
+            : unresolvedPendingInvalidationFields;
+          for (const field of fieldsToCheckPriority) {
+            const fieldPriority = pendingFieldPriorities?.get(field);
+            if (fieldPriority) {
+              invalidationPriority = higherFetchType(
+                invalidationPriority,
+                fieldPriority,
+              );
+            }
+          }
+          if (fullInvalidationPriority !== undefined) {
+            // The full-invalidation marker owes a requested field only when
+            // that field is neither reloaded nor covered by a per-field
+            // entry (an entry supersedes the marker for its field).
+            const owedByMarker = requestedFieldList
+              ? requestedFieldList.some(
+                  (field) =>
+                    !loadedFields.includes(field) &&
+                    !pendingFieldPriorities?.has(field),
+                )
+              : true;
+            if (owedByMarker) {
+              invalidationPriority = higherFetchType(
+                invalidationPriority,
+                fullInvalidationPriority,
+              );
+            }
+          }
 
           if (Array.isArray(fields) && fields.length > 0) {
             // Per-field stale-or-missing check: `inferFields` keeps vouching
@@ -1185,7 +1229,6 @@ export function useMultipleItems<
     fetchQueriesWithId,
     getUnresolvedPendingInvalidationFields,
     ignoreItemsInRefetchOnMount,
-    itemFieldInvalidationPriorities,
     itemPendingInvalidationFields,
     itemsPendingFullInvalidation,
     loadFromStateOnly,

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -738,6 +738,62 @@ export function useMultipleItems<
 
   const ignoreItemsInRefetchOnMount = useConst(() => new Set<string>());
 
+  // Whether the data a hook instance requests for the item is genuinely
+  // missing (never loaded, not vouched by `inferFields`, not merely stale).
+  // Missing data has nothing to show, so its fetch must not inherit a
+  // throttleable invalidation priority — stale-but-displayable data must keep
+  // it so scheduler throttling (e.g. realtime updates) stays effective.
+  const itemHasMissingRequestedData = useCallback(
+    (itemKey: string, fields: FieldsInput | undefined): boolean => {
+      const itemState = store.state.itemQueries[itemKey];
+      // Deleted items should stay deleted until explicitly fetched/invalidated.
+      if (itemState === null) return false;
+      if (!itemState?.wasLoaded) return true;
+      if (!partialResources) return false;
+
+      const loadedFields = store.state.itemLoadedFields[itemKey];
+      const item = store.state.items[itemKey];
+
+      if (Array.isArray(fields) && fields.length > 0) {
+        return (
+          getGenuinelyMissingRequestedFields(
+            itemKey,
+            { item, loadedFields },
+            fields,
+            partialResources.inferFields,
+            itemsPendingFullInvalidation,
+            getUnresolvedPendingInvalidationFields(itemKey),
+          ).length > 0
+        );
+      }
+
+      if (fields === '*') {
+        // A fully invalidated item whose (stale) snapshot is still present is
+        // stale data, not missing data.
+        const hasStaleFullInvalidation =
+          itemsPendingFullInvalidation.has(itemKey) &&
+          !hasFullyLoadedFields(loadedFields) &&
+          !!item;
+        return (
+          !hasStaleFullInvalidation &&
+          !snapshotIsFullyLoaded(
+            loadedFields,
+            item,
+            partialResources.inferFields,
+          )
+        );
+      }
+
+      return false;
+    },
+    [
+      getUnresolvedPendingInvalidationFields,
+      itemsPendingFullInvalidation,
+      partialResources,
+      store,
+    ],
+  );
+
   useOnEvtmitterEvent(events, 'invalidateItem', ({ payload: event }) => {
     if (loadFromStateOnly || !fetchItemFn) return;
 
@@ -824,6 +880,17 @@ export function useMultipleItems<
     const isUnboundedHook =
       !hookFields || hookFields === '*' || hookFields.length === 0;
 
+    // The refetch inherits the invalidation's priority, which the scheduler
+    // may delay (e.g. `realtimeUpdate` with `dynamicRealtimeThrottleMs`).
+    // Waiting is only acceptable when the requested data is
+    // stale-but-displayable — genuinely missing data has nothing to show, so
+    // its fetch must run immediately (mirrors the mount path).
+    const fetchPriority: FetchType =
+      event.priority !== 'highPriority' &&
+      itemHasMissingRequestedData(event.itemKey, hookFields)
+        ? 'highPriority'
+        : event.priority;
+
     if (itemInvalidationWasTriggered.has(event.itemKey)) {
       if (!fieldsToFetch) return;
 
@@ -842,7 +909,7 @@ export function useMultipleItems<
 
       if (contributionFields && contributionFields.length === 0) return;
 
-      scheduleAutomaticItemFetch(event.priority, firstQuery.payload, {
+      scheduleAutomaticItemFetch(fetchPriority, firstQuery.payload, {
         fields: contributionFields,
       });
       return;
@@ -879,7 +946,7 @@ export function useMultipleItems<
       query.refetchOnMount = false;
     });
 
-    scheduleAutomaticItemFetch(event.priority, firstQuery.payload, {
+    scheduleAutomaticItemFetch(fetchPriority, firstQuery.payload, {
       fields: fieldsToFetch ?? firstQuery.fields,
     });
     itemInvalidationWasTriggered.add(event.itemKey);
@@ -1119,43 +1186,12 @@ export function useMultipleItems<
         // `dynamicRealtimeThrottleMs`). Waiting is only acceptable when the
         // requested data is stale-but-displayable — genuinely missing data
         // has nothing to show, so its fetch must run immediately.
-        if (itemState?.refetchOnMount && fetchType !== 'highPriority') {
-          let hasMissingRequestedData = requiredFetch;
-
-          if (!hasMissingRequestedData && partialResources) {
-            const loadedFields = store.state.itemLoadedFields[itemKey];
-            const item = store.state.items[itemKey];
-
-            if (Array.isArray(fields) && fields.length > 0) {
-              hasMissingRequestedData =
-                getGenuinelyMissingRequestedFields(
-                  itemKey,
-                  { item, loadedFields },
-                  fields,
-                  partialResources.inferFields,
-                  itemsPendingFullInvalidation,
-                  getUnresolvedPendingInvalidationFields(itemKey),
-                ).length > 0;
-            } else if (fields === '*') {
-              // A fully invalidated item whose (stale) snapshot is still
-              // present is stale data, not missing data.
-              const hasStaleFullInvalidation =
-                itemsPendingFullInvalidation.has(itemKey) &&
-                !hasFullyLoadedFields(loadedFields) &&
-                !!item;
-              hasMissingRequestedData =
-                !hasStaleFullInvalidation &&
-                !snapshotIsFullyLoaded(
-                  loadedFields,
-                  item,
-                  partialResources.inferFields,
-                );
-            }
-          }
-
-          if (hasMissingRequestedData) {
-            fetchType = 'highPriority';
-          }
+        if (
+          itemState?.refetchOnMount &&
+          fetchType !== 'highPriority' &&
+          itemHasMissingRequestedData(itemKey, fields)
+        ) {
+          fetchType = 'highPriority';
         }
 
         // `refetchOnMount` carries only the priority of the LAST invalidation
@@ -1228,6 +1264,7 @@ export function useMultipleItems<
     fetchQueriesWithId,
     getUnresolvedPendingInvalidationFields,
     ignoreItemsInRefetchOnMount,
+    itemHasMissingRequestedData,
     itemPendingInvalidationFields,
     itemsPendingFullInvalidation,
     loadFromStateOnly,

--- a/src/listQueryStore/useMultipleItems.ts
+++ b/src/listQueryStore/useMultipleItems.ts
@@ -34,7 +34,6 @@ import {
 } from '../utils/payloadDebounce';
 import {
   fetchTypePriority,
-  higherFetchType,
   type PayloadDebounce,
   ValidPayload,
   ValidStoreState,
@@ -43,6 +42,7 @@ import {
   excludeLoadedFields,
   fallbackItemHasRequestedFields,
   getGenuinelyMissingRequestedFields,
+  getPendingInvalidationPriorityOfFields,
   getStaleOrMissingRequestedFields,
   hasFullyLoadedFields,
   snapshotIsFullyLoaded,
@@ -966,46 +966,15 @@ export function useMultipleItems<
           // adopted from another tab via state sync) contribute nothing, so
           // an all-unknown result stays undefined and the code below treats
           // the refetch as untracked (ungated, lifted to immediate).
-          const pendingFieldPriorities =
-            itemPendingInvalidationFields.get(itemKey);
-          const fullInvalidationPriority = hasUnresolvedFullInvalidation
-            ? itemsPendingFullInvalidation.get(itemKey)
-            : undefined;
-          let invalidationPriority: FetchType | undefined;
-          const requestedFieldList =
-            Array.isArray(fields) && fields.length > 0 ? fields : undefined;
-          const fieldsToCheckPriority = requestedFieldList
-            ? requestedFieldList.filter((field) =>
-                unresolvedPendingInvalidationFields.includes(field),
-              )
-            : unresolvedPendingInvalidationFields;
-          for (const field of fieldsToCheckPriority) {
-            const fieldPriority = pendingFieldPriorities?.get(field);
-            if (fieldPriority) {
-              invalidationPriority = higherFetchType(
-                invalidationPriority,
-                fieldPriority,
-              );
-            }
-          }
-          if (fullInvalidationPriority !== undefined) {
-            // The full-invalidation marker owes a requested field only when
-            // that field is neither reloaded nor covered by a per-field
-            // entry (an entry supersedes the marker for its field).
-            const owedByMarker = requestedFieldList
-              ? requestedFieldList.some(
-                  (field) =>
-                    !loadedFields.includes(field) &&
-                    !pendingFieldPriorities?.has(field),
-                )
-              : true;
-            if (owedByMarker) {
-              invalidationPriority = higherFetchType(
-                invalidationPriority,
-                fullInvalidationPriority,
-              );
-            }
-          }
+          const invalidationPriority = getPendingInvalidationPriorityOfFields(
+            Array.isArray(fields) && fields.length > 0 ? fields : undefined,
+            loadedFields,
+            unresolvedPendingInvalidationFields,
+            itemPendingInvalidationFields.get(itemKey),
+            hasUnresolvedFullInvalidation
+              ? itemsPendingFullInvalidation.get(itemKey)
+              : undefined,
+          );
 
           if (Array.isArray(fields) && fields.length > 0) {
             // Per-field stale-or-missing check: `inferFields` keeps vouching
@@ -1186,6 +1155,36 @@ export function useMultipleItems<
 
           if (hasMissingRequestedData) {
             fetchType = 'highPriority';
+          }
+        }
+
+        // `refetchOnMount` carries only the priority of the LAST invalidation
+        // that set it — fields this hook requests may still be owed at a
+        // higher tracked priority from an earlier invalidation (e.g. a
+        // high-priority per-field invalidation recorded before a later
+        // realtime full invalidation). Adopt the highest priority owed to the
+        // requested fields so the mount fetch is not under-prioritized.
+        if (
+          partialResources &&
+          itemState?.refetchOnMount &&
+          fetchType !== 'highPriority'
+        ) {
+          const loadedFields = store.state.itemLoadedFields[itemKey];
+          const invalidationPriority = getPendingInvalidationPriorityOfFields(
+            Array.isArray(fields) && fields.length > 0 ? fields : undefined,
+            loadedFields,
+            getUnresolvedPendingInvalidationFields(itemKey),
+            itemPendingInvalidationFields.get(itemKey),
+            hasFullyLoadedFields(loadedFields)
+              ? undefined
+              : itemsPendingFullInvalidation.get(itemKey),
+          );
+          if (
+            invalidationPriority &&
+            fetchTypePriority[invalidationPriority] >
+              fetchTypePriority[fetchType]
+          ) {
+            fetchType = invalidationPriority;
           }
         }
 

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -1186,6 +1186,69 @@ export function useMultipleListQueries<
     () => new Map<string, FetchType>(),
   );
 
+  // Whether the data a hook instance requests for the query's items is
+  // genuinely missing (never loaded, not vouched by `inferFields`, not merely
+  // stale). Missing data has nothing to show, so its fetch must not inherit a
+  // throttleable invalidation priority — stale-but-displayable data must keep
+  // it so scheduler throttling (e.g. realtime updates) stays effective.
+  const queryItemsHaveMissingRequestedData = useCallback(
+    (itemKeys: string[], fields: FieldsInput | undefined): boolean => {
+      if (!partialResources) return false;
+
+      if (Array.isArray(fields) && fields.length > 0) {
+        for (const itemKey of itemKeys) {
+          if (
+            getGenuinelyMissingRequestedFields(
+              itemKey,
+              {
+                item: store.state.items[itemKey],
+                loadedFields: store.state.itemLoadedFields[itemKey],
+              },
+              fields,
+              partialResources.inferFields,
+              itemsPendingFullInvalidation,
+              getUnresolvedPendingInvalidationFields(itemKey),
+            ).length > 0
+          ) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      if (fields === '*') {
+        for (const itemKey of itemKeys) {
+          const item = store.state.items[itemKey];
+          const loadedFields = store.state.itemLoadedFields[itemKey];
+          // A fully invalidated item whose (stale) snapshot is still present
+          // is stale data, not missing data.
+          const hasStaleFullInvalidation =
+            itemsPendingFullInvalidation.has(itemKey) &&
+            !hasFullyLoadedFields(loadedFields) &&
+            !!item;
+          if (
+            !hasStaleFullInvalidation &&
+            !snapshotIsFullyLoaded(
+              loadedFields,
+              item,
+              partialResources.inferFields,
+            )
+          ) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    },
+    [
+      getUnresolvedPendingInvalidationFields,
+      itemsPendingFullInvalidation,
+      partialResources,
+      store,
+    ],
+  );
+
   useOnEvtmitterEvent(events, 'invalidateQuery', ({ payload: event }) => {
     for (const {
       key,
@@ -1228,12 +1291,28 @@ export function useMultipleListQueries<
         queryInvalidationWasTriggered.add(key);
       }
 
+      // The refetch inherits the invalidation's priority, which the scheduler
+      // may delay (e.g. `realtimeUpdate` with `dynamicRealtimeThrottleMs`).
+      // Waiting is only acceptable when the requested data is
+      // stale-but-displayable — a query that never loaded (or items whose
+      // requested data is genuinely missing) has nothing to show, so its
+      // fetch must run immediately (mirrors the mount path). Derived queries
+      // borrow their source query's data, so they are displayable even
+      // without own loaded data.
+      const fetchPriority: FetchType =
+        event.priority !== 'highPriority' &&
+        (!resolvedQuery ||
+          (!resolvedQuery.query.wasLoaded && !resolvedQuery.isDerived) ||
+          queryItemsHaveMissingRequestedData(resolvedQuery.query.items, fields))
+          ? 'highPriority'
+          : event.priority;
+
       // Every instance schedules its own fields/loadSize — instances watching
       // the same query with different field subsets each contribute theirs,
       // and the scheduler's coalescing window merges the schedules into a
       // single fetch. Deduping the schedule per query key would drop the
       // other instances' fields, leaving them stale forever.
-      scheduleAutomaticListQueryFetch(event.priority, payload, loadSize, {
+      scheduleAutomaticListQueryFetch(fetchPriority, payload, loadSize, {
         fields,
       });
     }
@@ -1493,61 +1572,17 @@ export function useMultipleListQueries<
         // `dynamicRealtimeThrottleMs`). Waiting is only acceptable when the
         // requested data is stale-but-displayable — genuinely missing data
         // has nothing to show, so its fetch must run immediately.
-        if (queryState?.refetchOnMount && fetchType !== 'highPriority') {
-          let hasMissingRequestedData = requiredFetch;
-
-          if (
-            !hasMissingRequestedData &&
-            partialResources &&
-            effectiveQueryState
-          ) {
-            if (Array.isArray(fields) && fields.length > 0) {
-              for (const itemKey of effectiveQueryState.items) {
-                if (
-                  getGenuinelyMissingRequestedFields(
-                    itemKey,
-                    {
-                      item: store.state.items[itemKey],
-                      loadedFields: store.state.itemLoadedFields[itemKey],
-                    },
-                    fields,
-                    partialResources.inferFields,
-                    itemsPendingFullInvalidation,
-                    getUnresolvedPendingInvalidationFields(itemKey),
-                  ).length > 0
-                ) {
-                  hasMissingRequestedData = true;
-                  break;
-                }
-              }
-            } else if (fields === '*') {
-              for (const itemKey of effectiveQueryState.items) {
-                const item = store.state.items[itemKey];
-                const loadedFields = store.state.itemLoadedFields[itemKey];
-                // A fully invalidated item whose (stale) snapshot is still
-                // present is stale data, not missing data.
-                const hasStaleFullInvalidation =
-                  itemsPendingFullInvalidation.has(itemKey) &&
-                  !hasFullyLoadedFields(loadedFields) &&
-                  !!item;
-                if (
-                  !hasStaleFullInvalidation &&
-                  !snapshotIsFullyLoaded(
-                    loadedFields,
-                    item,
-                    partialResources.inferFields,
-                  )
-                ) {
-                  hasMissingRequestedData = true;
-                  break;
-                }
-              }
-            }
-          }
-
-          if (hasMissingRequestedData) {
-            fetchType = 'highPriority';
-          }
+        if (
+          queryState?.refetchOnMount &&
+          fetchType !== 'highPriority' &&
+          (requiredFetch ||
+            (effectiveQueryState &&
+              queryItemsHaveMissingRequestedData(
+                effectiveQueryState.items,
+                fields,
+              )))
+        ) {
+          fetchType = 'highPriority';
         }
 
         // `refetchOnMount` carries only the priority of the LAST invalidation
@@ -1646,6 +1681,7 @@ export function useMultipleListQueries<
     itemsPendingFullInvalidation,
     getHighestPendingInvalidationPriority,
     getUnresolvedPendingInvalidationFields,
+    queryItemsHaveMissingRequestedData,
     stickyDerivedQueryKeys,
   ]);
 

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -45,6 +45,7 @@ import {
   excludeLoadedFields,
   fallbackItemHasRequestedFields,
   getGenuinelyMissingRequestedFields,
+  getPendingInvalidationPriorityOfFields,
   getStaleOrMissingRequestedFields,
   hasFullyLoadedFields,
   snapshotIsFullyLoaded,
@@ -424,60 +425,26 @@ export function useMultipleListQueries<
       let highestPriority: FetchType | undefined;
 
       for (const itemKey of itemKeys) {
-        const unresolvedInvalidationFields =
-          getUnresolvedPendingInvalidationFields(itemKey);
         const loadedFields = store.state.itemLoadedFields[itemKey];
-        // A fully invalidated ('*'-loaded) item has no field list to
-        // enumerate — the pending-full marker alone proves every
-        // not-yet-reloaded field (requested ones included) is awaiting the
-        // re-fetch.
-        const fullInvalidationPriority =
-          loadedFields === '*'
-            ? undefined
-            : itemsPendingFullInvalidation.get(itemKey);
-        if (
-          unresolvedInvalidationFields.length === 0 &&
-          fullInvalidationPriority === undefined
-        ) {
-          continue;
-        }
-
-        const pendingFieldPriorities =
-          itemPendingInvalidationFields.get(itemKey);
-
         // Adopt only the priorities owed to the fields this hook actually
         // requests — a leftover obligation on an undisplayed field must not
         // escalate this hook's refetch. Fields without a tracked priority
         // (e.g. adopted from another tab) contribute nothing; callers treat
-        // an undefined result as an immediate refetch.
-        const fieldsToCheck = requestedFields
-          ? requestedFields.filter((field) =>
-              unresolvedInvalidationFields.includes(field),
-            )
-          : unresolvedInvalidationFields;
-        for (const field of fieldsToCheck) {
-          const fieldPriority = pendingFieldPriorities?.get(field);
-          if (fieldPriority) {
-            highestPriority = higherFetchType(highestPriority, fieldPriority);
-          }
-        }
-
-        if (fullInvalidationPriority !== undefined) {
-          // The marker owes every field not reloaded since the full
-          // invalidation and without its own (superseding) field entry.
-          const owedByMarker = requestedFields
-            ? requestedFields.some(
-                (field) =>
-                  !(loadedFields?.includes(field) ?? false) &&
-                  !pendingFieldPriorities?.has(field),
-              )
-            : true;
-          if (owedByMarker) {
-            highestPriority = higherFetchType(
-              highestPriority,
-              fullInvalidationPriority,
-            );
-          }
+        // an undefined result as an immediate refetch. A fully invalidated
+        // ('*'-loaded) item has no field list to enumerate — the pending-full
+        // marker alone proves every not-yet-reloaded field (requested ones
+        // included) is awaiting the re-fetch.
+        const itemPriority = getPendingInvalidationPriorityOfFields(
+          requestedFields,
+          loadedFields,
+          getUnresolvedPendingInvalidationFields(itemKey),
+          itemPendingInvalidationFields.get(itemKey),
+          loadedFields === '*'
+            ? undefined
+            : itemsPendingFullInvalidation.get(itemKey),
+        );
+        if (itemPriority) {
+          highestPriority = higherFetchType(highestPriority, itemPriority);
         }
       }
 
@@ -1580,6 +1547,31 @@ export function useMultipleListQueries<
 
           if (hasMissingRequestedData) {
             fetchType = 'highPriority';
+          }
+        }
+
+        // `refetchOnMount` carries only the priority of the LAST invalidation
+        // that set it — fields this hook displays may still be owed at a
+        // higher tracked priority from an earlier invalidation (e.g. a
+        // high-priority per-field invalidation recorded before a later
+        // realtime full invalidation). Adopt the highest priority owed to the
+        // displayed fields so the mount fetch is not under-prioritized.
+        if (
+          partialResources &&
+          queryState?.refetchOnMount &&
+          fetchType !== 'highPriority' &&
+          effectiveQueryState
+        ) {
+          const invalidationPriority = getHighestPendingInvalidationPriority(
+            effectiveQueryState.items,
+            Array.isArray(fields) && fields.length > 0 ? fields : undefined,
+          );
+          if (
+            invalidationPriority &&
+            fetchTypePriority[invalidationPriority] >
+              fetchTypePriority[fetchType]
+          ) {
+            fetchType = invalidationPriority;
           }
         }
 

--- a/src/listQueryStore/useMultipleListQueries.ts
+++ b/src/listQueryStore/useMultipleListQueries.ts
@@ -35,6 +35,7 @@ import {
 } from '../utils/payloadDebounce';
 import {
   fetchTypePriority,
+  higherFetchType,
   isStrictItemKeyPrefix,
   type PayloadDebounce,
   ValidPayload,
@@ -161,9 +162,8 @@ export function useMultipleListQueries<
     options?: { fields?: FieldsInput },
   ) => ScheduleFetchResults,
   queryInvalidationWasTriggered: Set<string>,
-  itemFieldInvalidationPriorities: Map<string, FetchType>,
-  itemPendingInvalidationFields: Map<string, string[]>,
-  itemsPendingFullInvalidation: Set<string>,
+  itemPendingInvalidationFields: Map<string, Map<string, FetchType | null>>,
+  itemsPendingFullInvalidation: Map<string, FetchType>,
   globalDisableRefetchOnMount: boolean | undefined,
   partialResources: PartialResourcesConfig<ItemState> | undefined,
   derivedQueries:
@@ -407,9 +407,10 @@ export function useMultipleListQueries<
       const itemLoadedFields = state
         ? state.itemLoadedFields
         : store.state.itemLoadedFields;
+      const pendingFields = itemPendingInvalidationFields.get(itemKey);
       return excludeLoadedFields(
         itemLoadedFields[itemKey],
-        itemPendingInvalidationFields.get(itemKey),
+        pendingFields && Array.from(pendingFields.keys()),
       );
     },
     [itemPendingInvalidationFields, store],
@@ -425,35 +426,58 @@ export function useMultipleListQueries<
       for (const itemKey of itemKeys) {
         const unresolvedInvalidationFields =
           getUnresolvedPendingInvalidationFields(itemKey);
+        const loadedFields = store.state.itemLoadedFields[itemKey];
         // A fully invalidated ('*'-loaded) item has no field list to
-        // enumerate — the pending-full marker alone proves every field
-        // (requested ones included) is awaiting the re-fetch.
-        const hasUnresolvedFullInvalidation =
-          itemsPendingFullInvalidation.has(itemKey) &&
-          !hasFullyLoadedFields(store.state.itemLoadedFields[itemKey]);
+        // enumerate — the pending-full marker alone proves every
+        // not-yet-reloaded field (requested ones included) is awaiting the
+        // re-fetch.
+        const fullInvalidationPriority =
+          loadedFields === '*'
+            ? undefined
+            : itemsPendingFullInvalidation.get(itemKey);
         if (
           unresolvedInvalidationFields.length === 0 &&
-          !hasUnresolvedFullInvalidation
-        ) {
-          continue;
-        }
-        if (
-          !hasUnresolvedFullInvalidation &&
-          requestedFields &&
-          !requestedFields.some((field) =>
-            unresolvedInvalidationFields.includes(field),
-          )
+          fullInvalidationPriority === undefined
         ) {
           continue;
         }
 
-        const itemPriority = itemFieldInvalidationPriorities.get(itemKey);
-        if (!itemPriority) continue;
-        if (
-          !highestPriority ||
-          fetchTypePriority[itemPriority] > fetchTypePriority[highestPriority]
-        ) {
-          highestPriority = itemPriority;
+        const pendingFieldPriorities =
+          itemPendingInvalidationFields.get(itemKey);
+
+        // Adopt only the priorities owed to the fields this hook actually
+        // requests — a leftover obligation on an undisplayed field must not
+        // escalate this hook's refetch. Fields without a tracked priority
+        // (e.g. adopted from another tab) contribute nothing; callers treat
+        // an undefined result as an immediate refetch.
+        const fieldsToCheck = requestedFields
+          ? requestedFields.filter((field) =>
+              unresolvedInvalidationFields.includes(field),
+            )
+          : unresolvedInvalidationFields;
+        for (const field of fieldsToCheck) {
+          const fieldPriority = pendingFieldPriorities?.get(field);
+          if (fieldPriority) {
+            highestPriority = higherFetchType(highestPriority, fieldPriority);
+          }
+        }
+
+        if (fullInvalidationPriority !== undefined) {
+          // The marker owes every field not reloaded since the full
+          // invalidation and without its own (superseding) field entry.
+          const owedByMarker = requestedFields
+            ? requestedFields.some(
+                (field) =>
+                  !(loadedFields?.includes(field) ?? false) &&
+                  !pendingFieldPriorities?.has(field),
+              )
+            : true;
+          if (owedByMarker) {
+            highestPriority = higherFetchType(
+              highestPriority,
+              fullInvalidationPriority,
+            );
+          }
         }
       }
 
@@ -461,7 +485,7 @@ export function useMultipleListQueries<
     },
     [
       getUnresolvedPendingInvalidationFields,
-      itemFieldInvalidationPriorities,
+      itemPendingInvalidationFields,
       itemsPendingFullInvalidation,
       store,
     ],
@@ -1626,7 +1650,6 @@ export function useMultipleListQueries<
     partialResources,
     autoFetchSignals,
     automaticRetryState,
-    itemFieldInvalidationPriorities,
     itemPendingInvalidationFields,
     itemsPendingFullInvalidation,
     getHighestPendingInvalidationPriority,

--- a/src/persistentStorage/asyncStorageAdapter.ts
+++ b/src/persistentStorage/asyncStorageAdapter.ts
@@ -28,6 +28,7 @@ import {
 import { getDefaultMaxBytesForScope } from './persistentStorageDefaults';
 import { logPersistentStorageQuotaCleanup } from './quotaDebug';
 import { scheduleInitialMaintenanceCleanup } from './scheduleIdleCleanup';
+import { getOfflineSessionStatusStorageKey } from './storageEntryPrefixes';
 import type {
   AsyncStorageAdapter,
   AsyncStorageDiscoveredScope,
@@ -99,7 +100,7 @@ function isSessionOfflineInLocalStorage(sessionKey: string): boolean {
 
   try {
     const statusEntry = parseCompactLocalStorageEntry(
-      localStorage.getItem(`tsdf.${sessionKey}._o_.s`),
+      localStorage.getItem(getOfflineSessionStatusStorageKey(sessionKey)),
     );
     const rawStatus = statusEntry?.value.d ?? null;
     return isOfflineModeStatusValue(rawStatus);

--- a/src/persistentStorage/localStorageMetadata.ts
+++ b/src/persistentStorage/localStorageMetadata.ts
@@ -21,6 +21,17 @@ import {
   getSerializedStringSize,
   isQuotaExceededError,
 } from './persistenceUtils';
+import {
+  COLLECTION_STORAGE_ENTRY_PREFIX,
+  getOfflineSessionStatusStorageKey,
+  LIST_QUERY_ITEM_STORAGE_ENTRY_PREFIX,
+  LIST_QUERY_QUERY_STORAGE_ENTRY_PREFIX,
+  OFFLINE_CONFLICT_STORAGE_ENTRY_PREFIX,
+  OFFLINE_ENTITY_STORAGE_ENTRY_PREFIX,
+  OFFLINE_QUEUE_STORAGE_ENTRY_PREFIX,
+  OFFLINE_ROOT_STORE_NAME,
+  OFFLINE_SESSION_STATUS_STORE_NAME,
+} from './storageEntryPrefixes';
 
 const METADATA_KEY_PREFIX = 'tsdf._m.';
 const GLOBAL_MAINTENANCE_KEY = `${METADATA_KEY_PREFIX}g`;
@@ -99,6 +110,66 @@ export function isLocalStorageQuotaWritesDisabled(): boolean {
 }
 
 /**
+ * Keys written by the currently running locked mutation. When a later write
+ * of the same mutation hits the quota, these keys must not be evicted by the
+ * recovery: a fresh payload is not referenced by any manifest until the
+ * (possibly deferred) manifest write lands, so the orphan-eviction pass would
+ * otherwise delete the very data the mutation just persisted.
+ */
+const inFlightMutationWrittenKeys = new Set<string>();
+let inFlightMutationDepth = 0;
+
+/**
+ * Runs a locked `localStorage` mutation while tracking every key it writes,
+ * so a quota recovery triggered mid-mutation never evicts them.
+ */
+export async function trackManagedLocalStorageMutationWrites<T>(
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  inFlightMutationDepth++;
+  try {
+    return await callback();
+  } finally {
+    inFlightMutationDepth--;
+    if (inFlightMutationDepth === 0) inFlightMutationWrittenKeys.clear();
+  }
+}
+
+/**
+ * Terminal quota-disable error raised on a code path with no
+ * `onPersistentStorageError` to report it to (e.g. a deferred manifest
+ * flush). It is stashed here and delivered by the next persistence operation
+ * that hits the quota-writes-disabled guard, preserving the "exactly one
+ * error reaches the app" invariant.
+ */
+let pendingQuotaWritesDisabledError: unknown = null;
+
+export function takePendingQuotaWritesDisabledError(): unknown {
+  const error = pendingQuotaWritesDisabledError;
+  pendingQuotaWritesDisabledError = null;
+  return error;
+}
+
+/**
+ * Error sink for background persistence work (idle flushes, scheduled
+ * removals) that has no caller to propagate errors to. The terminal
+ * quota-disable error is stashed for later delivery through
+ * `onPersistentStorageError`; anything else is only logged, since a dropped
+ * background write self-heals via maintenance sweeps.
+ */
+export function handleManagedLocalStorageBackgroundError(error: unknown): void {
+  // while writes are disabled, `setManagedLocalStorageItemWithQuotaRecovery`
+  // returns false without throwing, so an error caught with the flag set can
+  // only be the terminal disable error itself
+  if (managedLocalStorageQuotaWritesDisabled) {
+    pendingQuotaWritesDisabledError = error;
+    return;
+  }
+
+  console.error(error);
+}
+
+/**
  * Writes to `localStorage`, recovering from `QuotaExceededError` by evicting
  * TSDF-managed entries: first the least recently used half of the evictable
  * bytes, then everything unprotected. If the write still fails, persistence
@@ -116,6 +187,7 @@ export function setManagedLocalStorageItemWithQuotaRecovery(
 
   try {
     localStorage.setItem(key, value);
+    if (inFlightMutationDepth > 0) inFlightMutationWrittenKeys.add(key);
     return true;
   } catch (error) {
     if (
@@ -132,6 +204,7 @@ export function setManagedLocalStorageItemWithQuotaRecovery(
 
         try {
           localStorage.setItem(key, value);
+          if (inFlightMutationDepth > 0) inFlightMutationWrittenKeys.add(key);
           return true;
         } catch (retryError) {
           if (!isQuotaExceededError(retryError)) throw retryError;
@@ -204,6 +277,8 @@ function runManagedLocalStorageQuotaEviction(
             continue;
           }
           if (isManagedLocalStorageEntryOfflineProtected(entry.meta)) continue;
+          // never evict what the current mutation just wrote
+          if (inFlightMutationWrittenKeys.has(payloadKey)) continue;
 
           candidates.push({
             payloadKey,
@@ -232,6 +307,8 @@ function runManagedLocalStorageQuotaEviction(
     if (manifestOwnedPayloadKeys.has(key) || isOfflineRelatedPayloadKey(key)) {
       continue;
     }
+    // never evict what the current mutation just wrote
+    if (inFlightMutationWrittenKeys.has(key)) continue;
 
     const entry = readCompactListQueryEntry(key, io);
     if (entry?.offlineProtected === true) continue;
@@ -250,6 +327,10 @@ function runManagedLocalStorageQuotaEviction(
     if (manifestOwnedPayloadKeys.has(key) || isOfflineRelatedPayloadKey(key)) {
       continue;
     }
+    // a freshly written payload looks like an orphan until its (possibly
+    // deferred) manifest write lands — never evict the in-flight mutation's
+    // own writes
+    if (inFlightMutationWrittenKeys.has(key)) continue;
 
     // payloads not tracked by any manifest are orphans: evict them first
     candidates.push({
@@ -311,6 +392,22 @@ function runManagedLocalStorageQuotaEviction(
   }
 }
 
+/** Matches every payload key under the reserved `tsdf.<sessionKey>._o_.*` root. */
+const OFFLINE_ROOT_KEY_INFIX = `.${OFFLINE_ROOT_STORE_NAME}.`;
+const OFFLINE_SESSION_STATUS_KEY_SUFFIX = `.${OFFLINE_SESSION_STATUS_STORE_NAME}`;
+
+const OFFLINE_NAMESPACE_STORAGE_PREFIX_SUFFIXES = [
+  `.${OFFLINE_QUEUE_STORAGE_ENTRY_PREFIX}.`,
+  `.${OFFLINE_CONFLICT_STORAGE_ENTRY_PREFIX}.`,
+  `.${OFFLINE_ENTITY_STORAGE_ENTRY_PREFIX}.`,
+];
+
+function isOfflineNamespaceStoragePrefix(storagePrefix: string): boolean {
+  return OFFLINE_NAMESPACE_STORAGE_PREFIX_SUFFIXES.some((suffix) =>
+    storagePrefix.endsWith(suffix),
+  );
+}
+
 type ManagedLocalStorageManifestLocation =
   | { kind: 'single'; manifestKey: string; payloadKey: string }
   | { kind: 'namespace'; manifestKey: string; storagePrefix: string };
@@ -319,18 +416,14 @@ function isOfflineOwnedManifestLocation(
   manifestLocation: ManagedLocalStorageManifestLocation,
 ): boolean {
   if (manifestLocation.kind === 'single') {
-    return manifestLocation.payloadKey.includes('._o_.');
+    return manifestLocation.payloadKey.includes(OFFLINE_ROOT_KEY_INFIX);
   }
 
-  return (
-    manifestLocation.storagePrefix.endsWith('.oq.') ||
-    manifestLocation.storagePrefix.endsWith('.oc.') ||
-    manifestLocation.storagePrefix.endsWith('.oe.')
-  );
+  return isOfflineNamespaceStoragePrefix(manifestLocation.storagePrefix);
 }
 
 function isOfflineRelatedPayloadKey(payloadKey: string): boolean {
-  return payloadKey.includes('._o_.');
+  return payloadKey.includes(OFFLINE_ROOT_KEY_INFIX);
 }
 
 export function getManagedLocalStorageRuntimeConfig(): ManagedLocalStorageRuntimeConfig {
@@ -430,13 +523,13 @@ function normalizeRootIdentityValue(value: string): string {
 }
 
 const COMPRESSED_NAMESPACE_ROOT_SUFFIXES = [
-  ['.ci.', '.ci'],
-  ['.li.', '.li'],
-  ['.lq.', '.lq'],
-  ['.oq.', '.oq'],
-  ['.oc.', '.oc'],
-  ['.oe.', '.oe'],
-] as const;
+  COLLECTION_STORAGE_ENTRY_PREFIX,
+  LIST_QUERY_ITEM_STORAGE_ENTRY_PREFIX,
+  LIST_QUERY_QUERY_STORAGE_ENTRY_PREFIX,
+  OFFLINE_QUEUE_STORAGE_ENTRY_PREFIX,
+  OFFLINE_CONFLICT_STORAGE_ENTRY_PREFIX,
+  OFFLINE_ENTITY_STORAGE_ENTRY_PREFIX,
+].map((prefix) => [`.${prefix}.`, `.${prefix}`] as const);
 
 function compactNamespaceRootIdentityValue(storagePrefix: string): string {
   const normalized = normalizeRootIdentityValue(storagePrefix);
@@ -1237,7 +1330,7 @@ function isSessionOfflineDuringManagedCleanup(
   io: ManagedLocalStorageIo,
 ): boolean {
   const statusEntry = parseCompactLocalStorageEntry(
-    io.getItem(`tsdf.${sessionKey}._o_.s`),
+    io.getItem(getOfflineSessionStatusStorageKey(sessionKey)),
   );
   const rawStatus: unknown = statusEntry?.value;
   const status =
@@ -1403,17 +1496,14 @@ function collectManagedLocalStorageSweepTargets(io: ManagedLocalStorageIo): {
     const manifestLocation = parseManagedLocalStorageManifestKey(key);
     if (
       manifestLocation?.kind === 'single' &&
-      manifestLocation.payloadKey.includes('._o_.') &&
-      !manifestLocation.payloadKey.endsWith('._o_.s')
+      isOfflinePayloadKey(manifestLocation.payloadKey)
     ) {
       return false;
     }
 
     if (
       manifestLocation?.kind === 'namespace' &&
-      (manifestLocation.storagePrefix.endsWith('.oq.') ||
-        manifestLocation.storagePrefix.endsWith('.oc.') ||
-        manifestLocation.storagePrefix.endsWith('.oe.'))
+      isOfflineNamespaceStoragePrefix(manifestLocation.storagePrefix)
     ) {
       return false;
     }
@@ -1425,8 +1515,15 @@ function collectManagedLocalStorageSweepTargets(io: ManagedLocalStorageIo): {
   return { manifestKeys, knownKeys };
 }
 
+/**
+ * Offline-owned payload keys, excluding the session status entry (which is
+ * cleaned up like regular data so stale sessions do not pin it forever).
+ */
 function isOfflinePayloadKey(payloadKey: string): boolean {
-  return payloadKey.includes('._o_.') && !payloadKey.endsWith('._o_.s');
+  return (
+    payloadKey.includes(OFFLINE_ROOT_KEY_INFIX) &&
+    !payloadKey.endsWith(OFFLINE_SESSION_STATUS_KEY_SUFFIX)
+  );
 }
 
 function runGenericCleanupForManifest(
@@ -1452,7 +1549,7 @@ function runGenericCleanupForManifest(
   const now = Date.now();
   const sessionKey = getSessionKeyForManifestLocation(manifestLocation);
   const offlineStatusKey =
-    sessionKey === null ? null : `tsdf.${sessionKey}._o_.s`;
+    sessionKey === null ? null : getOfflineSessionStatusStorageKey(sessionKey);
   const skipExpiration =
     sessionKey !== null &&
     offlineStatusKey !== null &&
@@ -1542,6 +1639,9 @@ export function resetManagedLocalStorageState(): void {
   maintenanceCallbacks.clear();
   managedLocalStorageQuotaWritesDisabled = false;
   managedLocalStorageQuotaRecoveryActive = false;
+  pendingQuotaWritesDisabledError = null;
+  inFlightMutationWrittenKeys.clear();
+  inFlightMutationDepth = 0;
   managedLocalStorageRuntimeConfig = {
     ...defaultManagedLocalStorageRuntimeConfig,
   };

--- a/src/persistentStorage/offline/sessionCoordinator.ts
+++ b/src/persistentStorage/offline/sessionCoordinator.ts
@@ -34,6 +34,10 @@ import {
   readProtectedStorageKeys,
   type PersistentStorageHandle,
 } from '../persistentStorageManager';
+import {
+  getOfflineSessionStatusStorageKey,
+  OFFLINE_SESSION_STATUS_STORE_NAME,
+} from '../storageEntryPrefixes';
 import type { StorageAdapter } from '../types';
 import {
   clearSessionProtectedKeysSnapshot,
@@ -157,10 +161,6 @@ export function createDefaultStatus(sessionKey: string): GlobalOfflineStatus {
   };
 }
 
-function getOfflineStatusStorageKey(sessionKey: string): string {
-  return `tsdf.${sessionKey}._o_.s`;
-}
-
 function normalizeCompactModeState(value: { e?: 1; a?: 1 } | undefined): {
   enabled: boolean;
   active: boolean;
@@ -239,7 +239,7 @@ function readPersistedLocalSessionSnapshot(
 
   try {
     const entry = parseCompactLocalStorageEntry(
-      localStorage.getItem(getOfflineStatusStorageKey(sessionKey)),
+      localStorage.getItem(getOfflineSessionStatusStorageKey(sessionKey)),
     );
     if (!entry) return null;
 
@@ -534,7 +534,7 @@ function createSessionPersistenceHandle(
 
   return createPersistentStorageHandle<PersistedLocalSessionSnapshot>(
     {
-      storeName: '_o_.s',
+      storeName: OFFLINE_SESSION_STATUS_STORE_NAME,
       adapter: 'local-sync',
       getSessionKey: () => sessionKey,
       onPersistentStorageError,

--- a/src/persistentStorage/persistentStorageManager.ts
+++ b/src/persistentStorage/persistentStorageManager.ts
@@ -17,10 +17,12 @@ import {
 import { DOCUMENT_PERSISTED_ENTRY_KEY } from './documentEntryKey';
 import {
   getManagedLocalStorageRuntimeConfig,
+  handleManagedLocalStorageBackgroundError,
   isLocalStorageQuotaWritesDisabled,
   isManagedLocalStorageEntryOfflineProtected,
   resetManagedLocalStorageState,
   setManagedLocalStorageEntryOfflineProtected,
+  takePendingQuotaWritesDisabledError,
 } from './localStorageMetadata';
 import { getSessionProtectedKeysSnapshot } from './offline/sessionProtectionRegistry';
 import type { OfflineNetworkModeConfig } from './offline/types';
@@ -34,6 +36,7 @@ import {
   localPersistentStorage,
   type LocalStorageMetadataOptions,
 } from './storageAdapter';
+import { OFFLINE_SESSION_STATUS_STORE_NAME } from './storageEntryPrefixes';
 import type {
   AsyncStorageAdapter,
   AsyncStorageMetadataOrder,
@@ -41,6 +44,7 @@ import type {
   AsyncStorageNamespaceStaticPolicy,
   AsyncStorageTouchMode,
   PersistentStorageBaseConfig,
+  PersistentStorageErrorHandler,
   StorageAdapter,
   StorageCacheEntry,
 } from './types';
@@ -273,6 +277,21 @@ async function runLocalStorageMutation<T>(
   return localPersistentStorage.runLocked(callback);
 }
 
+/**
+ * Delivers the terminal quota-disable error to the app when it was raised on
+ * a background code path with no error handler (e.g. a deferred manifest
+ * flush). Only consumes the stashed error when a handler exists, so the
+ * first store with an `onPersistentStorageError` reports it exactly once.
+ */
+function deliverPendingQuotaWritesDisabledError(
+  onPersistentStorageError: PersistentStorageErrorHandler | null | undefined,
+): void {
+  if (!onPersistentStorageError) return;
+
+  const pendingError = takePendingQuotaWritesDisabledError();
+  if (pendingError !== null) onPersistentStorageError(pendingError);
+}
+
 export function recordLocalStorageTouch(key: string, timestamp: number): void {
   localStorageTouchTimestamps.set(key, timestamp);
 }
@@ -334,9 +353,9 @@ export function scheduleLocalStorageRemoval(
   options: LocalStorageMetadataOptions | undefined,
 ): void {
   scheduleIdleCleanup(() => {
-    void runLocalStorageMutation(() => {
+    runLocalStorageMutation(() => {
       localPersistentStorage.remove(key, options);
-    });
+    }).catch(handleManagedLocalStorageBackgroundError);
   });
 }
 
@@ -732,6 +751,7 @@ export function createPersistentStorageHandle<T>(
         return;
       }
       if (isLocalStorageQuotaWritesDisabled()) {
+        deliverPendingQuotaWritesDisabledError(onPersistentStorageError);
         if (import.meta.env.DEV) {
           logPersistentStorageOperation(
             withPersistentStorageDebugKey(debugContext, key),
@@ -1131,6 +1151,23 @@ export function createPersistentStorageNamespaceHandle<
         return;
       }
       if (isLocalStorageQuotaWritesDisabled()) {
+        deliverPendingQuotaWritesDisabledError(onPersistentStorageError);
+
+        // removals must still go through: they free space instead of
+        // consuming quota, and skipping them would resurrect deleted items
+        // from stale persisted entries on the next load
+        const removes = args.removes ?? [];
+        if (removes.length > 0) {
+          await runLocalStorageMutation(() => {
+            for (const entryKey of removes) {
+              localPersistentStorage.remove(`${prefix}${entryKey}`, {
+                metadata: 'namespace',
+                namespacePrefix: prefix,
+              });
+            }
+          });
+        }
+
         if (import.meta.env.DEV) {
           logPersistentStorageOperation(
             debugContext,
@@ -2207,7 +2244,10 @@ export async function clearSessionStorage(
   } else {
     await adapter.clearSession(sessionKey);
     await runLocalStorageMutation(() => {
-      const sessionOfflineStatusKey = getStorageKey(sessionKey, '_o_.s');
+      const sessionOfflineStatusKey = getStorageKey(
+        sessionKey,
+        OFFLINE_SESSION_STATUS_STORE_NAME,
+      );
       localPersistentStorage.clearManifest(
         localPersistentStorage.getManifestKeyForSingle(sessionOfflineStatusKey),
       );

--- a/src/persistentStorage/storageAdapter.ts
+++ b/src/persistentStorage/storageAdapter.ts
@@ -3,6 +3,9 @@ import {
   clearManagedLocalStorageManifest,
   clearManagedLocalStorageSession,
   directManagedLocalStorageIo,
+  handleManagedLocalStorageBackgroundError,
+  isLocalStorageQuotaWritesDisabled,
+  trackManagedLocalStorageMutationWrites,
   getManagedLocalStorageManifestKeyForPrefix,
   getManagedLocalStorageManifestKeyForSingle,
   listManagedLocalStorageKeysSync,
@@ -72,9 +75,17 @@ function createCachedManagedLocalStorageIo(): {
         // runs from idle callbacks / deactivate, so it must not throw; a
         // dropped manifest write self-heals via maintenance sweeps
         try {
-          setManagedLocalStorageItemWithQuotaRecovery(key, value, io);
+          const written = setManagedLocalStorageItemWithQuotaRecovery(
+            key,
+            value,
+            io,
+          );
+          // a dropped write must not leave a phantom cached value that later
+          // reads in the same locked scope would mistake for stored data
+          if (!written) cache.delete(key);
         } catch (error) {
-          console.error(error);
+          cache.delete(key);
+          handleManagedLocalStorageBackgroundError(error);
         }
       }
     }
@@ -154,6 +165,11 @@ function createCachedManagedLocalStorageIo(): {
         return;
       }
 
+      // while quota writes are disabled the deferred flush would drop the
+      // write anyway, so don't queue it (or cache a phantom value); removals
+      // still go through since they free space instead of consuming quota
+      if (value !== null && isLocalStorageQuotaWritesDisabled()) return;
+
       cache.set(key, value);
       pendingManifestWrites.set(key, value);
       schedulePendingManifestFlush();
@@ -208,11 +224,13 @@ async function runWithManagedLocalStorageLock<T>(
 
   if (lockManager === null) {
     warnIfNavigatorLockUnavailable(MANAGED_LOCAL_STORAGE_LOCK_WARNING);
-    return await callback();
+    return await trackManagedLocalStorageMutationWrites(callback);
   }
 
   return lockManager.request(MANAGED_LOCAL_STORAGE_LOCK_NAME, () =>
-    withManagedLocalStorageIoCache(callback),
+    trackManagedLocalStorageMutationWrites(() =>
+      withManagedLocalStorageIoCache(callback),
+    ),
   );
 }
 

--- a/src/persistentStorage/storageEntryPrefixes.ts
+++ b/src/persistentStorage/storageEntryPrefixes.ts
@@ -4,3 +4,18 @@ export const LIST_QUERY_QUERY_STORAGE_ENTRY_PREFIX = 'lq';
 export const OFFLINE_QUEUE_STORAGE_ENTRY_PREFIX = 'oq';
 export const OFFLINE_CONFLICT_STORAGE_ENTRY_PREFIX = 'oc';
 export const OFFLINE_ENTITY_STORAGE_ENTRY_PREFIX = 'oe';
+
+/**
+ * Store-name root reserved for offline coordination data. Every payload key
+ * of the form `tsdf.<sessionKey>._o_.<name>` belongs to the offline runtime
+ * and is never evicted by quota recovery or expired by generic cleanup.
+ */
+export const OFFLINE_ROOT_STORE_NAME = '_o_';
+
+/** Store name of the per-session offline mode status entry. */
+export const OFFLINE_SESSION_STATUS_STORE_NAME = '_o_.s';
+
+/** Builds the `localStorage` key holding a session's offline mode status. */
+export function getOfflineSessionStatusStorageKey(sessionKey: string): string {
+  return `tsdf.${sessionKey}.${OFFLINE_SESSION_STATUS_STORE_NAME}`;
+}

--- a/src/utils/storeShared.ts
+++ b/src/utils/storeShared.ts
@@ -111,6 +111,14 @@ export const fetchTypePriority: Record<FetchType, number> = {
   highPriority: 3,
 };
 
+/** Returns the higher-priority fetch type, treating a missing `a` as lower. */
+export function higherFetchType(
+  a: FetchType | null | undefined,
+  b: FetchType,
+): FetchType {
+  return a && fetchTypePriority[a] > fetchTypePriority[b] ? a : b;
+}
+
 /** Result error returned when a debounced or canceled mutation never runs. */
 export type MutationSkipped = {
   /** Stable discriminator for skipped mutations. */

--- a/tests/basic-functionality/list-query-store.test.ts
+++ b/tests/basic-functionality/list-query-store.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { GET_ALL } from '../../src/main';
 import { StoreFetchError } from '../../src/utils/storeShared';
@@ -742,6 +742,52 @@ describe('fetch query', () => {
     await flushAllTimers();
     expect(env.getItemQueryState('users||1')?.status).toBe('success');
     expect(env.apiStore.getItemState('users||1')).toBeDefined();
+  });
+
+  test('standalone item with a mutation in progress is protected from maxItems eviction on list-only stores', async () => {
+    const env = createListQueryStoreTestEnv(
+      {
+        users: range(1, 3).map((id) => ({ id, name: `User ${id}` })),
+        orders: range(1, 3).map((id) => ({ id, name: `Order ${id}` })),
+      },
+      // list-only store: without a fetchItemFn there is no item scheduler, so
+      // an in-flight mutation is the only signal protecting a standalone item
+      { maxItems: 3, disableFetchItemFn: true },
+    );
+
+    // create a standalone item that is not referenced by any query — it will
+    // be the eviction candidate under item pressure
+    act(() => {
+      env.apiStore.addItemToState('orders||1', { id: 1, name: 'Order 1' });
+    });
+
+    // start a slow mutation targeting the standalone item (with an optimistic
+    // update so the store reflects the new value)...
+    const mutation = env.performClientItemUpdateAction(
+      'orders||1',
+      { name: 'Order 1 updated' },
+      { duration: 5000, withOptimisticUpdate: true },
+    );
+
+    // ...and exceed maxItems while the mutation is still in flight: the list
+    // fetch loads 3 items, pushing the total to 4
+    env.scheduleFetch('highPriority', { tableId: 'users' });
+
+    // enough time for the list fetch to settle and idle eviction to run, but
+    // not enough for the slow mutation to settle
+    await advanceTime(4000);
+
+    // orders||1 is the standalone eviction candidate but its in-flight
+    // mutation protects it from being evicted (which would silently discard
+    // the optimistic update and the mutation result)
+    expect(env.apiStore.getItemState('orders||1')).toBeDefined();
+
+    // the mutation settles normally without the item being lost
+    await flushAllTimers();
+    await mutation;
+    expect(env.apiStore.getItemState('orders||1')?.name).toBe(
+      'Order 1 updated',
+    );
   });
 });
 

--- a/tests/hooks/collection-hooks.test.tsx
+++ b/tests/hooks/collection-hooks.test.tsx
@@ -1236,6 +1236,59 @@ test('an item that never loaded fetches immediately on remount after a realtime 
   expect(remount.result.current.data?.value.title).toBe('updated todo');
 });
 
+test('a mounted item that never loaded fetches immediately on a realtime invalidation', async () => {
+  // Same scenario as the remount test above, but the hook STAYS mounted: the
+  // invalidation is handled by the mounted hook's invalidation event handler
+  // instead of the mount effect. Batch fetch mode shares one scheduler — and
+  // therefore one realtime throttle timing — across all items of a batch key,
+  // so a successful fetch of one item can throttle realtime-priority fetches
+  // of a different, never-loaded item.
+  const env = createCollectionStoreTestEnv<Todo>(
+    { '1': defaultTodo, '2': { title: 'todo 2', completed: false } },
+    {
+      useBatchFetch: true,
+      usesRealTimeUpdates: true,
+      dynamicRealtimeThrottleMs() {
+        return 5000;
+      },
+    },
+  );
+
+  // Item 1 loads successfully, giving the shared batch scheduler the fetch
+  // history that activates the realtime throttle.
+  const item1 = renderHook(() => env.apiStore.useItem('1'));
+  await flushAllTimers();
+  expect(item1.result.current.status).toBe('success');
+
+  // Item 2's first-ever fetch fails, leaving its (still mounted) hook in an
+  // error state with nothing displayable.
+  env.serverTable.setNextFetchError('2', 'network error');
+  const item2 = renderHook(() => env.apiStore.useItem('2'));
+  // Advance just past the fetch duration (~800ms) — `flushAllTimers` would
+  // also run pending retry timers and mask the error state.
+  await advanceTime(900);
+  expect(item2.result.current.status).toBe('error');
+
+  // A realtime record-change event invalidates item 2 while its hook is
+  // still mounted — the mounted-hook invalidation handler schedules the
+  // refetch at the event's `realtimeUpdate` priority.
+  await advanceTime(100);
+  act(() => {
+    env.serverTable.setItem(
+      '2',
+      { title: 'updated todo', completed: true },
+      { triggerRTUEvent: true },
+    );
+  });
+
+  // Item 2 never loaded, so there is nothing to show — the fetch must run
+  // immediately instead of waiting out the realtime throttle (5s) attached
+  // to the invalidation's priority.
+  await advanceTime(1000);
+  expect(item2.result.current.status).toBe('success');
+  expect(item2.result.current.data?.value.title).toBe('updated todo');
+});
+
 test('fetch error then mount component without error', async () => {
   const env = createCollectionStoreTestEnv<Todo>({
     '1': defaultTodo,

--- a/tests/hooks/list-query-hooks-mutations.test.tsx
+++ b/tests/hooks/list-query-hooks-mutations.test.tsx
@@ -766,3 +766,52 @@ test('mount component after a RTU', async () => {
     "
   `);
 });
+
+test('a mounted item that never loaded fetches immediately on a realtime invalidation', async () => {
+  // Batch fetch mode shares one scheduler — and therefore one realtime
+  // throttle timing — across all items of the batch key, so a successful
+  // fetch of one item can throttle realtime-priority fetches of a different,
+  // never-loaded item.
+  const env = createListQueryStoreTestEnv(initialServerData, {
+    useBatchFetch: true,
+    usesRealTimeUpdates: true,
+    dynamicRealtimeThrottleMs() {
+      return 5000;
+    },
+  });
+
+  // Item 1 loads successfully, giving the shared batch scheduler the fetch
+  // history that activates the realtime throttle.
+  const item1 = renderHook(() => env.apiStore.useItem('users||1'));
+  await flushAllTimers();
+  expect(item1.result.current.status).toBe('success');
+
+  // Item 2's first-ever fetch fails (single-item batches fall back to the
+  // per-item fetch), leaving its (still mounted) hook in an error state with
+  // nothing displayable.
+  env.serverTable.setNextFetchError('users||2', 'network error');
+  const item2 = renderHook(() => env.apiStore.useItem('users||2'));
+  // Advance just past the fetch duration (~800ms) — `flushAllTimers` would
+  // also run pending retry timers and mask the error state.
+  await advanceTime(900);
+  expect(item2.result.current.status).toBe('error');
+
+  // A realtime record-change event invalidates item 2 while its hook is
+  // still mounted — the mounted-hook invalidation handler schedules the
+  // refetch at the event's `realtimeUpdate` priority.
+  await advanceTime(100);
+  act(() => {
+    env.serverTable.setItem(
+      'users||2',
+      { id: 2, name: 'User 2 updated' },
+      { triggerRTUEvent: true },
+    );
+  });
+
+  // Item 2 never loaded, so there is nothing to show — the fetch must run
+  // immediately instead of waiting out the realtime throttle (5s) attached
+  // to the invalidation's priority.
+  await advanceTime(1000);
+  expect(item2.result.current.status).toBe('success');
+  expect(item2.result.current.data?.name).toBe('User 2 updated');
+});

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -2094,6 +2094,148 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
     expect(nameHook.result.current.data?.name).toBe('New User 1');
     expect(addressHook.result.current.data?.address).toBe('New Address 1');
   });
+
+  test("a full high-priority invalidation of a '*'-loaded item does not disable throttling of later realtime invalidations", async () => {
+    const env = createRealtimeEnv();
+
+    // A detail view loaded the full item at some point (fields: '*'), then
+    // closed — no '*' hook stays mounted afterwards.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A list grid stays mounted with a fixed set of fields.
+    renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'address'] },
+      ),
+    );
+    await flushAllTimers();
+
+    // Idle long enough for the realtime throttle window to pass.
+    await advanceTime(2_000);
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    // After a mutation the app fully invalidates the mutated record at
+    // highPriority — the list refetches immediately, which is expected.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+      });
+    });
+    // The refetch (800ms) settles; we are now 200ms after it — well inside
+    // the realtime throttle window of that fetch.
+    await advanceTime(1_000);
+    expect(env.serverTable.getRequestHistory('list').length).toBe(1);
+
+    env.addTimelineComments('beforeNextAction', ['realtime event arrives']);
+
+    // A realtime record-change event arrives shortly after (e.g. an
+    // automation side effect). The high-priority refetch only reloaded the
+    // list's fields, so the item's '*' full-invalidation marker is still
+    // unresolved — that leftover obligation must NOT escalate this realtime
+    // invalidation to an immediate high-priority refetch.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: () => true,
+        itemPayload: () => true,
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // The refetch must stay delayed until the throttle boundary — no
+    // cancellation of the scheduled realtime fetch, no immediate fetch.
+    await flushAllTimers();
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      3.62s | -- timeline-cleared
+      3.63s | 🟡 >list-fetch-started
+      4.43s | 🟡 <list-fetch-finished (value: {"count":5})
+      4.62s | -- realtime event arrives
+      .     | rt-fetch-scheduled (delay: 810ms)
+      5.43s | scheduled-rt-fetch-started
+      5.44s | 🟢 >list-fetch-started
+      6.24s | 🟢 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+  });
+
+  test('leftover stale fields from a wider-loaded item do not disable throttling of later realtime invalidations', async () => {
+    const env = createRealtimeEnv();
+
+    // The item was loaded with MORE named fields than the list displays
+    // (e.g. an expanded row view), then that view closed.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: ['name', 'address', 'age', 'country'],
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A list grid stays mounted with a narrower set of fields.
+    renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'address'] },
+      ),
+    );
+    await flushAllTimers();
+
+    // Idle long enough for the realtime throttle window to pass.
+    await advanceTime(2_000);
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    // Full high-priority invalidation of the record: every loaded field goes
+    // stale, but the immediate list refetch only reloads the list's fields —
+    // 'age' and 'country' remain pending at highPriority with no mounted
+    // hook to ever refetch them.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+      });
+    });
+    await advanceTime(1_000);
+    expect(env.serverTable.getRequestHistory('list').length).toBe(1);
+
+    env.addTimelineComments('beforeNextAction', ['realtime event arrives']);
+
+    // A realtime record-change event arrives inside the throttle window. The
+    // leftover high-priority fields ('age'/'country') are not displayed by
+    // any hook — they must not escalate the list's realtime refetch.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: () => true,
+        itemPayload: () => true,
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // The refetch must stay delayed until the throttle boundary — no
+    // cancellation of the scheduled realtime fetch, no immediate fetch.
+    await flushAllTimers();
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      3.62s | -- timeline-cleared
+      3.63s | 🟡 >list-fetch-started
+      4.43s | 🟡 <list-fetch-finished (value: {"count":5})
+      4.62s | -- realtime event arrives
+      .     | rt-fetch-scheduled (delay: 810ms)
+      5.43s | scheduled-rt-fetch-started
+      5.44s | 🟢 >list-fetch-started
+      6.24s | 🟢 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+  });
 });
 
 describe('partial resources: query invalidations with multiple same-payload hooks', () => {

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -2320,6 +2320,88 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
       "
     `);
   });
+
+  test("fields reloaded since a high-priority '*'-vouched marker stay throttled on a later realtime full invalidation", async () => {
+    // Same failure mode as the tests above, but with an `inferFields` that
+    // vouches '*' once the item snapshot is complete (the docs' shape for
+    // manually inserted / persisted rows). With a complete snapshot in state,
+    // EVERY full invalidation takes the '*' marker path — including ones on
+    // an item whose tracked `itemLoadedFields` is a narrow array. Fields
+    // reloaded since a high-priority marker are owed only at the incoming
+    // priority, and must not fall back to the marker's high priority once
+    // `itemLoadedFields` is cleared.
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: starInferFieldsConfig,
+      usesRealTimeUpdates: true,
+      dynamicRealtimeThrottleMs: () => 1000,
+    });
+
+    // The item is fully loaded ('*') via a detail view, then that view
+    // closes.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A narrow hook (e.g. a kanban card) stays mounted.
+    renderHook(() => env.apiStore.useItem('users||1', { fields: ['name'] }));
+    await flushAllTimers();
+
+    // Idle long enough for the realtime throttle window to pass.
+    await advanceTime(2_000);
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    // A full high-priority invalidation records the '*' marker; the mounted
+    // hook refetches 'name' immediately, which is expected. 'name' is now
+    // reloaded SINCE the high marker, but the marker itself survives (the
+    // item never returns to '*'-loaded).
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+      });
+    });
+    // The refetch (800ms) settles; we are now 200ms after it — well inside
+    // the realtime throttle window of that fetch.
+    await advanceTime(1_000);
+    expect(env.serverTable.getRequestHistory('item').length).toBe(1);
+
+    env.addTimelineComments('beforeNextAction', ['realtime event arrives']);
+
+    // A realtime record-change event arrives inside the throttle window. The
+    // snapshot is still complete, so this full invalidation also takes the
+    // '*' marker path. 'name' is owed only at `realtimeUpdate` — the
+    // leftover high-priority marker must not escalate its refetch to an
+    // immediate high-priority fetch.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // The refetch must stay delayed until the throttle boundary — no
+    // cancellation of the scheduled realtime fetch, no immediate fetch.
+    await flushAllTimers();
+    expect(env.timelineString).not.toContain('rt-fetch-cancelled');
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      2.81s | -- timeline-cleared
+      2.82s | 🟠 >fetch-started
+      3.62s | 🟠 <fetch-finished (value: {"name":"User 1"})
+      3.81s | -- realtime event arrives
+      .     | rt-fetch-scheduled (delay: 810ms)
+      4.62s | scheduled-rt-fetch-started
+      4.63s | 🟡 >fetch-started
+      5.43s | 🟡 <fetch-finished (value: {"name":"User 1"})
+      "
+    `);
+  });
 });
 
 describe('partial resources: query invalidations with multiple same-payload hooks', () => {

--- a/tests/list-query-features/list-query-partial-resources-regressions.test.ts
+++ b/tests/list-query-features/list-query-partial-resources-regressions.test.ts
@@ -2236,6 +2236,90 @@ describe('partial resources: realtime invalidations keep the scheduler throttle'
       "
     `);
   });
+
+  test("a leftover high-priority obligation on a '*'-loaded item's undisplayed field must not escalate a later realtime full invalidation", async () => {
+    const env = createRealtimeEnv();
+
+    // The item was fully loaded ('*') via a detail view (e.g. an edit form),
+    // then that view closed.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A list grid stays mounted with fields that do NOT include 'age'.
+    renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'address'] },
+      ),
+    );
+    await flushAllTimers();
+
+    // Idle long enough for the realtime throttle window to pass.
+    await advanceTime(2_000);
+    env.clearTimeline();
+    env.serverTable.clearFetchHistory();
+
+    // Per-field HIGH invalidation of 'age' — a field no mounted hook
+    // displays. The item is '*'-loaded, so this records a pending
+    // {age: highPriority} entry while `loadedFields` stays '*'. Nothing
+    // displays 'age', so no refetch happens and the obligation stays
+    // pending.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        fields: ['age'],
+        type: 'highPriority',
+      });
+    });
+
+    // A query-only high invalidation gives the realtime throttle a fresh
+    // baseline fetch (it does not touch item invalidation tracking).
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: { tableId: 'users' },
+        itemPayload: false,
+        type: 'highPriority',
+      });
+    });
+    await advanceTime(1_000);
+    expect(env.serverTable.getRequestHistory('list').length).toBe(1);
+
+    env.addTimelineComments('beforeNextAction', ['realtime event arrives']);
+
+    // A realtime record-change event arrives inside the throttle window.
+    // The leftover high-priority 'age' obligation must NOT fold into the
+    // item's full-invalidation marker and escalate the list's realtime
+    // refetch past the throttle.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: () => true,
+        itemPayload: () => true,
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // The refetch must stay delayed until the throttle boundary — no
+    // cancellation of the scheduled realtime fetch, no immediate fetch.
+    await flushAllTimers();
+    expect(env.timelineString).not.toContain('rt-fetch-cancelled');
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      3.62s | -- timeline-cleared
+      3.63s | 🟡 >list-fetch-started
+      4.43s | 🟡 <list-fetch-finished (value: {"count":5})
+      4.62s | -- realtime event arrives
+      .     | rt-fetch-scheduled (delay: 810ms)
+      5.43s | scheduled-rt-fetch-started
+      5.44s | 🟢 >list-fetch-started
+      6.24s | 🟢 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+  });
 });
 
 describe('partial resources: query invalidations with multiple same-payload hooks', () => {
@@ -2886,5 +2970,210 @@ describe('partial resources: a hook mounting after a realtime invalidation must 
             pos: { limit: 50, offset: 0 }
           returned_items: 5
       `);
+  });
+
+  test('a late-mounting hook requesting a field owed at high priority fetches immediately despite a later realtime invalidation', async () => {
+    const env = createRealtimeEnv();
+
+    // The item's fields load through a hook that then unmounts.
+    const firstMount = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name', 'age'] }),
+    );
+    await flushAllTimers();
+    firstMount.unmount();
+    env.clearTimeline();
+
+    // A high-priority per-field invalidation of 'age' arrives while no hook
+    // is mounted — the obligation stays pending at `highPriority`.
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        fields: ['age'],
+        type: 'highPriority',
+      });
+    });
+
+    // A later realtime full invalidation overwrites `refetchOnMount` with
+    // `realtimeUpdate` — but the per-field tracking still owes 'age' at
+    // `highPriority`.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // The server value changes; the cached age (10) is genuinely stale.
+    env.serverTable.updateItem('users||1', { age: 99 });
+
+    // A hook mounts requesting 'age': the field is owed at `highPriority`,
+    // so the mount fetch must run immediately instead of inheriting the
+    // throttled realtime priority from `refetchOnMount`.
+    await advanceTime(50);
+    const { result } = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['age'] }),
+    );
+
+    // An immediate fetch has finished by now (~1.77s); the throttled
+    // alternative would only start fetching at the throttle boundary.
+    await advanceTime(850);
+    expect(result.current.data?.age).toBe(99);
+
+    await flushAllTimers();
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | server-data-changed (value: {"age":99})
+      970ms | 🟠 >fetch-started
+      1.77s | 🟠 <fetch-finished (value: {"age":99})
+      "
+    `);
+  });
+
+  test('a late-mounting query hook displaying a field owed at high priority fetches immediately despite a later realtime invalidation', async () => {
+    const env = createRealtimeEnv();
+
+    // The list's fields load through a hook that then unmounts.
+    const firstMount = renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'age'] },
+      ),
+    );
+    await flushAllTimers();
+    firstMount.unmount();
+    env.clearTimeline();
+
+    // A high-priority per-field invalidation of 'age' on the items arrives
+    // while nothing is mounted.
+    await advanceTime(100);
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: (itemKey) => itemKey.startsWith('users||'),
+        fields: ['age'],
+        type: 'highPriority',
+      });
+    });
+
+    // A later realtime full invalidation overwrites the query's
+    // `refetchOnMount` with `realtimeUpdate` — but the items' per-field
+    // tracking still owes 'age' at `highPriority`.
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: { tableId: 'users' },
+        itemPayload: (itemKey) => itemKey.startsWith('users||'),
+        type: 'realtimeUpdate',
+      });
+    });
+
+    // The server value changes; the cached age (10) is genuinely stale.
+    env.serverTable.updateItem('users||1', { age: 99 });
+
+    // The query hook remounts displaying 'age': owed at `highPriority`, so
+    // the mount fetch must run immediately, not throttled.
+    await advanceTime(50);
+    const { result } = renderHook(() =>
+      env.apiStore.useListQuery(
+        { tableId: 'users' },
+        { fields: ['id', 'name', 'age'] },
+      ),
+    );
+
+    // An immediate fetch has finished by now (~1.77s); the throttled
+    // alternative would only start fetching at the throttle boundary.
+    await advanceTime(850);
+    expect(result.current.items[0]?.age).toBe(99);
+
+    await flushAllTimers();
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      810ms | -- timeline-cleared
+      910ms | server-data-changed (value: {"age":99})
+      970ms | 🟠 >list-fetch-started
+      1.77s | 🟠 <list-fetch-finished (value: {"count":5})
+      "
+    `);
+  });
+});
+
+describe('partial resources: failed optimistic deletes keep pending invalidation tracking', () => {
+  // Finding: `deleteItemState` clears the item's durable full-invalidation
+  // marker, but the mutation rollback snapshot never captured it — a failed
+  // optimistic delete restored the stale snapshot without the marker, so
+  // `inferFields` vouched the stale data as complete indefinitely and hooks
+  // never refetched the still-owed fields.
+
+  test('fields still owed by a full invalidation refetch after a failed optimistic delete', async () => {
+    const env = createListQueryStoreTestEnv(initialServerData, {
+      partialResources: listInferFieldsConfig,
+    });
+
+    // The item is fully loaded ('*') via a detail view, then that view
+    // closes.
+    const preload = env.apiStore.getItemFromStateOrFetch('users||1', {
+      fields: '*',
+    });
+    await flushAllTimers();
+    await preload;
+
+    // A full high-priority invalidation records the durable
+    // full-invalidation marker (the '*' snapshot has no field list to
+    // enumerate).
+    act(() => {
+      env.apiStore.invalidateQueryAndItems({
+        queryPayload: false,
+        itemPayload: 'users||1',
+        type: 'highPriority',
+      });
+    });
+
+    // A narrow hook consumes the invalidation for its own field only —
+    // 'age' stays owed by the marker while its stale value remains in state
+    // (without the marker, `inferFields` would vouch for it as fresh).
+    const narrowHook = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['name'] }),
+    );
+    await flushAllTimers();
+    narrowHook.unmount();
+
+    // The server value changes; the cached age (10) is genuinely stale.
+    env.serverTable.updateItem('users||1', { age: 99 });
+
+    // Optimistically delete the item, then the mutation fails and rolls
+    // back the deletion.
+    await act(async () => {
+      await env.apiStore.performMutation('users||1', {
+        optimisticUpdate: () => {
+          env.apiStore.deleteItemState('users||1');
+        },
+        mutation: () => Promise.reject(new Error('boom')),
+      });
+    });
+    await flushAllTimers();
+    env.clearTimeline();
+
+    // A hook mounts requesting 'age' — still owed by the restored
+    // full-invalidation marker, so it must refetch instead of trusting the
+    // stale rolled-back value.
+    const { result } = renderHook(() =>
+      env.apiStore.useItem('users||1', { fields: ['age'] }),
+    );
+    await flushAllTimers();
+
+    expect(result.current.data?.age).toBe(99);
+    expect(env.timelineString).toMatchInlineSnapshot(`
+      "
+      time  |
+      1.62s | -- timeline-cleared
+      1.63s | 🟡 >fetch-started
+      2.43s | 🟡 <fetch-finished (value: {"age":99})
+      "
+    `);
   });
 });

--- a/tests/list-query-features/list-query-partial-resources.test.ts
+++ b/tests/list-query-features/list-query-partial-resources.test.ts
@@ -1487,7 +1487,7 @@ describe('invalidateQueryAndItems with fields', () => {
     `);
   });
 
-  test('per-field invalidation keeps the highest emitted priority for mounted full-resource hooks', async () => {
+  test('per-field invalidation events carry the incoming priority; earlier invalidations do not escalate them', async () => {
     const env = createListQueryStoreTestEnv(initialServerData, {
       partialResources: partialResourcesConfig,
     });
@@ -1525,8 +1525,13 @@ describe('invalidateQueryAndItems with fields', () => {
     await flushAllTimers();
     stopListening();
 
+    // The second (lowPriority) invalidation targets a different field, so it
+    // must NOT be escalated by the earlier highPriority invalidation of
+    // 'age' — escalating unrelated later invalidations is what used to break
+    // scheduler throttling (e.g. realtime updates). The 'age' obligation
+    // keeps its own high priority in the per-field tracking.
     expect(emittedPriorities).toMatchInlineSnapshot(
-      `['highPriority', 'highPriority']`,
+      `['highPriority', 'lowPriority']`,
     );
     expect(env.serverTable.getRequestHistory('item')).toMatchInlineSnapshot(`
       - _type: 'item'
@@ -1622,6 +1627,9 @@ describe('invalidateQueryAndItems with fields', () => {
     });
 
     const itemKey = env.getStoreItemKeyFromRaw('users||1');
+    // refetchOnMount carries the incoming (lowPriority) full invalidation;
+    // the earlier highPriority obligation for 'age' stays tracked per-field
+    // and is adopted by hooks that actually request 'age'.
     expect({
       itemLoadedFields: env.store.state.itemLoadedFields[itemKey],
       itemFieldInvalidationFields:
@@ -1629,7 +1637,7 @@ describe('invalidateQueryAndItems with fields', () => {
       refetchOnMount: env.store.state.itemQueries[itemKey]?.refetchOnMount,
     }).toMatchInlineSnapshot(`
       itemLoadedFields: []
-      refetchOnMount: 'highPriority'
+      refetchOnMount: 'lowPriority'
     `);
 
     const nameHookRenders = createLoggerStore();

--- a/tests/persistent-storage/quota-exceeded-recovery-no-locks.test.ts
+++ b/tests/persistent-storage/quota-exceeded-recovery-no-locks.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { resetManagedLocalStorageState } from '../../src/persistentStorage/localStorageMetadata';
+import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
+import { advanceTime, flushAllTimers } from '../utils/genericTestUtils';
+import {
+  clearSimulatedLocalStorageQuota,
+  createEnv,
+  getLocalStorageUsedChars,
+  HOUR,
+  installQuotaEnforcingSetItem,
+  persistentStore,
+  seedCachedItem,
+  simulateLocalStorageQuota,
+} from './quotaRecoveryTestUtils';
+
+/**
+ * Browsers without `navigator.locks` (e.g. insecure contexts) skip the
+ * cached/deferred manifest io, so manifest writes go to `localStorage`
+ * immediately during a flush — a payload write and the manifest write that
+ * registers it are separate `setItem` calls, and the quota can be hit
+ * between them. These tests run in a dedicated file so no earlier test can
+ * leave behind manifests or pending timers that would mask the quota-recovery
+ * ordering under test.
+ */
+beforeAll(() => {
+  vi.useFakeTimers();
+  installQuotaEnforcingSetItem();
+});
+
+beforeEach(() => {
+  vi.setSystemTime(TEST_INITIAL_TIME);
+  // the per-test setup in vitest.setup.ts reinstalls a mock `navigator.locks`
+  // before each test, so it must be removed here for every test in this file
+  Object.defineProperty(globalThis.navigator, 'locks', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  clearSimulatedLocalStorageQuota();
+  vi.runOnlyPendingTimers();
+  localStorage.clear();
+  // clears the quota circuit breaker so tests stay isolated
+  resetManagedLocalStorageState();
+});
+
+test('a freshly persisted item survives the quota recovery triggered by its own manifest write', async () => {
+  const errors: unknown[] = [];
+
+  // old cached data from another store fills most of the quota
+  const seededPayloads = ['a', 'b', 'c', 'd'];
+  for (const [index, payload] of seededPayloads.entries()) {
+    seedCachedItem(
+      'old-col',
+      'sess1',
+      payload,
+      'x'.repeat(200),
+      (4 - index) * HOUR,
+    );
+  }
+
+  // measure exactly how many chars the item payload below will occupy by
+  // persisting an identical item through a probe store first (same-length
+  // store name, so the storage key has the same length too)
+  const probeEnv = createEnv({ storeName: 'probe-col' });
+  probeEnv.apiStore.addItemToState('new', {
+    value: { id: 'new', name: 'n'.repeat(300) },
+  });
+  await advanceTime(1100);
+  await flushAllTimers();
+  const probeKey = persistentStore
+    .scope('probe-col', 'sess1')
+    .collection.itemStorageKey('new');
+  const probeValue = localStorage.getItem(probeKey);
+  expect(probeValue).not.toBeNull();
+  const payloadChars = probeKey.length + (probeValue?.length ?? 0);
+
+  const env = createEnv({
+    storeName: 'quota-col',
+    onPersistentStorageError: (error) => errors.push(error),
+  });
+
+  // leave room for the item payload itself but not for the manifest write
+  // that registers it: the quota error then fires *after* the payload
+  // reached localStorage but *before* any manifest references it
+  simulateLocalStorageQuota(getLocalStorageUsedChars() + payloadChars + 10);
+
+  env.apiStore.addItemToState('new', {
+    value: { id: 'new', name: 'n'.repeat(300) },
+  });
+  await advanceTime(1100);
+  await flushAllTimers();
+
+  // recovery is silent and must evict old cached entries — never the
+  // payload that the failing manifest write was in the middle of committing
+  expect(errors).toMatchInlineSnapshot(`[]`);
+  const persisted = persistentStore
+    .scope('quota-col', 'sess1')
+    .collection.readItemData<{ value: { id: string; name: string } }>('new');
+  expect(persisted?.value.id).toBe('new');
+  expect(persisted?.value.name).toBe('n'.repeat(300));
+});

--- a/tests/persistent-storage/quota-exceeded-recovery.test.ts
+++ b/tests/persistent-storage/quota-exceeded-recovery.test.ts
@@ -1,4 +1,3 @@
-import { rc_object, rc_string } from 'runcheck';
 import {
   afterEach,
   beforeAll,
@@ -12,120 +11,19 @@ import {
   resetManagedLocalStorageState,
   syncManagedLocalStorageSessionProtection,
 } from '../../src/persistentStorage/localStorageMetadata';
-import { createCollectionStoreTestEnv } from '../mocks/collectionStoreTestEnv';
 import { TEST_INITIAL_TIME } from '../mocks/testEnvUtils';
 import { advanceTime, flushAllTimers } from '../utils/genericTestUtils';
-import { createLocalStoragePersistentTestStore } from '../utils/persistentStorageTestStore';
-
-const wrappedItemSchema = rc_object({
-  value: rc_object({ id: rc_string, name: rc_string }),
-});
-const persistentStore = createLocalStoragePersistentTestStore();
-
-const HOUR = 60 * 60 * 1000;
-
-type ItemState = { id: string; name: string };
-
-function createEnv(options: {
-  storeName: string;
-  sessionKey?: string;
-  onPersistentStorageError?: (error: unknown) => void;
-}) {
-  return createCollectionStoreTestEnv<ItemState>(
-    {},
-    {
-      id: options.storeName,
-      getSessionKey: () => options.sessionKey ?? 'sess1',
-      persistentStorage: {
-        adapter: 'local-sync',
-        schema: wrappedItemSchema,
-        payloadSchema: rc_string,
-        onPersistentStorageError: options.onPersistentStorageError,
-      },
-    },
-  );
-}
-
-/** Seeds a cached item persisted `ageMs` in the past (older = evicted first). */
-function seedCachedItem(
-  storeName: string,
-  sessionKey: string,
-  payload: string,
-  name: string,
-  ageMs: number,
-): string {
-  return persistentStore
-    .scope(storeName, sessionKey)
-    .collection.seedItem(
-      payload,
-      { value: { id: payload, name } },
-      { timestamp: Date.now() - ageMs },
-    );
-}
-
-function getLocalStorageUsedChars(): number {
-  let total = 0;
-  for (let index = 0; index < localStorage.length; index++) {
-    const key = localStorage.key(index);
-    if (key === null) continue;
-    total += key.length + (localStorage.getItem(key)?.length ?? 0);
-  }
-  return total;
-}
-
-/**
- * Simulates the browser origin quota: while a budget is set, any `setItem`
- * that would push the total stored chars above it throws a
- * `QuotaExceededError` DOMException, exactly like real browsers do when
- * localStorage is full (e.g. because other parts of the app filled it).
- */
-let quotaBudgetChars: number | null = null;
-
-function simulateLocalStorageQuota(budgetChars: number): void {
-  quotaBudgetChars = budgetChars;
-}
-
-function installQuotaEnforcingSetItem(): void {
-  const originalSetItem = Storage.prototype.setItem.bind(localStorage);
-
-  // spying on the instance instead of Storage.prototype is required for the
-  // spy to reliably intercept happy-dom's localStorage method lookups; the
-  // spy is installed once for the whole file because mock restoration does
-  // not reliably detach from happy-dom's localStorage proxy between tests
-  vi.spyOn(localStorage, 'setItem').mockImplementation(
-    (key: string, value: string) => {
-      if (quotaBudgetChars !== null) {
-        const existingValue = localStorage.getItem(key);
-        const usedCharsDelta =
-          existingValue === null
-            ? key.length + value.length
-            : value.length - existingValue.length;
-
-        if (getLocalStorageUsedChars() + usedCharsDelta > quotaBudgetChars) {
-          throw new DOMException(
-            `Failed to execute 'setItem' on 'Storage': Setting the value of '${key}' exceeded the quota.`,
-            'QuotaExceededError',
-          );
-        }
-      }
-
-      originalSetItem(key, value);
-    },
-  );
-}
-
-/** Returns which of the given seeded payloads are still present in storage. */
-function listSurvivingPayloads(
-  storeName: string,
-  sessionKey: string,
-  payloads: string[],
-): string[] {
-  const scope = persistentStore.scope(storeName, sessionKey);
-  return payloads.filter(
-    (payload) =>
-      localStorage.getItem(scope.collection.itemStorageKey(payload)) !== null,
-  );
-}
+import {
+  clearSimulatedLocalStorageQuota,
+  createEnv,
+  getLocalStorageUsedChars,
+  HOUR,
+  installQuotaEnforcingSetItem,
+  listSurvivingPayloads,
+  persistentStore,
+  seedCachedItem,
+  simulateLocalStorageQuota,
+} from './quotaRecoveryTestUtils';
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -137,7 +35,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  quotaBudgetChars = null;
+  clearSimulatedLocalStorageQuota();
   vi.runOnlyPendingTimers();
   localStorage.clear();
   // clears the quota circuit breaker so tests stay isolated
@@ -356,5 +254,65 @@ describe('localStorage quota exceeded recovery', () => {
         .scope('quota-col', 'sess1')
         .collection.readItemData('later'),
     ).toBeNull();
+  });
+
+  test('deleting an item while quota writes are disabled still removes it from storage', async () => {
+    const errors: unknown[] = [];
+
+    const env = createEnv({
+      storeName: 'quota-col',
+      onPersistentStorageError: (error) => errors.push(error),
+    });
+
+    // persist an item normally while the quota is still fine
+    env.apiStore.addItemToState('keep', {
+      value: { id: 'keep', name: 'Keep' },
+    });
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    const keepStorageKey = persistentStore
+      .scope('quota-col', 'sess1')
+      .collection.itemStorageKey('keep');
+    // protect the item so the escalated eviction below cannot remove it —
+    // offline-protected data is exactly what survives a failed recovery and
+    // could therefore resurrect after being deleted
+    syncManagedLocalStorageSessionProtection('sess1', [keepStorageKey]);
+
+    // non-tsdf data fills the quota so the next flush cannot free enough
+    // space even after evicting everything unprotected
+    localStorage.setItem('other-app-data', 'z'.repeat(3000));
+    simulateLocalStorageQuota(getLocalStorageUsedChars() + 10);
+
+    env.apiStore.addItemToState('big', {
+      value: { id: 'big', name: 'n'.repeat(600) },
+    });
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    // circuit breaker tripped with a single reported error, and the
+    // protected item survived the escalated eviction
+    expect(errors.length).toBe(1);
+    expect(
+      persistentStore
+        .scope('quota-col', 'sess1')
+        .collection.readItemData('keep'),
+    ).not.toBeNull();
+
+    // deleting the item must still remove its persisted entry even though
+    // writes are disabled: removals free space instead of consuming quota,
+    // and skipping them would resurrect the deleted item on the next load
+    env.apiStore.deleteItemState('keep');
+    await advanceTime(1100);
+    await flushAllTimers();
+
+    expect(
+      persistentStore
+        .scope('quota-col', 'sess1')
+        .collection.readItemData('keep'),
+    ).toBeNull();
+
+    // the removal itself cannot hit the quota, so no new error was reported
+    expect(errors.length).toBe(1);
   });
 });

--- a/tests/persistent-storage/quotaRecoveryTestUtils.ts
+++ b/tests/persistent-storage/quotaRecoveryTestUtils.ts
@@ -1,0 +1,120 @@
+import { rc_object, rc_string } from 'runcheck';
+import { vi } from 'vitest';
+import { createCollectionStoreTestEnv } from '../mocks/collectionStoreTestEnv';
+import { createLocalStoragePersistentTestStore } from '../utils/persistentStorageTestStore';
+
+const wrappedItemSchema = rc_object({
+  value: rc_object({ id: rc_string, name: rc_string }),
+});
+
+export const persistentStore = createLocalStoragePersistentTestStore();
+
+export const HOUR = 60 * 60 * 1000;
+
+type ItemState = { id: string; name: string };
+
+export function createEnv(options: {
+  storeName: string;
+  sessionKey?: string;
+  onPersistentStorageError?: (error: unknown) => void;
+}) {
+  return createCollectionStoreTestEnv<ItemState>(
+    {},
+    {
+      id: options.storeName,
+      getSessionKey: () => options.sessionKey ?? 'sess1',
+      persistentStorage: {
+        adapter: 'local-sync',
+        schema: wrappedItemSchema,
+        payloadSchema: rc_string,
+        onPersistentStorageError: options.onPersistentStorageError,
+      },
+    },
+  );
+}
+
+/** Seeds a cached item persisted `ageMs` in the past (older = evicted first). */
+export function seedCachedItem(
+  storeName: string,
+  sessionKey: string,
+  payload: string,
+  name: string,
+  ageMs: number,
+): string {
+  return persistentStore
+    .scope(storeName, sessionKey)
+    .collection.seedItem(
+      payload,
+      { value: { id: payload, name } },
+      { timestamp: Date.now() - ageMs },
+    );
+}
+
+export function getLocalStorageUsedChars(): number {
+  let total = 0;
+  for (let index = 0; index < localStorage.length; index++) {
+    const key = localStorage.key(index);
+    if (key === null) continue;
+    total += key.length + (localStorage.getItem(key)?.length ?? 0);
+  }
+  return total;
+}
+
+/**
+ * Simulates the browser origin quota: while a budget is set, any `setItem`
+ * that would push the total stored chars above it throws a
+ * `QuotaExceededError` DOMException, exactly like real browsers do when
+ * localStorage is full (e.g. because other parts of the app filled it).
+ */
+let quotaBudgetChars: number | null = null;
+
+export function simulateLocalStorageQuota(budgetChars: number): void {
+  quotaBudgetChars = budgetChars;
+}
+
+/** Removes the simulated quota budget (call in `afterEach`). */
+export function clearSimulatedLocalStorageQuota(): void {
+  quotaBudgetChars = null;
+}
+
+export function installQuotaEnforcingSetItem(): void {
+  const originalSetItem = Storage.prototype.setItem.bind(localStorage);
+
+  // spying on the instance instead of Storage.prototype is required for the
+  // spy to reliably intercept happy-dom's localStorage method lookups; the
+  // spy is installed once for the whole file because mock restoration does
+  // not reliably detach from happy-dom's localStorage proxy between tests
+  vi.spyOn(localStorage, 'setItem').mockImplementation(
+    (key: string, value: string) => {
+      if (quotaBudgetChars !== null) {
+        const existingValue = localStorage.getItem(key);
+        const usedCharsDelta =
+          existingValue === null
+            ? key.length + value.length
+            : value.length - existingValue.length;
+
+        if (getLocalStorageUsedChars() + usedCharsDelta > quotaBudgetChars) {
+          throw new DOMException(
+            `Failed to execute 'setItem' on 'Storage': Setting the value of '${key}' exceeded the quota.`,
+            'QuotaExceededError',
+          );
+        }
+      }
+
+      originalSetItem(key, value);
+    },
+  );
+}
+
+/** Returns which of the given seeded payloads are still present in storage. */
+export function listSurvivingPayloads(
+  storeName: string,
+  sessionKey: string,
+  payloads: string[],
+): string[] {
+  const scope = persistentStore.scope(storeName, sessionKey);
+  return payloads.filter(
+    (payload) =>
+      localStorage.getItem(scope.collection.itemStorageKey(payload)) !== null,
+  );
+}


### PR DESCRIPTION
## Summary

Refactor list-query invalidation tracking so priorities are stored per field instead of escalating at the item level. This preserves correct refetch behavior for partially loaded resources and prevents unrelated stale fields from breaking scheduler throttling, especially for realtime updates.
### Changes

- Store pending invalidations as per-field priority maps and full-item markers with tracked priority.
- Adopt invalidation priority only from fields a hook actually requests, avoiding cross-field escalation.
- Keep full-item invalidation markers and per-field obligations in sync across fetch, mutation, rollback, and cleanup flows.
- Update partial-resource docs to explain the new priority model and its effect on throttling.
- Add regression coverage for realtime throttling and priority propagation across mixed invalidation scenarios.

### Testing Notes

Verify that partial-resource hooks still refetch the correct fields after invalidation, including full-item ('*') loads followed by narrower refetches. Also confirm realtime invalidations remain throttled when earlier high-priority invalidations leave stale fields behind, and that rollback/reload paths preserve pending invalidation state correctly.

## Test Plan

- [ ] Tested locally
- [ ] Added/updated tests
